### PR TITLE
Fix Windows path aliases in release lifecycle

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -662,7 +662,7 @@ install_opencode_activation() {
 canonical_legacy_path() {
   local value="$1"
   if command -v cygpath >/dev/null 2>&1; then
-    cygpath -am -- "$value" 2>/dev/null | tr '[:upper:]' '[:lower:]'
+    cygpath -alm -- "$value" 2>/dev/null | tr '[:upper:]' '[:lower:]'
     return ${PIPESTATUS[0]}
   fi
   value="${value//\\//}"

--- a/scripts/install/lib/install-lib.sh
+++ b/scripts/install/lib/install-lib.sh
@@ -3929,6 +3929,23 @@ _uninstall_remove_empty_dirs() {
 [ -n "${AUTOPROMPT_COMPARABLE_PATH_CACHE+set}" ] ||
   declare -A AUTOPROMPT_COMPARABLE_PATH_CACHE=()
 
+_idem_windows_long_path() {
+  local input_path="${1//\\//}" output_name="$2"
+  local filesystem_path directory parent component suffix="" long_directory
+  filesystem_path="$(cygpath -au -- "$input_path" 2>/dev/null)" || return 1
+  directory="$filesystem_path"
+  while [ ! -e "$directory" ] && [ ! -L "$directory" ]; do
+    component="${directory##*/}"
+    parent="${directory%/*}"
+    [ "$parent" != "$directory" ] || return 1
+    [ -n "$parent" ] || parent="/"
+    suffix="/$component$suffix"
+    directory="$parent"
+  done
+  long_directory="$(cygpath -alm -- "$directory" 2>/dev/null)" || return 1
+  printf -v "$output_name" '%s' "${long_directory%/}$suffix"
+}
+
 _idem_comparable_path() {
   local input_path="$1" output_name="${2:-}" result_value windows_path=0
   input_path="${input_path//\\//}"
@@ -3936,18 +3953,16 @@ _idem_comparable_path() {
     msys*:*|cygwin*:*|mingw*:*|*:MSYS*|*:MINGW*) windows_path=1 ;;
   esac
   if [ "$windows_path" -eq 1 ]; then
-    case "$input_path" in
-      [A-Za-z]:/*) result_value="$input_path" ;;
-      /[A-Za-z]/*) result_value="${input_path:1:1}:${input_path:2}" ;;
-      /[A-Za-z]) result_value="${input_path:1:1}:" ;;
-      *)
-        if command -v cygpath >/dev/null 2>&1; then
-          result_value="$(cygpath -am -- "$input_path" 2>/dev/null)" || return 1
-        else
-          result_value="$input_path"
-        fi
-        ;;
-    esac
+    if command -v cygpath >/dev/null 2>&1; then
+      _idem_windows_long_path "$input_path" result_value || return 1
+    else
+      case "$input_path" in
+        [A-Za-z]:/*) result_value="$input_path" ;;
+        /[A-Za-z]/*) result_value="${input_path:1:1}:${input_path:2}" ;;
+        /[A-Za-z]) result_value="${input_path:1:1}:" ;;
+        *) result_value="$input_path" ;;
+      esac
+    fi
     result_value="${result_value,,}"
   else
     result_value="$input_path"

--- a/tests/source/harness-provider-config.test.cjs
+++ b/tests/source/harness-provider-config.test.cjs
@@ -15,6 +15,17 @@ const BASH = process.platform === 'win32'
   : 'bash'
 const POWERSHELL = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
 
+function toBashPath (value) {
+  return value.replaceAll('\\', '/').replace(
+    /^([A-Za-z]):/,
+    (_, drive) => `/${drive.toLowerCase()}`
+  )
+}
+
+function shellLiteral (value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
+}
+
 function runHelper (args) {
   return childProcess.spawnSync(process.execPath, [HELPER, ...args], {
     cwd: ROOT,
@@ -357,6 +368,50 @@ test('new harness uninstall ownership is provider-scoped in both shell ports', {
       ], { cwd: ROOT, encoding: 'utf8', timeout: 30000 })
       assert.equal(powershell.status, 0, `${provider}: ${powershell.stdout}\n${powershell.stderr}`)
     }
+  } finally {
+    fs.rmSync(sandbox, { recursive: true, force: true })
+  }
+})
+
+test('Git Bash path identity collapses Windows short aliases and keeps root bounds', {
+  skip: process.platform !== 'win32'
+}, (t) => {
+  const sandbox = fs.mkdtempSync(path.join(
+    os.tmpdir(),
+    'autoprompt-windows-long-path-alias-regression-'
+  ))
+  const root = path.join(sandbox, 'managed-root')
+  const owned = path.join(root, 'agents', 'ap-manager.md')
+  const missing = path.join(root, 'agents', 'missing', 'leaf.md')
+  const foreign = path.join(sandbox, 'outside.md')
+  try {
+    fs.mkdirSync(path.dirname(owned), { recursive: true })
+    fs.writeFileSync(owned, 'owned\n')
+    fs.writeFileSync(foreign, 'foreign\n')
+    const short = childProcess.spawnSync('cmd.exe', [
+      '/d', '/c', `for %I in ("${sandbox}") do @echo %~sI`
+    ], { encoding: 'utf8', timeout: 30000 })
+    assert.equal(short.status, 0, short.stderr)
+    const shortSandbox = short.stdout.trim()
+    if (!shortSandbox || shortSandbox.toLowerCase() === sandbox.toLowerCase()) {
+      t.skip('Windows short aliases are unavailable on this volume')
+      return
+    }
+    const shortRoot = path.join(shortSandbox, 'managed-root')
+    const library = path.join(ROOT, 'scripts', 'install', 'lib', 'install-lib.sh')
+    const command = [
+      `. ${shellLiteral(toBashPath(library))}`,
+      `_uninstall_receipt_path_under_root ${shellLiteral(toBashPath(shortRoot))} ` +
+        `${shellLiteral(toBashPath(owned))}`,
+      `_uninstall_receipt_path_under_root ${shellLiteral(toBashPath(shortRoot))} ` +
+        `${shellLiteral(toBashPath(missing))}`,
+      `! _uninstall_receipt_path_under_root ${shellLiteral(toBashPath(shortRoot))} ` +
+        `${shellLiteral(toBashPath(foreign))}`
+    ].join('; ')
+    const result = childProcess.spawnSync(BASH, [
+      '--noprofile', '--norc', '-c', command
+    ], { cwd: ROOT, encoding: 'utf8', timeout: 30000 })
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
   } finally {
     fs.rmSync(sandbox, { recursive: true, force: true })
   }

--- a/tests/source/new-harness-lifecycle.test.cjs
+++ b/tests/source/new-harness-lifecycle.test.cjs
@@ -274,8 +274,14 @@ function writeFakeClaude(context) {
 }
 
 function receiptPathKey(value) {
-  const normalized = value.replaceAll('\\', '/')
+  let candidate = value.replaceAll('\\', '/')
     .replace(/^\/([A-Za-z])\//, '$1:/')
+  if (process.platform === 'win32') {
+    try {
+      candidate = fs.realpathSync.native(candidate)
+    } catch {}
+  }
+  const normalized = candidate.replaceAll('\\', '/')
     .replace(/\/$/, '')
   return process.platform === 'win32' ? normalized.toLowerCase() : normalized
 }


### PR DESCRIPTION
## Summary

- normalize Git Bash paths through their long Windows form
- preserve safe handling for not-yet-created receipt paths
- compare lifecycle receipt paths through the same canonical identity
- add a Windows short-path regression test

## Verification

- npm test (149 passed)
- focused Git Bash short-path regression (passed)
- Git for Windows shell syntax check (passed)

This fixes the three Windows lifecycle failures in release-readiness run 32481402055 and unblocks v1.0.4 publication.