### PR TITLE
feat(omp): add supervisor, model-casting, and shared bash resolver for tests

### DIFF
--- a/agents/manifests/omp-runtime.json
+++ b/agents/manifests/omp-runtime.json
@@ -7,6 +7,7 @@
     "MODES.md",
     "PLAYBOOKS.md",
     "README.md",
+    "SKILL.md",
     "VERSION",
     "agents/ap-arbiter.md",
     "agents/ap-depth-prober.md",
@@ -33,6 +34,7 @@
     "agents/ap-sweeper.md",
     "agents/ap-synthesizer.md",
     "agents/ap-verifier.md",
+    "autoprompt-models.schema.md",
     "frameworks/QUICKSTART.md",
     "frameworks/README.md",
     "frameworks/apply.md",
@@ -50,13 +52,21 @@
     "frameworks/plan-research.md",
     "frameworks/plan-scope.md",
     "frameworks/polish.md",
-    "frameworks/refactor.md"
+    "frameworks/refactor.md",
+    "workflow/agent-definitions-cli.js",
+    "workflow/autoprompt-gate.js",
+    "workflow/autoprompt-ledger-check.js",
+    "workflow/model-casting.js",
+    "workflow/phase-budget.js",
+    "workflow/supervisor.ps1",
+    "workflow/supervisor.sh"
   ],
   "sha256": {
     "GATES.md": "3832ebad454d715bd65d8a2643cbad09508b3248c72cde2ee234930642bc333c",
     "MODES.md": "2e1e76bfd609b3660427d5988bdaa0ef8831a153c3c686b35159d178d34475e7",
     "PLAYBOOKS.md": "448d779d63eed528e1e9b0631d81af38d35944807e63f28ac26c0b2d0ff6b597",
     "README.md": "1383f55681c4b08134690a779723a6f05d2d9d1f970ca2b577ae63387cb053f7",
+    "SKILL.md": "3f5d2536d13c9ced5fe274e6a909fcd41707583d75d6c7a899a516d36d01bcb7",
     "VERSION": "d1b77b88f4b9f675a900e4143ac768a21218623cfe1703ca43162388c3271bd6",
     "agents/ap-arbiter.md": "18ede91afaa6eda00e408507d9801ee52983aee2a62e1e04547ad46e0f5feee5",
     "agents/ap-depth-prober.md": "8e4db06908166ac0c173e0a1f8d0f03c6f91ee5c7d6f2691e85460fe216f2662",
@@ -83,6 +93,7 @@
     "agents/ap-sweeper.md": "f59cadc649c1b17e23619061bfc05a48617c2707515b6b1a05a3333a73240bd5",
     "agents/ap-synthesizer.md": "bb58e7bdc61cee55a35f860d27ece2dc34fa62aefab542cbe57ed7156da949bd",
     "agents/ap-verifier.md": "5c6ac1095af4aaac7490b0055434931528103d3c446a1f54882ee653d8714e66",
+    "autoprompt-models.schema.md": "9eb59bd59fde7e70ebf338927dc1d745ae36b1327714e96c70f3b4a94896e06f",
     "frameworks/QUICKSTART.md": "cca9c0cca44a1399597e884b9ca0089759175a485de3bdb914c5d341ffa4a734",
     "frameworks/README.md": "e9a95984ad18d815d3ce7348d3b184214f115eca661ecd4386c4e25d12515435",
     "frameworks/apply.md": "81b421b02bb3cb71fe54a297011b744b3b4cee0dde636b84e078cc4c62fc7f1b",
@@ -100,6 +111,13 @@
     "frameworks/plan-research.md": "750bc9bbcb1bf1ff5821ffc64947dd07bb8a5af2cc226ee10bdfd0ed6590b3fe",
     "frameworks/plan-scope.md": "62fc4a29a3bd8376248480b43edbdd196afde49c83320dd5c472eb20776cbf18",
     "frameworks/polish.md": "1771c799d56efccc63048103c7391a0b92b7ab4fd74a59163656f68dbfa99e01",
-    "frameworks/refactor.md": "c1a938ba1c2859918f255c914ce23eac73233bec3d92ce9924cf658854083fd4"
+    "frameworks/refactor.md": "c1a938ba1c2859918f255c914ce23eac73233bec3d92ce9924cf658854083fd4",
+    "workflow/agent-definitions-cli.js": "24fe3ab637799f62ed6dcd385eed61976c6266ccbb5615013714b524df11634c",
+    "workflow/autoprompt-gate.js": "69ef58436d351e3b749e587525b5fb87858dda5d776e3bd30584fe6dd9135e38",
+    "workflow/autoprompt-ledger-check.js": "2282331501e8eb97de8d3640b04f10941e5fe1ac57ce7c7f52de7dc40038a419",
+    "workflow/model-casting.js": "5bc431be1c4710eb37cbf39bbff4b1a799fb33229e0dc20bcaeede57a164809c",
+    "workflow/phase-budget.js": "2805c86b27bc3c36224a34bac2ec19c00dff6a10fb05e3d9f30cb6e5f33c6cf1",
+    "workflow/supervisor.ps1": "a2bab9720f4bbf76567d933da1c50e4773e078b28dc28ba524dddd6b34fa1d7a",
+    "workflow/supervisor.sh": "89c15fa1b4854f99eeafdcc303427faf7c68b9efebef51660e33a5a1898cf145"
   }
 }

--- a/agents/omp/autoprompt-models.schema.md
+++ b/agents/omp/autoprompt-models.schema.md
@@ -1,0 +1,117 @@
+# Model registry: the precise contract
+
+The optional omp model registry lives at
+`~/.omp/agent/autoprompt-models.json`. It maps exact-case names used in `agents=`
+selectors to omp model selector strings and the one process-wide provider context
+an omp child will use.
+
+The registry is a JSON array of objects. Unknown fields are rejected.
+
+## Schema
+
+| Field | Required | Purpose |
+|---|---|---|
+| `name` | yes | Exact-case selector name, such as `DeepSeek-V3` |
+| `provider` | yes | Informational provider label; arbitrary non-empty strings are accepted |
+| `modelString` | yes | Exact omp model selector (e.g. `deepseek/deepseek-v4-flash`) assigned to the run's tiers |
+| `baseUrl` | no | Absolute HTTP(S) endpoint used by the child |
+| `apiKeyEnv` | no | **Name** of the environment variable holding the child endpoint credential |
+| `effortHint` | no | Auto-ranking hint: `max`, `high`, `medium`, or `low` |
+
+`apiKeyEnv` is never a key value. The registry and serialized casting metadata
+contain only the variable name; the secret itself is never serialized.
+
+## Selection semantics
+
+- `agents=off` does not read or resolve the registry.
+- `agents=auto` reads the full registry and ranks it by `effortHint`; registry
+  order breaks ties. The default path must exist.
+- `agents=<comma-list>` preserves the supplied strongest-to-weakest order. With a
+  registry, every item is resolved by exact-case `name`. Without one, each item
+  is treated directly as an exact omp model selector.
+- `agents=auto:<comma-list>` resolves the exact-case names from the registry,
+  restricts the pool to those entries, and ranks that pool automatically.
+
+Control words are case-insensitive. Names and model selectors are not.
+Duplicates are detected case-sensitively.
+
+## Tier mapping
+
+omp has no fixed alias pool. One to five selected model selectors map onto the
+R1..R5 casting tiers: one selector fills every tier (all workers use it); more
+selectors map strongest->R1 down to weakest->R5. The resolved per-tier selectors
+are emitted as `selectors` in the serialized casting and applied by the conductor
+as run-scoped `task.agentModelOverrides` project settings at the governance root,
+so dispatch re-reads them without touching the user's global `config.yml`.
+
+## Registry and proxy responsibilities
+
+The registry supplies an exact `modelString` plus optional child endpoint
+metadata. It does not create or provision 9Router or other reverse-proxy aliases.
+Autoprompt assigns the configured string unchanged to the run's tiers. When the
+selected pool carries no endpoint metadata, the child inherits its normal
+provider configuration.
+
+## omp pool constraints
+
+The registry may contain any number of entries. A selected omp pool must contain
+one to five unique model selectors; more than five fails because casting binds
+only R1..R5.
+
+Every selected entry must resolve to the same effective `baseUrl` and the same
+effective `apiKeyEnv`. Omitting both from every selected entry means "inherit the
+child's provider endpoint and authentication." Mixing omitted and explicit
+values, or selecting different values, fails. omp cannot switch endpoint or
+credentials per persona.
+
+Heterogeneous upstream providers are valid when one model-aware reverse proxy
+exposes every selected model through one endpoint and one credential source.
+
+## Valid example: three upstreams behind one proxy
+
+```json
+[
+  {
+    "name": "DeepSeek-V3",
+    "provider": "deepseek-via-router",
+    "modelString": "deepseek/deepseek-chat",
+    "baseUrl": "http://localhost:20128/v1",
+    "apiKeyEnv": "AUTOPROMPT_ROUTER_TOKEN",
+    "effortHint": "high"
+  },
+  {
+    "name": "Qwen-Max",
+    "provider": "alibaba-via-router",
+    "modelString": "qwen/qwen-max",
+    "baseUrl": "http://localhost:20128/v1",
+    "apiKeyEnv": "AUTOPROMPT_ROUTER_TOKEN",
+    "effortHint": "high"
+  },
+  {
+    "name": "GLM4",
+    "provider": "zhipu-via-router",
+    "modelString": "zhipu/glm-4-plus",
+    "baseUrl": "http://localhost:20128/v1",
+    "apiKeyEnv": "AUTOPROMPT_ROUTER_TOKEN",
+    "effortHint": "medium"
+  }
+]
+```
+
+This pool is executable in one child because all three entries share the proxy
+endpoint and credential variable. `agents=auto` ranks `DeepSeek-V3`, `Qwen-Max`,
+and `GLM4` by hint, with registry order breaking the high/high tie.
+
+Direct provider endpoints can also be registered, but entries with different
+direct endpoints or credential variables may only be selected in separate omp
+runs unless a shared proxy unifies them.
+
+## Consumption
+
+`agents/omp/workflow/model-casting.js` is the authoritative resolver. The POSIX
+and PowerShell supervisors run it before launching the child, verify every tier
+selector resolved, and export the non-secret `AUTOPROMPT_AGENT_CASTING` metadata
+to the child session; the conductor applies it as run-scoped
+`task.agentModelOverrides` project settings. PREFLIGHT reports installed state
+for diagnostics; INTAKE validates and records it. Neither can install new
+selectors after the child has started.

--- a/agents/omp/workflow/agent-definitions-cli.js
+++ b/agents/omp/workflow/agent-definitions-cli.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+function parseFrontmatter(text, filePath) {
+  const fields = {}
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) continue
+    const separator = line.indexOf(':')
+    if (separator < 1) throw new Error(`agent definition has invalid frontmatter: ${filePath}`)
+    const key = line.slice(0, separator).trim()
+    let value = line.slice(separator + 1).trim()
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1)
+    }
+    fields[key] = value
+  }
+  return fields
+}
+
+function parseAgentDefinition(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8')
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/)
+  if (!match) throw new Error(`agent definition has invalid frontmatter: ${filePath}`)
+
+  const frontmatter = parseFrontmatter(match[1], filePath)
+  const name = frontmatter && frontmatter.name
+  if (typeof name !== 'string' || !/^ap-[a-z0-9-]+$/.test(name)) {
+    throw new Error(`agent definition has invalid name: ${filePath}`)
+  }
+
+  const tools = typeof frontmatter.tools === 'string'
+    ? frontmatter.tools.split(',').map(tool => tool.trim()).filter(Boolean)
+    : frontmatter.tools
+  if (!Array.isArray(tools) || tools.length === 0) {
+    throw new Error(`agent definition has no tools: ${filePath}`)
+  }
+
+  const privatePersonaPath = path.resolve(filePath)
+  const activationTools = tools.includes('Read') ? tools : ['Read', ...tools]
+  return [name, {
+    description: String(frontmatter.description || ''),
+    prompt: [
+      'Internal Autoprompt role; invalid outside an explicit Autoprompt run.',
+      `Read and obey the complete private persona at: ${privatePersonaPath}`,
+      'Before any other action, require its exact AUTOPROMPT-RUN-MARKER,',
+      'RUN-NONCE, and mission binding. If absent or the persona is unreadable,',
+      'return INVALID-DISPATCH and stop. Never load or invoke the Autoprompt skill.',
+    ].join(' '),
+    tools: activationTools,
+    model: String(frontmatter.model || 'inherit'),
+  }]
+}
+
+function loadAgentDefinitions(directory) {
+  const files = fs.readdirSync(directory)
+    .filter(name => /^ap-.*\.md$/.test(name))
+    .sort()
+  if (files.length === 0) throw new Error(`no ap-* agent definitions found: ${directory}`)
+
+  return Object.fromEntries(files.map(name => parseAgentDefinition(path.join(directory, name))))
+}
+
+function main(argv) {
+  if (argv.length !== 1 || !argv[0]) {
+    throw new Error('usage: agent-definitions-cli.js <private-agents-directory>')
+  }
+  process.stdout.write(JSON.stringify(loadAgentDefinitions(path.resolve(argv[0]))))
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`agent-definitions-cli: ${error.message}\n`)
+    process.exitCode = 1
+  }
+}
+
+module.exports = { loadAgentDefinitions, main, parseAgentDefinition }

--- a/agents/omp/workflow/autoprompt-gate.js
+++ b/agents/omp/workflow/autoprompt-gate.js
@@ -1,0 +1,4937 @@
+export const meta = {
+  name: 'autoprompt-gate',
+  description: 'Useful-first Autoprompt runtime: produce one executable roadmap, independently approve it, dispatch ready dependency lanes, and verify real behavior under deterministic gates. The first roadmap author receives the exact mission; later typed workers receive a cryptographically bound mission pointer.',
+  whenToUse: 'When you want roadmap-first execution with fail-closed capability checks, adaptive scope, strict TDD, independent review and verification, and resumable three-file governance. Pass args.mission plus optional mode, selector, concurrency, resume, and ledger settings.',
+  phases: [
+    { title: 'Roadmap', detail: 'useful-first capability proof, repository inspection, adaptive scope, and concurrent assurance' },
+    { title: 'Plan', detail: 'conditional G1 only for debug, unresolved design, explicit detailed-plan, or plan conflict' },
+    { title: 'Build', detail: 'implementation, independent review, and real runtime verification' },
+    { title: 'Sign-off', detail: 'independent risk sign-off when the selected route requires it' },
+    { title: 'Sweep', detail: 'production sweep and adversarial goal check' },
+    { title: 'Scribe', detail: 'append PROMPTS.txt, ROADMAP.md, and GATELOG.md; clean scratch only after sealed DONE' },
+  ],
+}
+
+// Model and effort routing are centralized in applyPersonaCasting. With agent
+// selection off, dispatch inherits the session. An explicit pre-launch cast is
+// validated against the live aliases before any per-call model/effort is added.
+// Selectable effort uses the provider's verified maximum for reasoning-heavy
+// roles; inherited-only, unsupported, and unknown omit the per-call field.
+
+// ----- execution modes (the easily-customizable block) -------------------
+// TOKENSAVER (default): bounded fan-out - up to 6 agents live per wave (the
+//   MODE_LIVE_CAP teeth below), so a lean run still parallelizes a little while
+//   staying cheap and checkpoint-friendly.
+// WIDE (professional primary name) / BILLIONAIRE (retained working alias):
+//   unbounded fan-out. Every independent unit at once, no script-imposed cap
+//   (not 3, not 30 - the harness queues past its own per-workflow slot limit),
+//   bounded only by MAX_CONCURRENT. Use when speed matters and budget does not.
+// CUSTOM: wide fan-out bounded by the operator's max_subs (feeds MAX_CONCURRENT).
+// Select with args.mode: 'tokensaver' | 'wide' | 'billionaire' | 'custom'.
+const EXECUTION_MODES = {
+  tokensaver:  { parallelFeatures: true,  parallelPanel: true },
+  wide:        { parallelFeatures: true,  parallelPanel: true },
+  billionaire: { parallelFeatures: true,  parallelPanel: true }, // alias of wide
+  custom:      { parallelFeatures: true,  parallelPanel: true },
+}
+const DEFAULT_MODE = 'tokensaver'
+
+// ----- 5-level hierarchical topology (L0 -> L4) --------------------------
+// base-instructions.Md re-architects the loop into FIVE levels. The harness is
+// gate-based, but it MUST be level-aware so it can (a) forbid execution at L1
+// (rule 68), (b) cap each L3's L4 leaf fan-out by mode, and (c) drive L3 tracks
+// serially (TOKENSAVER) or in parallel (BILLIONAIRE) - the global throttle axis,
+// distinct from the per-L3 fan-out (no numeric ceiling in BILLIONAIRE).
+//
+//   L0  lean conductor - start-dispatch + end-verdict only; touches nothing.
+//   L1  coordinators - determine work/scope + own fleet-state reasoning; Agent-ONLY.
+//       base:68 forbids ALL tools but Agent (no Read/Glob/Grep/Write/Edit/Bash) - fleet
+//       state flows up via Agent-tool results / a reader-leaf on RESUME. For a single
+//       bounded feature an L1 dispatches L3 executors DIRECTLY (manager optional).
+//   L2  manager - holds context, builds the 5-field handoff; Read/Glob/Grep only.
+//   L3  EXECUTORS - own one task, WRITE an artifact as their core function;
+//       execute directly and/or fan to L4 leaves.
+//   L4  terminal leaves - single-shot, independent, no fan-out (no Agent); they
+//       still execute (write/run), they just spawn nothing further.
+//
+// Every gate persona is classified to its level here, matching the binding
+// arbiter ruling and each persona file. The execution gates route to L3/L4
+// personas; the supervisory roles to L0/L1; the manager to L2. A gate wired to
+// an L0/L1/L2 persona is a programmer error caught by assertExecLevel.
+const LEVEL_OF = {
+  // L0 conductor (the harness/driver itself acts as L0 in code form)
+  'cl-conductor': 'L0',
+  // L1 coordinators - Agent-ONLY; own fleet-state reasoning, but base:68 forbids ALL
+  // Read/Glob/Grep/Write/Edit/Bash (L1 never reads a file, nothing) - fleet state flows
+  // up via Agent-tool results / a reader-leaf on RESUME
+  'ap-scope-coordinator': 'L1',
+  'ap-feature-coordinator': 'L1',
+  'ap-sweep-coordinator': 'L1',
+  // L2 manager - OPTIONAL; coordinates a multi-feature slice, may Read/Glob/Grep, writes nothing
+  'ap-manager': 'L2',
+  // L3 executors - own one task, write artifacts as their core function, fan to L4
+  'ap-scoper': 'L3',
+  'ap-planner': 'L3',
+  'ap-synthesizer': 'L3',
+  'ap-intake': 'L3',
+  'ap-implementer': 'L3',
+  'ap-reviewer': 'L3',
+  'ap-verifier': 'L3',
+  'ap-sweeper': 'L3',
+  'ap-researcher': 'L3',
+  'ap-execharness-resolver': 'L3',
+  'ap-framework-generator': 'L3',
+  // L4 terminal leaves - single-shot, independent, no fan-out (no Agent)
+  'ap-fresh-verifier': 'L4',
+  'ap-depth-prober': 'L4',
+  'ap-framework-validator': 'L4',
+  'ap-juror': 'L4',
+  'ap-goal-checker': 'L4',
+  'ap-preflight-probe': 'L4',
+  'ap-arbiter': 'L4',
+  'ap-re-anchor': 'L4',
+  'ap-scribe': 'L4',
+  'ap-janitor': 'L4',
+}
+
+// Per-L3 fan-out by mode. base-instructions line 27's "10" was a DEFAULT working
+// set, NOT a hard cap; line 64 ("we can even have 50 agents, it really doesnt
+// matter") + the mission govern. TOKENSAVER = up to 6 leaves per wave (the lean
+// bounded fan-out). WIDE/BILLIONAIRE/CUSTOM = null = NO numeric per-L3 leaf
+// ceiling: an L3 fans to as many disjoint L4 leaves as the work genuinely needs,
+// bounded by MAX_CONCURRENT + disjoint ownership + real need + dedupe + the
+// iron-rule-9 token budget - never a per-L3 number. This is NOT the global
+// throttle (which decides whether sibling L3 tracks run serially or in parallel -
+// modeled by EXECUTION_MODES.parallelFeatures). Consumed by resolveTopology's
+// published summary AND, via MODE_LIVE_CAP below, given REAL teeth in the fanout
+// chunker (TOKENSAVER waves of <=6; WIDE/CUSTOM up to MAX_CONCURRENT).
+const LEAF_CAP = { tokensaver: 6, wide: null, billionaire: null, custom: null }
+
+// Per-mode LIVE cap with REAL teeth: the fanout chunker bounds each parallel wave
+// at min(MAX_CONCURRENT, MODE_LIVE_CAP[MODE]). null => no per-mode cap (only the
+// global MAX_CONCURRENT ceiling applies). TOKENSAVER's 6 is what makes "up to 6
+// concurrent" a hard runtime bound, not a cosmetic label; WIDE/BILLIONAIRE/CUSTOM
+// stay null so they fan out to the global ceiling.
+const MODE_LIVE_CAP = { tokensaver: 6, wide: null, billionaire: null, custom: null }
+
+// ----- the user-settable GLOBAL max-concurrent knob (base 200) ------------
+// The single number a user can set to bound how many agents run live at once
+// across the WHOLE run, regardless of mode. It is a CEILING, not a target:
+// TOKENSAVER still runs one at a time; BILLIONAIRE still fans out - but never
+// wider than this many concurrent agents in any one parallel wave. Set it via
+// task.maxConcurrency in ~/.omp/agent/config.yml (or the omp settings UI), or
+// export the env var, or pass args.maxConcurrent. Base default is 200. A value < 1 or
+// non-numeric falls back to the base. This is the knob the README points at.
+// The GATES.md tier numbers (T0..T3) are an ADVISORY total-work / anti-sprawl
+// target enforced by MODEL DISCIPLINE (dedupe), NOT a code-enforced concurrency
+// cap. The real live ceiling is THIS knob; BILLIONAIRE parallelism is bounded by
+// MAX_CONCURRENT + disjoint ownership + real need + dedupe, never by a per-L3 leaf
+// number and never by a tier number.
+const MAX_CONCURRENT_BASE = 200
+function resolveMaxConcurrent() {
+  // args may be a string (the mission) or undefined, so read maxConcurrent only
+  // when args is a real object; otherwise treat it as absent (NOT false) so the
+  // env var is still consulted. A bare-string args must never shadow the env knob.
+  const fromArg = (typeof args === 'object' && args && args.maxConcurrent != null)
+    ? args.maxConcurrent
+    : undefined
+  // max_subs=<N> operator alias: a lower-precedence source than the explicit
+  // maxConcurrent knob, feeding the SAME ceiling. args.maxConcurrent wins when
+  // both are set; args.maxSubs then wins over the env var.
+  const fromSubs = (typeof args === 'object' && args && args.maxSubs != null)
+    ? args.maxSubs
+    : undefined
+  const fromEnv = (typeof process === 'object' && process && process.env)
+    ? process.env.AUTOPROMPT_MAX_CONCURRENT
+    : undefined
+  const picked = fromArg != null ? fromArg : (fromSubs != null ? fromSubs : fromEnv)
+  const raw = Number(picked)
+  return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : MAX_CONCURRENT_BASE
+}
+const MAX_CONCURRENT = resolveMaxConcurrent()
+
+// Levels at which execution (file writes, shell, real work) is FORBIDDEN. L0
+// and L1 are Agent-ONLY - they touch NOTHING (base:68: L1 never reads a file,
+// nothing); fleet state flows up via Agent-tool results / a reader-leaf. L2 may
+// Read/Glob/Grep to scope but writes no code. Only L3 (the executor) and its L4
+// leaves execute (write/run).
+const NON_EXEC_LEVELS = new Set(['L0', 'L1', 'L2'])
+
+// assertExecLevel (rule-68 guard): every executor gate site passes its agentType
+// here before spawning. If a gate that does real work is ever wired to an L0/L1/
+// L2 persona, this throws a deterministic programmer error (NON-transient) rather
+// than letting a non-executing level silently run an execution gate. L1 in
+// particular must never reach an execution site (base-instructions line 68).
+function assertExecLevel(agentType, site) {
+  const level = LEVEL_OF[agentType]
+  if (!level) {
+    throw new TypeError(`RULE-68 GUARD: executor site "${site}" wired to unknown persona "${agentType}" (no level mapping); fix LEVEL_OF`)
+  }
+  if (NON_EXEC_LEVELS.has(level)) {
+    throw new TypeError(`RULE-68 GUARD: executor site "${site}" wired to a ${level} persona "${agentType}", but ${level} must NOT execute (base-instructions line 68 - L1 is Agent-only, never reads/writes/runs). Wire it to an L3/L4 executor.`)
+  }
+  return level
+}
+
+// assertSingleBlock (rule-67 spawn hygiene): every brief the harness assembles
+// is ONE clean, single block. A malformed/oversized spawn splits in transit -
+// one part sends, the rest is queued and lost (base-instructions line 67). A
+// brief carrying a control split marker (NUL / line- or paragraph-separator) or
+// an empty body would split downstream, so it is rejected here at assembly time.
+const SPLIT_MARKERS = [0x0000, 0x2028, 0x2029].map(c => String.fromCharCode(c))
+function assertSingleBlock(text, site) {
+  if (typeof text !== 'string' || text.length === 0) {
+    throw new TypeError(`RULE-67 SPAWN HYGIENE: brief for "${site}" is empty/non-string; a brief must be one whole block`)
+  }
+  for (const marker of SPLIT_MARKERS) {
+    if (text.indexOf(marker) !== -1) {
+      throw new TypeError(`RULE-67 SPAWN HYGIENE: brief for "${site}" carries a control split marker; it would split in transit (one part sent, the tail queued). Emit ONE clean block.`)
+    }
+  }
+  return text
+}
+
+// resolveTopology: the run-stable 5-level topology the harness actually computed
+// from MODE. Published in the summary so the level map, the per-L3 fan-out, and
+// the global throttle axis are inspectable behaviorally (not just grep-able).
+function resolveTopology(mode) {
+  const personasByLevel = { L0: [], L1: [], L2: [], L3: [], L4: [] }
+  for (const [persona, level] of Object.entries(LEVEL_OF)) personasByLevel[level].push(persona)
+  const ROLE = {
+    L0: 'lean conductor - start-dispatch + end-verdict only; touches nothing',
+    L1: 'coordinators - determine work/scope + own fleet-state; read to scope, never write/run (rule 68)',
+    L2: 'managers (optional) - hold context for a multi-feature slice, build the handoff; Read/Glob/Grep only',
+    L3: 'executors - own one task; execute directly and/or fan to L4 leaves',
+    L4: 'fan-out leaves - parallel hands; terminal',
+  }
+  return {
+    levels: ['L0', 'L1', 'L2', 'L3', 'L4'].map(level => ({
+      level,
+      role: ROLE[level],
+      canExecute: !NON_EXEC_LEVELS.has(level),
+      personas: personasByLevel[level],
+    })),
+    leafCap: Object.prototype.hasOwnProperty.call(LEAF_CAP, mode) ? LEAF_CAP[mode] : LEAF_CAP[DEFAULT_MODE],
+    liveCap: (Object.prototype.hasOwnProperty.call(MODE_LIVE_CAP, mode) ? MODE_LIVE_CAP[mode] : MODE_LIVE_CAP[DEFAULT_MODE]) ?? null,
+    parallelTracks: !!(EXECUTION_MODES[mode] || EXECUTION_MODES[DEFAULT_MODE]).parallelFeatures,
+    multiTaskSplitSite: 'L2->L3',
+    depthCap: 5,
+  }
+}
+
+// ----- config -----------------------------------------------------------
+const MAX_PLAN_CYCLES = 2          // G1<->G2 SMASH cycles before arbiter
+const MAX_FRESH_CYCLES = 1         // G3 REJECT cycles before a binding decision
+const PLAN_ATTEMPT_BUDGET = 3      // hard cap on total plan attempts; arbiter cannot reset past this
+const IMPL_ATTEMPT_BUDGET = 3      // hard cap on total implement+verify attempts; survives arbiter resets
+const MAX_IMPL_CYCLES = 2          // G4<->G5 SMASH cycles before arbiter
+const MAX_VERIFY_CYCLES = 1        // G6 FAILED -> G4 retry budget before arbiter
+const PANEL_SIZE = 3               // G7 independent sign-off agents
+const MAX_SWEEP_ROUNDS = 2         // hard cap on sweep rounds (cost + termination guard)
+const REQUIRED_CLEAN_SWEEPS = 1    // one clean sweep closes a bounded convergence pass
+const MIN_BUDGET_TO_SPAWN = 60000  // stop opening NEW work below this many output tokens remaining
+const COVERAGE_FLOOR = 95          // the mission's hard coverage floor; a <95 number FAILS verify and blocks DONE
+const MAX_SCOPE_CYCLES = 2         // one targeted repair after the initial assurance cycle
+const RETRY_MAX_ATTEMPTS = 3       // one call may consume at most three provider dispatches
+const RETRY_MAX_ELAPSED_MS = 90 * 1000
+// === USEFUL-OUTPUT-BUDGET-SLICE:START ===
+function retryBudgetVerdict({
+  attempt,
+  elapsedMs,
+  maxAttempts,
+  maxElapsedMs,
+}) {
+  if (attempt >= maxAttempts) {
+    return {
+      canRetry: false,
+      reason:
+        `transient retry attempt budget exhausted ` +
+        `(${attempt}/${maxAttempts})`,
+    }
+  }
+  if (elapsedMs >= maxElapsedMs) {
+    return {
+      canRetry: false,
+      reason:
+        `transient retry wall-clock budget exhausted ` +
+        `(${elapsedMs}ms/${maxElapsedMs}ms)`,
+    }
+  }
+  return { canRetry: true, reason: '' }
+}
+
+function researchProgressReasons(progress) {
+  const value = progress && typeof progress === 'object'
+    ? progress
+    : {}
+  const reasons = []
+  const pairs = [
+    ['search', value.searchesClaimed, value.searchesReceipted, 6],
+    ['fetch', value.fetchesClaimed, value.fetchesReceipted, 6],
+    [
+      'usable-inspection',
+      value.usableInspectionsClaimed,
+      value.usableInspectionsReceipted,
+      null,
+    ],
+  ]
+
+  for (const [label, claimed, receipted, budget] of pairs) {
+    const areValidCounts =
+      Number.isInteger(claimed) &&
+      claimed >= 0 &&
+      Number.isInteger(receipted) &&
+      receipted >= 0
+    if (!areValidCounts) {
+      reasons.push(
+        `${label} counts must be non-negative integers`,
+      )
+      continue
+    }
+    if (claimed > receipted) {
+      reasons.push(
+        `${label} claims exceed inspectable receipts ` +
+        `(${claimed} claimed, ${receipted} receipted)`,
+      )
+    } else if (receipted > claimed) {
+      reasons.push(
+        `${label} receipts exceed claims ` +
+        `(${receipted} receipted, ${claimed} claimed)`,
+      )
+    } else if (budget !== null && claimed > budget) {
+      reasons.push(`${label} budget exceeded (${claimed}/${budget})`)
+    }
+  }
+
+  if (
+    !Number.isInteger(value.materializedOutputs) ||
+    value.materializedOutputs < 1
+  ) {
+    reasons.push('research produced zero materialized outputs')
+  }
+  return reasons
+}
+
+function hashResearchReceiptText(text) {
+  const getBuiltin =
+    typeof process === 'object' &&
+    process &&
+    typeof process.getBuiltinModule === 'function'
+      ? process.getBuiltinModule.bind(process)
+      : null
+  const crypto = getBuiltin &&
+    (getBuiltin('node:crypto') || getBuiltin('crypto'))
+  if (!crypto) return ''
+  return crypto.createHash('sha256').update(text).digest('hex')
+}
+
+function readResearchReceiptArtifact(artifactPath) {
+  const getBuiltin =
+    typeof process === 'object' &&
+    process &&
+    typeof process.getBuiltinModule === 'function'
+      ? process.getBuiltinModule.bind(process)
+      : null
+  const fileSystem = getBuiltin &&
+    (getBuiltin('node:fs') || getBuiltin('fs'))
+  if (!fileSystem) {
+    throw new TypeError('filesystem inspection is unavailable')
+  }
+  return fileSystem.readFileSync(artifactPath, 'utf8')
+}
+
+function researchReceiptReasons(
+  progress,
+  readReceipt = readResearchReceiptArtifact,
+  hashText = hashResearchReceiptText,
+) {
+  const value = progress && typeof progress === 'object'
+    ? progress
+    : {}
+  const binding = value.receiptArtifact
+  if (
+    !binding ||
+    typeof binding.path !== 'string' ||
+    binding.path === '' ||
+    /\.tmp$/i.test(binding.path) ||
+    !/^sha256:[a-f0-9]{64}$/.test(binding.hash || '') ||
+    !Number.isInteger(binding.bytes) ||
+    binding.bytes < 1
+  ) {
+    return ['research receipt artifact binding is missing or malformed']
+  }
+
+  let receiptText
+  try {
+    receiptText = readReceipt(binding.path)
+  } catch (error) {
+    return [
+      `research receipt artifact is not inspectable (${error && error.code || 'read failed'})`,
+    ]
+  }
+  const reasons = []
+  const actualHash = typeof hashText === 'function'
+    ? `sha256:${hashText(receiptText)}`
+    : ''
+  if (actualHash !== binding.hash) {
+    reasons.push(
+      'research receipt artifact hash does not match durable bytes',
+    )
+  }
+  const actualBytes = unescape(encodeURIComponent(receiptText)).length
+  if (actualBytes !== binding.bytes) {
+    reasons.push(
+      'research receipt artifact byte count does not match durable bytes',
+    )
+  }
+  if (reasons.length) return reasons
+
+  let rows
+  try {
+    rows = JSON.parse(receiptText)
+  } catch {
+    return ['research receipt artifact is not valid JSON']
+  }
+  if (!Array.isArray(rows)) {
+    return ['research receipt artifact must contain an array of call receipts']
+  }
+
+  const counts = {
+    search: 0,
+    fetch: 0,
+    'usable-inspection': 0,
+  }
+  rows.forEach((row, index) => {
+    if (!row || typeof row !== 'object' || !(row.kind in counts)) {
+      reasons.push(`research receipt row ${index + 1} has an invalid kind`)
+      return
+    }
+    counts[row.kind]++
+    if (typeof row.request !== 'string' || row.request.trim() === '') {
+      reasons.push(`research receipt row ${index + 1} has no request`)
+    }
+    if (typeof row.source !== 'string' || row.source.trim() === '') {
+      reasons.push(`research receipt row ${index + 1} has no source`)
+    }
+    if (
+      typeof row.contribution !== 'string' ||
+      row.contribution.trim() === ''
+    ) {
+      reasons.push(
+        `research receipt row ${index + 1} has no material contribution`,
+      )
+    }
+  })
+  for (const [kind, reported] of [
+    ['search', value.searchesReceipted],
+    ['fetch', value.fetchesReceipted],
+    ['usable-inspection', value.usableInspectionsReceipted],
+  ]) {
+    if (Number.isInteger(reported) && counts[kind] !== reported) {
+      reasons.push(
+        `${kind} receipt rows do not match the reported count ` +
+        `(${counts[kind]} rows, ${reported} reported)`,
+      )
+    }
+  }
+  return reasons
+}
+// === USEFUL-OUTPUT-BUDGET-SLICE:END ===
+
+const SCOPING_ANGLES = [           // ordered complementary evidence themes used only when the classified profile needs scouts
+  { key: 'domain', label: 'DOMAIN & LANDSCAPE', research: true },
+  { key: 'capability', label: 'CAPABILITY / FEATURE TREE', research: false },
+  { key: 'experience', label: 'EXPERIENCE / INTERFACE SURFACES', research: false },
+  { key: 'architecture', label: 'REAL-SYSTEMS / ARCHITECTURE + STRESS', research: false },
+  { key: 'operability', label: 'OPERABILITY / QUALITY', research: false },
+]
+
+// ----- TIER LADDER (the proportionality fix; GATES.md "TIER CONTRACTS") ----
+// The gate sequence is NOT one fixed pipeline. ROADMAP.md assigns each item a
+// TIER (T0-T3, rubric in PLAYBOOKS.md) and the feature runs ONLY that tier's
+// gate SUBSET. The full G1-G6 + 3-juror panel + converge-SWEEP stack is T3 -
+// the ceiling, not the default. This is the mechanical fix for the benchmark's
+// always-heavy 22x cost: a four-line bug fix (T1) must not run the same gates
+// as "build me a SaaS" (T3). Every tier still ends in the run-level default-FAIL
+// GOAL-CHECK (the keeper that caught the one real benchmark defect).
+//
+//   plan       - a tier may run G1 when the roadmap marks a conditional-plan reason
+//   planLoop   - a conditional G1 plan gets review+fresh-verify assurance at T3
+//   implReview - G5 IMPL-REVIEW runs after IMPLEMENT
+//   verify     - G6 VERIFY runs (T1 once / T2-T3 with retries)
+//   panelSize  - G7 SIGN-OFF jurors (0 = no panel, 1 = T2, 3 = T3 unanimous)
+//   redoBudget - in-tier FAIL redos before the feature ESCALATES one tier up
+const TIER_PIPELINE = {
+  T0: { plan: false, planLoop: false, implReview: true,  verify: true,  panelSize: 0, redoBudget: 1 },
+  T1: { plan: false, planLoop: false, implReview: true,  verify: true,  panelSize: 0, redoBudget: 1, freshVerifyDebug: true },
+  T2: { plan: true,  planLoop: false, implReview: true,  verify: true,  panelSize: 1, redoBudget: 2 },
+  T3: { plan: true,  planLoop: true,  implReview: true,  verify: true,  panelSize: PANEL_SIZE, redoBudget: MAX_IMPL_CYCLES },
+}
+const TIER_ORDER = ['T0', 'T1', 'T2', 'T3']
+const DEFAULT_TIER = 'T3'   // an omitted/unknown tier resolves to the safe ceiling
+
+// Run-level SWEEP scaled by the mission's highest feature tier (PLAYBOOKS:
+// T0/T1 no sweep - GOAL-CHECK is the backstop; T2 mini-sweep 1 round; T3 sweep
+// to convergence). This is the lean win at the run level: a bounded mission
+// skips the whole sweeper wave and goes straight to the terminal GOAL-CHECK.
+const SWEEP_BY_TIER = {
+  T0: { rounds: 0, cleanRequired: 0 },
+  T1: { rounds: 0, cleanRequired: 0 },
+  T2: { rounds: 1, cleanRequired: 1 },
+  T3: { rounds: MAX_SWEEP_ROUNDS, cleanRequired: REQUIRED_CLEAN_SWEEPS },
+}
+
+// Every run enters the adaptive roadmap flow once. The roadmap author classifies
+// scope as bounded, multi-surface, or unusually-large; scopeTopology() then fixes
+// the agent/round budget. ROADMAP.md carries the repository intelligence, ordered
+// dependency lanes, framework choices, tests, and verification needed by build.
+
+// resolveTier: an explicit, recognized tier is honored; anything else (omitted,
+// null, unknown) resolves to a SAFE FALLBACK so a feature can never silently
+// take a leaner path than it earns. The fallback is the T3 ceiling for an
+// expand-mission (ambitious) run, but drops to T1 when EXPAND_MISSION is off -
+// a bounded run's omitted tier is a bounded task, not a moonshot. An explicit
+// tier from ROADMAP.md always wins either way; the fallback only fills a blank.
+function resolveTier(feature) {
+  const t = feature && feature.tier
+  if (TIER_PIPELINE[t]) return t
+  return (typeof EXPAND_MISSION !== 'undefined' && !EXPAND_MISSION) ? 'T1' : DEFAULT_TIER
+}
+
+// nextTier: a feature climbs exactly ONE tier on FAIL/OUT-OF-SCOPE and re-runs
+// there. T3 is the ceiling and never climbs (it arbitrates instead).
+function nextTier(tier) {
+  const i = TIER_ORDER.indexOf(tier)
+  return i < 0 || i >= TIER_ORDER.length - 1 ? DEFAULT_TIER : TIER_ORDER[i + 1]
+}
+
+// ----- FRAMEWORK HARD GATE (SPD-4 / F-FRAMEWORK) --------------------------
+// Framework selection is a HARD GATE at dispatch. Every feature builds under a
+// framework LEAF; the leaf's declared `GATE PATH:` line is the gate sequence and
+// its tier is the depth ceiling. An ABSENT or UNKNOWN framework at dispatch is an
+// INVALID-DISPATCH: the feature routes to ap-framework-generator to MINT one before
+// any build gate runs (mirrors the ledger-side frameworkTierFindings/Fallthrough
+// rules, which are the post-hoc teeth; this is the pre-dispatch teeth).
+// The 14 leaves are lockstep with agents/claude/frameworks/*.md (the prose decision tree,
+// the single routing source of truth since framework-selector.js was deleted, P-26).
+const KNOWN_FRAMEWORK_LEAVES = new Set([
+  'apply', 'backend-build', 'backend-fix', 'backend-implement', 'docs',
+  'frontend-build', 'frontend-fix', 'frontend-implement', 'frontend-review',
+  'plan-design', 'plan-research', 'plan-scope', 'polish', 'refactor',
+])
+// The `apply` leaf's GATE PATH skips G1-G3 (no PLAN/FRESH-VERIFY) and G7 (no
+// SIGN-OFF): APPLY -> DIFF-REVIEW -> VERIFY-GREEN, i.e. G4 -> G5 -> G6 + the
+// GOAL-CHECK floor. NARROW GATE-PATH INTERPRETATION: this is the one leaf whose
+// declared path materially reshapes the tier pipeline (like the debug playbook's
+// G3.5), so it is special-cased here. FULL interpretation would parse every leaf's
+// `GATE PATH:` line and drive the exact sequence per leaf; that is deferred - the
+// tier ladder + this apply special-case cover the material cases today.
+const APPLY_FRAMEWORK = 'apply'
+
+// frameworkDispatchVerdict: the pre-dispatch hard-gate verdict for a feature.
+// Returns { ok:true, framework } when the leaf is known, else { ok:false, reason,
+// framework } naming the INVALID-DISPATCH so the caller routes to the generator.
+function frameworkDispatchVerdict(feature) {
+  const framework = feature && typeof feature.framework === 'string' ? feature.framework.trim() : ''
+  if (framework === '') {
+    return { ok: false, framework: '', reason: 'absent framework - no leaf selected for this feature' }
+  }
+  if (!KNOWN_FRAMEWORK_LEAVES.has(framework)) {
+    return { ok: false, framework, reason: `unknown framework leaf "${framework}" - not one of the ${KNOWN_FRAMEWORK_LEAVES.size} declared leaves` }
+  }
+  return { ok: true, framework }
+}
+
+// defaultFrameworkForCategory: the deterministic leaf ap-framework-generator would
+// MINT for a feature whose framework is absent/unknown, derived from its category +
+// tag. This is the narrow generator: it never blocks the run, but it ALWAYS names a
+// concrete known leaf so no build gate runs framework-less (the ledger-side rules
+// then attest the FEATURE-META framework= token). FULL routing spawns the
+// ap-framework-generator agent; this deterministic mapping is the narrow stand-in.
+function defaultFrameworkForCategory(feature) {
+  const category = feature && typeof feature.category === 'string' ? feature.category : ''
+  const isDebug = feature && feature.tag === 'debug'
+  switch (category) {
+    case 'frontend': return isDebug ? 'frontend-fix' : 'frontend-build'
+    case 'plan':     return 'plan-design'
+    case 'docs':     return 'docs'
+    case 'data':
+    case 'integration':
+    case 'infra':
+    case 'backend':
+    default:         return isDebug ? 'backend-fix' : 'backend-build'
+  }
+}
+
+// resolveFramework: the HARD GATE applied once at dispatch. A known leaf passes
+// through; an absent/unknown one is an INVALID-DISPATCH that the narrow generator
+// repairs by MINTING a category-derived leaf (logged loudly), so the feature never
+// builds framework-less. Returns the resolved known leaf and mutates feature.framework.
+function resolveFramework(feature) {
+  const verdict = frameworkDispatchVerdict(feature)
+  if (verdict.ok) return verdict.framework
+  const minted = defaultFrameworkForCategory(feature)
+  log(`INVALID-DISPATCH ${feature.id}: ${verdict.reason}; routing to ap-framework-generator - minted framework="${minted}" (${feature.category}${feature.tag ? `/${feature.tag}` : ''}). No build gate runs framework-less.`)
+  feature.framework = minted
+  return minted
+}
+
+
+// maxTier: the mission-level tier is the HIGHEST feature tier; it decides the
+// run-level sweep depth and is recorded in the summary.
+function maxTier(featureList) {
+  let top = 'T0'
+  for (const f of featureList) {
+    const t = resolveTier(f)
+    if (TIER_ORDER.indexOf(t) > TIER_ORDER.indexOf(top)) top = t
+  }
+  return top
+}
+
+// ----- persona routing (v4.0 hierarchical personas) -----------------------
+// Each gate maps to a specific custom agent definition (in agents/claude/agents/).
+// agentType routes agent() to the right persona. When recursive depth is
+// available, supervisors (L1) handle pipeline orchestration; when unavailable,
+// the parent drives the gates directly via the L3 executor / L4 leaf personas.
+const PERSONA = {
+  preflight: 'ap-preflight-probe',
+  intake: 'ap-intake',
+  scopeSupervisor: 'ap-scope-coordinator',
+  scoper: 'ap-scoper',
+  researcher: 'ap-researcher',
+  synthesizer: 'ap-synthesizer',
+  featureSupervisor: 'ap-feature-coordinator',
+  planner: 'ap-planner',
+  reviewer: 'ap-reviewer',
+  freshVerifier: 'ap-fresh-verifier',
+  depthProber: 'ap-depth-prober',
+  implementer: 'ap-implementer',
+  verifier: 'ap-verifier',
+  execharnessResolver: 'ap-execharness-resolver',
+  frameworkGenerator: 'ap-framework-generator',
+  frameworkValidator: 'ap-framework-validator',
+  juror: 'ap-juror',
+  scribe: 'ap-scribe',
+  sweepSupervisor: 'ap-sweep-coordinator',
+  sweeper: 'ap-sweeper',
+  goalChecker: 'ap-goal-checker',
+  arbiter: 'ap-arbiter',
+  reAnchor: 'ap-re-anchor',
+  janitor: 'ap-janitor',
+}
+
+// ----- wait-and-retry policy --------------------------------------------
+// A transient interruption retries the SAME call, but a provider outage cannot
+// hold one gate for hours. The attempt and wall-clock budgets above terminate
+// the call loudly; the external supervisor can resume from durable state.
+const RETRY_BASE_MS = 1000
+const RETRY_FACTOR = 2
+const RETRY_CAP_MS = 15 * 1000
+const RETRY_JITTER = 0.2
+// CONTEXT IS NON-TERMINAL: a full context window is a COMPACTION event, never a
+// stop. In a model-discipline run the loop compacts (preserving mission text,
+// RUN-NONCE, current phase, frozen plans, completed artifacts), runs the
+// POST-COMPACTION RE-ANCHOR, and resumes the in-flight gate. This can fire any
+// number of times, anywhere; the harness never voluntarily yields the loop.
+
+// ----- schemas ----------------------------------------------------------
+// ROADMAP.md is the single executable scope contract. It replaces intake.md,
+// scope-map.md, bucketlist.md, and redundant lane-local plans on new runs.
+const ROADMAP_ITEM_PROPERTIES = {
+  id: { type: 'string', description: 'stable feature id' },
+  title: { type: 'string' },
+  category: { type: 'string', enum: ['plan', 'backend', 'frontend', 'data', 'integration', 'infra', 'docs'] },
+  tag: { type: 'string', enum: ['debug', 'research', 'user-facing', 'polish', 'external-target'] },
+  tier: { type: 'string', enum: ['T0', 'T1', 'T2', 'T3'] },
+  framework: { type: 'string', description: 'selected framework leaf' },
+  boundary: { type: 'string', description: 'owned paths/area; parallel lanes must not overlap' },
+  dependsOn: { type: 'array', items: { type: 'string' } },
+  launchGroup: { type: 'integer', minimum: 0 },
+  integrationLane: { type: 'string', description: 'where and how this item joins the final deliverable' },
+  doneMeans: { type: 'string' },
+  implementationSteps: { type: 'array', minItems: 1, items: { type: 'string' } },
+  acceptanceCriteria: { type: 'array', minItems: 1, items: { type: 'string' } },
+  unhappyPaths: { type: 'array', minItems: 1, items: { type: 'string' } },
+  testsFirst: { type: 'array', minItems: 1, items: { type: 'string' } },
+  verification: { type: 'array', minItems: 1, items: { type: 'string' } },
+  coverageRequirement: { type: 'string', pattern: '95%' },
+  requiresDetailedPlan: { type: 'boolean' },
+}
+const ROADMAP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['capability', 'resolvedModel', 'effortStatus', 'promptLedgerPath', 'missionPointer', 'scopeProfile', 'repositoryIntel', 'toolDecisions', 'frameworkDecisions', 'items', 'ordered', 'hasTimeEstimates', 'roadmapPath', 'roadmapHash', 'roadmapBytes'],
+  properties: {
+    capability: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['run', 'read', 'write', 'evidence'],
+      properties: {
+        run: { type: 'boolean' },
+        read: { type: 'boolean' },
+        write: { type: 'boolean' },
+        evidence: { type: 'string' },
+      },
+    },
+    resolvedModel: { type: 'string' },
+    effortStatus: { type: 'string', enum: ['selectable', 'inherited-only', 'unsupported', 'unknown'] },
+    promptLedgerPath: { type: 'string' },
+    missionPointer: {
+      type: 'object', additionalProperties: false,
+      required: ['path', 'hash', 'bytes', 'nonce'],
+      properties: {
+        path: { type: 'string' },
+        hash: { type: 'string', pattern: '^sha256:[a-f0-9]{64}$' },
+        bytes: { type: 'integer', minimum: 1 },
+        nonce: { type: 'string' },
+      },
+    },
+    scopeProfile: { type: 'string', enum: ['bounded', 'multi-surface', 'unusually-large'] },
+    escalationReason: { type: 'string' },
+    repositoryIntel: { type: 'string' },
+    toolDecisions: { type: 'array', minItems: 1, items: { type: 'string' } },
+    frameworkDecisions: { type: 'array', minItems: 1, items: { type: 'string' } },
+    items: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'title', 'category', 'tier', 'framework', 'boundary', 'dependsOn', 'launchGroup', 'integrationLane', 'doneMeans', 'implementationSteps', 'acceptanceCriteria', 'unhappyPaths', 'testsFirst', 'verification', 'coverageRequirement', 'requiresDetailedPlan'],
+        properties: ROADMAP_ITEM_PROPERTIES,
+      },
+    },
+    ordered: { type: 'boolean' },
+    hasTimeEstimates: { type: 'boolean' },
+    roadmapPath: { type: 'string' },
+    roadmapHash: { type: 'string', pattern: '^sha256:[a-f0-9]{64}$' },
+    roadmapBytes: { type: 'integer', minimum: 1 },
+    nonce: { type: 'string' },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'reasons'],
+  properties: {
+    verdict: { type: 'string', enum: ['SMASH', 'PASS'] },
+    reasons: { type: 'array', items: { type: 'string' }, description: 'numbered, specific; what to change if SMASH' },
+    suggestions: { type: 'array', items: { type: 'string' } },
+    outOfScope: { type: 'boolean', description: 'true ONLY if this task is larger/riskier than its assigned tier (touches >1 subsystem, needs a real design decision, a hidden cross-cutting failure surfaced) - it climbs ONE tier and re-runs there. A fixable local defect is NOT out-of-scope; that is an ordinary SMASH.' },
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+
+const PUBLICATION_PROPERTIES = {
+  transition: { type: 'string' },
+  featureId: { type: 'string' },
+  artifactPath: { type: 'string' },
+  artifactExists: { type: 'boolean' },
+  artifactHash: {
+    type: 'string',
+    pattern: '^sha256:[a-f0-9]{64}$',
+  },
+  artifactBytes: { type: 'integer', minimum: 1 },
+  nonce: { type: 'string' },
+  producerGate: { type: 'string' },
+  producerPersona: { type: 'string' },
+  verdict: { type: 'string' },
+  ledgerPath: { type: 'string' },
+  ledgerRow: { type: 'string' },
+  ledgerRowHash: {
+    type: 'string',
+    pattern: '^sha256:[a-f0-9]{64}$',
+  },
+  ledgerRowDurable: { type: 'boolean' },
+}
+
+const PUBLICATION_REQUIRED = Object.keys(
+  PUBLICATION_PROPERTIES,
+)
+
+const PUBLICATION_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: PUBLICATION_REQUIRED,
+  properties: PUBLICATION_PROPERTIES,
+}
+
+const FRESH_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'reasons'],
+  properties: {
+    verdict: { type: 'string', enum: ['APPROVE', 'REJECT'] },
+    reasons: { type: 'array', items: { type: 'string' } },
+    publication: PUBLICATION_SCHEMA,
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+
+const PLAN_DRAFT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['plan', 'publication'],
+  properties: {
+    plan: { type: 'string' },
+    publication: PUBLICATION_SCHEMA,
+    nonce: { type: 'string' },
+  },
+}
+
+const SCOUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'evidence',
+    'corrections',
+    'evidenceHash',
+    'evidenceBytes',
+    'researchRequired',
+    'searchesClaimed',
+    'searchesReceipted',
+    'fetchesClaimed',
+    'fetchesReceipted',
+    'usableInspectionsClaimed',
+    'usableInspectionsReceipted',
+    'materializedOutputs',
+  ],
+  properties: {
+    evidence: { type: 'array', items: { type: 'string' } },
+    corrections: { type: 'array', items: { type: 'string' } },
+    evidenceHash: { type: 'string', pattern: '^sha256:[a-f0-9]{64}$' },
+    evidenceBytes: { type: 'integer', minimum: 1 },
+    researchRequired: { type: 'boolean' },
+    searchesClaimed: { type: 'integer', minimum: 0 },
+    searchesReceipted: { type: 'integer', minimum: 0 },
+    fetchesClaimed: { type: 'integer', minimum: 0 },
+    fetchesReceipted: { type: 'integer', minimum: 0 },
+    usableInspectionsClaimed: { type: 'integer', minimum: 0 },
+    usableInspectionsReceipted: { type: 'integer', minimum: 0 },
+    materializedOutputs: { type: 'integer', minimum: 0 },
+    receiptArtifact: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['path', 'hash', 'bytes'],
+      properties: {
+        path: { type: 'string' },
+        hash: { type: 'string', pattern: '^sha256:[a-f0-9]{64}$' },
+        bytes: { type: 'integer', minimum: 1 },
+      },
+    },
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+
+const IMPLEMENT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'status',
+    'filesChanged',
+    'testsWritten',
+    'testEvidence',
+    'conflictReason',
+  ],
+  properties: {
+    status: { type: 'string', enum: ['COMPLETE', 'PLAN-CONFLICT', 'SPLIT-REQUEST'] },
+    filesChanged: { type: 'array', items: { type: 'string' } },
+    testsWritten: { type: 'array', items: { type: 'string' } },
+    testEvidence: { type: 'string' },
+    conflictReason: { type: 'string' },
+    splitBoundaries: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['boundary', 'dependsOn'],
+        properties: {
+          boundary: { type: 'string' },
+          dependsOn: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+    publication: PUBLICATION_SCHEMA,
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+
+// F-DEPTH G3.5 DEPTH-LOCK schema. The ap-depth-prober derives D1-D5 from the
+// issue text BLIND to the proposed fix layer, then compares. The verdict is
+// RECOMPUTED in code via depthLockPass (never trusted from the string): a PASS
+// over a layer that does not equal d3DeepestCause, or a D4 repro not proven RED
+// unpatched, is overridden to depth-miss.
+const DEPTH_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'd3DeepestCause', 'reproRed'],
+  properties: {
+    verdict: { type: 'string', enum: ['PASS', 'REJECT'] },
+    d1HomeFunction: { type: 'string', description: 'file:function where the behavior is DECIDED, derived from the issue text alone' },
+    d3DeepestCause: { type: 'string', description: 'the single deepest point (file.py::function) fixing ALL D2 input classes - derived BLIND to the proposed fix layer' },
+    reproRed: { type: 'boolean', description: 'was the D4 adversarial issue-derived repro proven RED against UNPATCHED code (real captured red output on record)?' },
+    reasons: { type: 'array', items: { type: 'string' } },
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+
+const VERIFY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'evidence', 'coveragePercent'],
+  properties: {
+    verdict: { type: 'string', enum: ['VERIFIED', 'FAILED'] },
+    evidence: { type: 'string', description: 'key command output proving the verdict - the VERBATIM before/after test runs, not a paraphrase' },
+    coveragePercent: { type: 'number' },
+    // GROUNDED BEFORE/AFTER FIELDS (the anti-coverage-theater fix). VERIFIED is
+    // RECOMPUTED in code from these, never trusted from the verdict string: a
+    // model that says VERIFIED while a pre-existing test regressed (the
+    // astropy-7606 failure) is overridden to FAILED.
+    testCommand: { type: 'string', description: 'the exact command run to exercise the tests (so the run is reproducible and auditable)' },
+    reproWasRed: { type: 'boolean', description: 'DEBUG: did the issue reproduction case provably FAIL on the code BEFORE the fix (real captured red output)? A debug fix with no red baseline is invalid - you cannot prove you fixed what you never reproduced. Non-debug features may report true vacuously only if there is genuinely no repro to run.' },
+    reproNowGreen: { type: 'boolean', description: 'did the reproduction case / the feature\'s target behavior provably PASS after the fix (real captured green output)? Required true for VERIFIED.' },
+    preExistingRegressions: { type: 'array', items: { type: 'string' }, description: 'test ids that were GREEN before the change and are RED after it, across every touched module AND its direct dependents. ANY entry is a hard FAILED - a green→red flip is a regression, never arbitrable into DONE. Empty list = no regressions found (you MUST have actually run those tests to claim this).' },
+    outOfScope: { type: 'boolean', description: 'true ONLY if verifying revealed the task is larger/riskier than its assigned tier (a hidden cross-cutting failure surfaced, it needs a real design decision) - it climbs ONE tier and re-runs there. A plain failing test is NOT out-of-scope; that is an ordinary FAILED.' },
+    // REAL-RUNNER EVIDENCE FIELDS (the keystone anti-MVCE fix). Optional in the
+    // schema, RECOMPUTED in code on a debug verify (never trusted): a verifier
+    // that ran only a `python -c "...print..."` MVCE instead of a real test
+    // runner is overridden to FAILED. The non-debug vacuous path co-exists, so
+    // these are not in `required` - the recompute is the enforcement locus.
+    runnerKind: { type: 'string', enum: ['pytest', 'unittest', 'nose', 'tox', 'go-test', 'jest', 'cargo', 'other', 'none'], description: 'the test-runner family actually invoked; `none` means no real runner ran (auto-FAIL on a debug verify).' },
+    runnerInvocation: { type: 'string', description: 'the exact runner command executed, e.g. python -m pytest path::node. A python -c "..." MVCE re-run is NOT a runner invocation.' },
+    collectedTestCount: { type: 'integer', minimum: 0, description: 'how many tests the runner collected (the "collected N items" line). <1 is auto-FAIL on a debug verify.' },
+    assertingTestNodeId: { type: 'string', description: 'the specific test node id that reproduces the bug, e.g. tests/test_x.py::TestY::test_z. Required non-empty whenever reproNowGreen===true on a debug verify.' },
+    redBaselineStashGated: { type: 'boolean', description: 'DEBUG: was the authored asserting test proven RED on a git-stashed CLEAN tree (git stash -> run -> assert red -> git stash pop) before counting as the red baseline? A claimed reproWasRed=true without a stash-gated red run is recomputed to FAILED (the red baseline must be git-restorable proof, not a trusted assertion).' },
+    inputClassesCovered: { type: 'integer', minimum: 0, description: 'ADVISORY: how many DISTINCT input FORMS/classes the repro + fix exercise (e.g. foo / ./foo / /abs/foo / foo/ for path matching; the structural post-conditions for a state bug). On a debug verify, < 2 is a SOFT floor fed back to G4 (arbitrable, not a hard FAIL).' },
+    branchCoveragePercent: { type: 'number', description: 'ADVISORY: branch coverage on the changed lines, measured by the coverage tool. On a debug verify, below the named branch floor is a SOFT floor fed back to G4 (arbitrable, not a hard FAIL).' },
+    reasons: { type: 'array', items: { type: 'string' } },
+    publication: PUBLICATION_SCHEMA,
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+
+// === KEYSTONE-RECOMPUTE-SLICE:START - test-only export seam; sliced by keystone-grounded-verify.test.js. Self-contained: references only these symbols + built-ins. ===
+const REAL_RUNNER_RE = /\b(pytest|py\.test|python -m pytest|unittest|nose2?|tox|go test|jest|mocha|cargo test)\b/
+const MIN_INPUT_CLASSES = 2                 // FIX-03 soft floor: a debug repro must exercise >= 2 distinct input classes
+const BRANCH_COVERAGE_FLOOR = 90            // FIX-15 soft floor: branch coverage on changed lines (distinct from the 95% LINE floor; branch coverage is structurally harder, and matplotlib's verify-fragile pass sat at ~71%)
+
+// Recompute the grounded-verify failure reasons from CAPTURED fields, never the
+// verdict string. The three runner rules are DEBUG-GATED (isDebug): the forensic
+// 0/6 failures were all debug/SWE-bench, and a non-debug feature may legitimately
+// have no runnable test target (docs/config/pure-refactor) - gating them there
+// avoids a false-FAIL while still trapping every debug fix. Non-debug still clears
+// the ungated reproNowGreen / preExistingRegressions rules.
+function groundedVerifyReasons(verify, isDebug) {
+  const reasons = []
+  // Ungated affirmative-evidence rules: an omitted field is NEVER clean
+  // evidence. VERIFIED requires an explicit green and an explicit (possibly
+  // empty) regression sweep, on debug and non-debug alike.
+  const regressions = Array.isArray(verify.preExistingRegressions) ? verify.preExistingRegressions : null
+  if (verify.reproNowGreen === false) reasons.push('repro/target is not green after the fix (reproNowGreen=false)')
+  else if (verify.reproNowGreen !== true) reasons.push('no affirmative post-change green evidence (reproNowGreen omitted) - an omitted field is not a green run')
+  if (regressions === null) reasons.push('no affirmative regression-sweep evidence (preExistingRegressions omitted) - an omitted field is not a clean sweep')
+  else if (regressions.length) reasons.push(`pre-existing test regression(s) green->red (hard FAILED, never arbitrable into DONE): ${regressions.join(', ')}`)
+  if (isDebug) {
+    if (verify.reproWasRed !== true) reasons.push('debug fix has no proven RED baseline (reproWasRed!=true) - cannot claim a fix for a bug never shown failing first')
+    const invocation = typeof verify.runnerInvocation === 'string' ? verify.runnerInvocation.trim() : ''
+    if (verify.runnerKind === 'none' || !REAL_RUNNER_RE.test(invocation)) reasons.push('G6 artifact contains no real test-runner invocation (a `python -c` MVCE re-run is not evidence)')
+    if (!(typeof verify.collectedTestCount === 'number' && verify.collectedTestCount >= 1)) reasons.push('zero tests collected (collectedTestCount < 1)')
+    const node = typeof verify.assertingTestNodeId === 'string' ? verify.assertingTestNodeId.trim() : ''
+    if (verify.reproNowGreen === true && node === '') reasons.push('no asserting test named (reproNowGreen=true but assertingTestNodeId empty)')
+    if (verify.reproWasRed === true && verify.redBaselineStashGated !== true) reasons.push('red baseline not git-stash-gated (the authored test must FAIL on a git-stashed clean tree: git stash -> run -> assert red -> git stash pop, before it counts as the red baseline)')
+  }
+  return reasons
+}
+
+// SOFT rigor floors (FIX-03 input-domain, FIX-15 branch coverage). Advisory and
+// DEBUG-GATED: a breach is fed back to G4 like the COVERAGE_FLOOR (arbitrable),
+// NOT a hard verdict override. Permissive-on-absence (mirrors COVERAGE_FLOOR): a
+// missing/non-number field does not trip the floor, so non-debug and field-less
+// verifies are never false-FAILed and the keystone HARD rules are not made soft.
+function softFloorReasons(verify, isDebug) {
+  const reasons = []
+  if (!isDebug) return reasons
+  const inputClasses = verify.inputClassesCovered
+  if (typeof inputClasses === 'number' && inputClasses < MIN_INPUT_CLASSES) reasons.push(`input-domain too narrow: only ${inputClasses} distinct input class(es) exercised (< ${MIN_INPUT_CLASSES}); enumerate and cover more input forms, then re-verify`)
+  const branch = verify.branchCoveragePercent
+  if (typeof branch === 'number' && branch < BRANCH_COVERAGE_FLOOR) reasons.push(`branch coverage ${branch}% on changed lines is below the ${BRANCH_COVERAGE_FLOOR}% branch floor; exercise the un-hit branches, then re-verify`)
+  return reasons
+}
+
+// Apply the override: mutate the verify object to FAILED and append the reasons.
+// Returns true when an override was applied (so the caller logs it). The log line
+// stays at the call site because it needs feature.id/attempts from the loop closure.
+function applyGroundedOverride(verify, reasons) {
+  if (!reasons.length) return false
+  verify.verdict = 'FAILED'
+  verify.reasons = [...(verify.reasons || []), ...reasons]
+  return true
+}
+// === KEYSTONE-RECOMPUTE-SLICE:END ===
+
+// === INTAKE-CONTRACT-SLICE:START - test-only export seam; sliced by intake-contract-reject.test.js. Self-contained: references only these symbols + built-ins. ===
+const SYMPTOM_RE = /no (longer )?(raise|throw|error|exception|crash)/i
+const SYMPTOM_REJECT_REASON = 'symptom-shaped criterion - state the behavioral contract'
+
+// A debug-tagged feature MUST carry at least one POSITIVE post-condition: a
+// stated (non-empty) acceptanceCriteria entry that does NOT match SYMPTOM_RE.
+// Returns true only when such a positive entry exists. Absent / empty /
+// all-whitespace / non-array / all-symptom => false (no contract).
+function hasPositivePostCondition(criteria) {
+  const stated = (Array.isArray(criteria) ? criteria : [])
+    .filter(c => typeof c === 'string' && c.trim() !== '')
+  if (stated.length === 0) return false
+  return stated.some(c => !SYMPTOM_RE.test(c))
+}
+
+// Returns the {id, reason} of every DEBUG feature lacking a behavioral
+// contract (empty list => clean). Debug-gated, exactly like
+// groundedVerifyReasons(verify, isDebug): a non-debug feature is NEVER
+// rejected, so existing non-debug fixtures and the legacy schema are safe.
+// Absence is itself a reject (no escape hatch): the ONLY structurally
+// available path for a debug feature is to state a positive post-condition.
+function debugContractRejects(features) {
+  return (Array.isArray(features) ? features : [])
+    .filter(f => f && f.tag === 'debug')
+    .filter(f => !hasPositivePostCondition(f.acceptanceCriteria))
+    .map(f => ({ id: f.id, reason: SYMPTOM_REJECT_REASON }))
+}
+// === INTAKE-CONTRACT-SLICE:END ===
+
+// === DEBUGPATH-FRESHVERIFY-SLICE:START - test-only export seam; sliced by debugpath-freshverify.test.js. Self-contained: references only its params + built-ins. ===
+//
+// FIX-07: a debug-tagged feature on a freshVerifyDebug tier (T1) must run a G1
+// plan draft + a G3 fresh-verify (ap-fresh-verifier, mission+plan only) that
+// RE-DERIVES the root cause independently BEFORE the fix (G4). The predicate is
+// the single decision the live runFeatureInner branches on, so the flag is
+// consumed, never dead. Proportionality: true ONLY for tag==='debug' on a tier
+// whose cfg carries freshVerifyDebug===true (T1). T0 (no flag) and non-debug
+// features are always false.
+function debugFreshVerifyRequired(feature, tierCfg) {
+  return !!(tierCfg && tierCfg.freshVerifyDebug === true && feature && feature.tag === 'debug')
+}
+// === DEBUGPATH-FRESHVERIFY-SLICE:END ===
+
+// === DEPTHLOCK-SLICE:START - test-only export seam; sliced by depth-lock.test.js. Self-contained: references only its params + built-ins. ===
+//
+// F-DEPTH (G3.5 DEPTH-LOCK): the single binary decision the gate verdict turns
+// on. A debug fix is depth-locked ONLY when the frozen fix LAYER EQUALS the
+// independently-derived deepest-cause function (D3) AND the adversarial D4 repro
+// was proven RED against unpatched code. Strict `=== true` on reproRed (a truthy
+// non-true never passes) and strict layer equality (the pylint-7080 wrong-layer
+// slip - pylinter.py != expand_modules.py::_is_ignored_file - returns false).
+// Fail-safe: any null/undefined arg yields false, never throws.
+function depthLockPass(frozenLayer, d3DeepestCause, reproRed) {
+  if (typeof frozenLayer !== 'string' || frozenLayer === '') return false
+  if (typeof d3DeepestCause !== 'string' || d3DeepestCause === '') return false
+  return frozenLayer === d3DeepestCause && reproRed === true
+}
+// === DEPTHLOCK-SLICE:END ===
+
+// === PROVENANCE-SLICE:START - test-only export seam; sliced by integrity-provenance.test.js. Self-contained: references only these symbols + built-ins. ===
+
+// FIX-06 #4 (S2/B3): assertDistinctImplementVerify is DEFENSIVE CODIFICATION of
+// the implement!=verify invariant, in the assertExecLevel family. On the live
+// PERSONA map implementer ('ap-implementer') and verifier ('ap-verifier') are
+// already distinct, so this NEVER throws in the live path - a regression
+// tripwire that fails loudly if a FUTURE refactor points both spawns at one
+// persona. NOT the catch for F5-18; selfReviewSignatureFindings (ledger-check)
+// is. Throws a deterministic TypeError (nonTransient -> loud escalate) for every
+// tier because independent implementation review and runtime verification are floors.
+const TIERS_REQUIRING_DISTINCT_VERIFY = new Set(['T0', 'T1', 'T2', 'T3'])
+function assertDistinctImplementVerify(implementer, verifier, tier, site) {
+  if (!TIERS_REQUIRING_DISTINCT_VERIFY.has(tier)) return true
+  if (!implementer || !verifier) {
+    throw new TypeError(`NO-SELF-REVIEW GUARD: ${site} missing an implement/verify persona (implementer=${implementer}, verifier=${verifier})`)
+  }
+  if (implementer === verifier) {
+    throw new TypeError(`NO-SELF-REVIEW GUARD: ${site} would let one persona ("${implementer}") BOTH implement and verify at tier ${tier} (FIX-06). implement and verify must be distinct subagent_type.`)
+  }
+  return true
+}
+
+// FIX-05 #1: the canonical gate->expected-persona map. A recorded spawn whose
+// persona disagrees is a substitution (self-review-via-relabel). Duplicated in
+// ledger-check.js (gate.js is an ES module, cannot be require()d) - keep the two
+// copies in lockstep (non-blocking note in the review).
+const GATE_EXPECTED_PERSONA = {
+  'G1': 'ap-planner', 'G2': 'ap-reviewer', 'G3': 'ap-fresh-verifier',
+  'G3.5': 'ap-depth-prober',
+  'G4': 'ap-implementer', 'G5': 'ap-reviewer', 'G6': 'ap-verifier',
+  'G7': 'ap-juror', 'G8': 'ap-scribe',
+}
+
+// gateProvenanceReasons: the PURE reconcile the in-harness seal and (a sibling
+// copy in) the standalone validator share. Each claimed gate is
+// { gate, persona, artifactPresent }: persona is the spawned subagent_type
+// actually recorded ('' == no spawn == fabrication); artifactPresent is whether
+// evidence backs it. PERMISSIVE-ON-ABSENCE: only CLAIMED gates are passed in; a
+// gate the tier never runs is never in the list and never flagged.
+function gateProvenanceReasons(claimedGates) {
+  const reasons = []
+  for (const c of (Array.isArray(claimedGates) ? claimedGates : [])) {
+    if (!c || typeof c.gate !== 'string') continue
+    const expected = GATE_EXPECTED_PERSONA[c.gate]
+    const persona = typeof c.persona === 'string' ? c.persona.trim() : ''
+    if (persona === '') reasons.push(`${c.gate} claimed PASS with no spawned agent (fabricated attestation - F1-03)`)
+    else if (expected && persona !== expected) reasons.push(`${c.gate} claimed PASS by "${persona}" but the gate routes to ${expected} (persona substitution)`)
+    if (c.artifactPresent !== true) reasons.push(`${c.gate} claimed PASS with no on-disk artifact (no captured evidence behind the verdict)`)
+  }
+  return reasons
+}
+
+// assertGateArtifact: the in-harness throw. Any unbacked claimed gate -> a
+// deterministic (loud, nonTransient) error before the feature may reach DONE.
+function assertGateArtifact(feature, claimedGates) {
+  const reasons = gateProvenanceReasons(claimedGates)
+  if (reasons.length) {
+    throw new TypeError(`PROVENANCE GUARD (${feature && feature.id}): ${reasons.join('; ')}`)
+  }
+  return true
+}
+
+// FIX-05 #1 (live teeth): the REAL per-feature spawn ledger. recordGateSpawn is
+// called at each real gate spawn site (§3.1.C) with the SAME agentType value the
+// spawn used, so the recorded persona IS the spawned persona. markResumed flags
+// a feature that completed via ANY resume/crash shortcut (its gates ran in a
+// prior session). Both default to the module-global log for the live path and
+// accept an injected Map for hermetic unit tests (no state bleed).
+function recordGateSpawn(feature, gate, persona, log) {
+  if (!feature || !feature.id) return
+  const entry = log.get(feature.id) || { gates: [], resumed: false }
+  entry.gates.push({ gate, persona: typeof persona === 'string' ? persona : '' })
+  log.set(feature.id, entry)
+}
+function markResumed(feature, log) {
+  if (!feature || !feature.id) return
+  const entry = log.get(feature.id) || { gates: [], resumed: false }
+  entry.resumed = true
+  log.set(feature.id, entry)
+}
+
+// expectedGatesForTier: the gates a tier ACTUALLY runs, derived from the EXACT
+// flags the harness branches on (NEW-1 fix). planUntilApproved (gate.js ~957)
+// keys the plan-review/fresh-verify SMASH loop on tierCfg.planLoop, NOT plan:
+// at T2 (plan:true, planLoop:false) it takes the single-draft early branch that
+// spawns ONLY the planner (G1). So G1 is gated on cfg.plan, but G2+G3 are gated
+// on cfg.planLoop (T3 only) - mirroring the live spawn topology exactly. This is
+// what makes the seal PERMISSIVE-ON-ABSENCE WITH TEETH: a tier never expects a
+// gate it does not run, but a tier that DOES run a gate must have recorded it.
+function expectedGatesForTier(tierCfg, isDebug, hasDetailedPlan) {
+  const cfg = tierCfg || {}
+  const gates = []
+  if (cfg.plan && hasDetailedPlan) gates.push('G1')
+  if (cfg.planLoop && hasDetailedPlan) gates.push('G2', 'G3')
+  if (cfg.freshVerifyDebug && isDebug) {        // FIX-07: a debug feature on a freshVerifyDebug tier (T1) ran a G1 draft + G3 fresh-verify
+    if (!gates.includes('G1')) gates.push('G1')
+    if (!gates.includes('G3')) gates.push('G3')
+  }
+  // F-DEPTH (G3.5 DEPTH-LOCK): a debug feature runs DEPTH-LOCK after the plan freezes
+  // and before G4 at EVERY tier (resolvePlan + the resume branches call lockDebugPlan
+  // unconditionally for tag==='debug'). It is therefore a STRUCTURAL expectation for
+  // any debug feature - the seal requires the gate to have recorded a G3.5 spawn, so a
+  // debug feature cannot reach DONE with DEPTH-LOCK skipped. Non-debug features never
+  // run it and never expect it (proportionality).
+  if (isDebug) gates.push('G3.5')
+  gates.push('G4')                              // implement always runs
+  if (cfg.implReview) gates.push('G5')
+  if (cfg.verify) gates.push('G6')
+  if ((cfg.panelSize || 0) > 0) gates.push('G7')
+  return gates
+}
+
+// MIN_ARTIFACT_SUBSTANCE_CHARS: the same 200-char substance floor the standalone
+// validator (autoprompt-ledger-check.js artifactSubstantiationReasons) enforces on
+// disk. Kept in lockstep with that constant by necessity (gate.js is an ES module,
+// cannot require the CJS validator).
+const MIN_ARTIFACT_SUBSTANCE_CHARS = 200
+
+// hasArtifactSubstance: true only when `text` is a captured artifact body with at
+// least MIN_ARTIFACT_SUBSTANCE_CHARS of real (whitespace-collapsed) content beyond
+// the mandatory ARTIFACT scaffolding. PURE, total: a null / non-string / template-
+// only body returns false. This is the substance predicate the seal AUGMENTS
+// byGate.has with when a disk reader is injected - it never reads fs itself.
+function hasArtifactSubstance(text) {
+  if (typeof text !== 'string') return false
+  const collapsed = text
+    .replace(/^\s*ARTIFACT\b.*$/gim, '')       // drop the mandatory ARTIFACT header scaffold
+    .replace(/\s+/g, ' ')
+    .trim()
+  return collapsed.length >= MIN_ARTIFACT_SUBSTANCE_CHARS
+}
+
+// claimedGatesFromLog: build the claimed set for a FRESH completion from the
+// tier's expected gates reconciled against the recorded spawn ledger. A gate the
+// tier runs but the ledger never recorded -> persona '' + artifactPresent false
+// (two trip reasons). A recorded gate carries its REAL recorded persona (so a
+// substitution trips via GATE_EXPECTED_PERSONA). First recorded spawn per gate
+// wins (plan retries / multiple jurors append duplicates - harmless).
+// P-01 #2 AUGMENT: `artifactSubstantial(gate) -> boolean` is an OPTIONAL injected
+// disk-substance probe. When supplied (a fs-capable caller or a unit test), a gate
+// counts as backed ONLY when it was recorded AND its on-disk artifact clears the
+// 200-char substance floor - so a recorded spawn that wrote a hollow/template file
+// no longer passes on the spawn record alone. When absent (the fs-less live seal),
+// artifactPresent falls back to byGate.has and the on-disk+substance authority is
+// the wired runLedgerCheck hard-stop at the SCRIBE->JANITOR boundary.
+function claimedGatesFromLog(feature, tierCfg, log, artifactSubstantial) {
+  const entry = log.get(feature && feature.id) || { gates: [] }
+  const byGate = new Map()
+  for (const g of entry.gates) if (!byGate.has(g.gate)) byGate.set(g.gate, g.persona)
+  const hasDetailedPlan = byGate.has('G1') || !!feature && (
+    feature.requiresDetailedPlan === true ||
+    feature.tag === 'debug'
+  )
+  return expectedGatesForTier(tierCfg, feature && feature.tag === 'debug', hasDetailedPlan).map(gate => ({
+    gate,
+    persona: byGate.has(gate) ? byGate.get(gate) : '',
+    artifactPresent: byGate.has(gate) && (artifactSubstantial ? artifactSubstantial(gate) === true : true),
+  }))
+}
+
+// claimedGatesResumed: a resumed/crash completion reconciles ONLY the gates it
+// re-spawned THIS session (NEW-2 fix). Prior-session frozen-artifact gates are
+// absent from this session's log and are NOT required here - that cross-session
+// on-disk check is the standalone validator's job. Every gate present in the
+// session log is treated as backed (it really spawned + wrote its artifact this
+// session); a wrong-persona re-spawn still trips via GATE_EXPECTED_PERSONA.
+function claimedGatesResumed(entry) {
+  const byGate = new Map()
+  for (const g of entry.gates) if (!byGate.has(g.gate)) byGate.set(g.gate, g.persona)
+  return [...byGate].map(([gate, persona]) => ({ gate, persona, artifactPresent: true }))
+}
+
+// sealDoneProvenance: the SINGLE funnel guard (B1). Applied to EVERY runFeature
+// return. A non-DONE result passes straight through. A FRESH DONE is reconciled
+// against the tier's expected gates (teeth). A RESUMED/crash DONE is checked only
+// against the gates it re-ran THIS session (S4 - prior-session gates are the
+// standalone validator's cross-session job). Throws on an unbacked claim.
+function sealDoneProvenance(feature, result, tierCfg, log, artifactSubstantial) {
+  if (!result || result.status !== 'DONE') return result
+  const entry = log.get(feature && feature.id) || { gates: [], resumed: false }
+  const claimed = entry.resumed
+    ? claimedGatesResumed(entry)
+    : claimedGatesFromLog(feature, tierCfg, log, artifactSubstantial)
+  assertGateArtifact(feature, claimed)
+  return result
+}
+// === PROVENANCE-SLICE:END ===
+
+// === HIERARCHY-DISPATCH-SLICE:START - test-only export seam; sliced by hierarchy-dispatch.test.js. Self-contained: references only these symbols + built-ins. ===
+//
+// FX-HIERARCHY (FIX-11/12/13/14) gate-side dispatch guards, in the assertExecLevel
+// family. These are PURE, deterministic functions - a breach throws a NON-transient
+// TypeError (a loud-escalate programmer error), the legal path passes untouched.
+// FIX-12's assertTypedPersona is WIRED LIVE into the rebound agent() dispatch choke
+// point below (so every harness spawn is validated); FIX-14's assertGateRouting is
+// wired defensively at the goal-check + janitor sites. The slice duplicates a
+// minimal level/registry map (lockstep with LEVEL_OF), the same necessity as
+// GATE_EXPECTED_PERSONA - the PERSONA-membership test is the lockstep tripwire.
+
+// The lockstep level mirror - every autoprompt persona keyed to its level. Kept
+// in sync with LEVEL_OF above (gate.js evaluates top-to-bottom; this self-contained
+// copy lets the slice classify a spawner's level without reaching outside itself).
+const HIERARCHY_LEVEL_OF = {
+  'cl-conductor': 'L0',
+  'ap-scope-coordinator': 'L1', 'ap-feature-coordinator': 'L1', 'ap-sweep-coordinator': 'L1',
+  'ap-manager': 'L2',
+  'ap-scoper': 'L3', 'ap-planner': 'L3', 'ap-synthesizer': 'L3', 'ap-intake': 'L3',
+  'ap-implementer': 'L3', 'ap-reviewer': 'L3', 'ap-verifier': 'L3', 'ap-sweeper': 'L3',
+  'ap-researcher': 'L3', 'ap-execharness-resolver': 'L3', 'ap-framework-generator': 'L3',
+  'ap-fresh-verifier': 'L4', 'ap-depth-prober': 'L4', 'ap-framework-validator': 'L4',
+  'ap-juror': 'L4', 'ap-goal-checker': 'L4',
+  'ap-preflight-probe': 'L4', 'ap-arbiter': 'L4', 'ap-re-anchor': 'L4',
+  'ap-scribe': 'L4', 'ap-janitor': 'L4',
+}
+
+// FIX-12: the registry of every spawnable ap-* persona (= every key of the level
+// mirror, so it contains every live PERSONA.* value - the registry tripwire test
+// asserts this). A spawn whose agentType is not in here (general-purpose, an
+// undefined type, a typo'd cl-bogus) is structurally un-spawnable.
+const CL_PERSONA_REGISTRY = new Set(Object.keys(HIERARCHY_LEVEL_OF))
+
+// assertTypedPersona (FIX-12 live teeth): the rebound agent() choke point calls
+// this before every spawn. A non-ap-* / undefined / unregistered agentType throws
+// a deterministic TypeError (general-purpose un-spawnable). The thrown message
+// names the offending type.
+function assertTypedPersona(childType, site) {
+  if (typeof childType !== 'string' || !CL_PERSONA_REGISTRY.has(childType)) {
+    throw new TypeError(`TYPED-PERSONA GUARD: spawn at "${site}" names persona "${childType}", which is not a registered ap-* autoprompt persona - general-purpose is un-spawnable in a autoprompt run; name a typed ap-* persona.`)
+  }
+  return true
+}
+
+// FIX-13: the legal child set per spawner level, locked to the ledger's stricter
+// roster (L1_LEGAL_CHILDREN / thinSprawlFindings in autoprompt-ledger-check.js).
+// L0 may stand up an L1 coordinator (or the two pre-hierarchy personas
+// preflight/intake, which L0 ALONE owns - neither is ever a legal L1/L2 child);
+// an L1 coordinator may spawn an L2 ap-manager (for a MULTI-FEATURE slice) OR -
+// for a single bounded feature - dispatch L3 executors and single-shot L4 leaves
+// DIRECTLY (L1→L3 is a legal hop; the manager is OPTIONAL, merged into the L1's
+// own fleet-state reasoning); an L2 dispatches L3 executors + L4 leaves; an L3 is
+// normally terminal - ONLY ap-implementer/ap-intake may fan out, and only to L4
+// leaves (thin-sprawl); an L4 is terminal. ap-preflight-probe is never re-stood
+// below L0. (JS const name L1_SUPERVISORS unchanged; the persona STRINGS are the
+// -coordinators.)
+const L1_SUPERVISORS = ['ap-scope-coordinator', 'ap-feature-coordinator', 'ap-sweep-coordinator']
+const L3_EXECUTORS = [
+  'ap-scoper', 'ap-planner', 'ap-synthesizer', 'ap-implementer', 'ap-reviewer',
+  'ap-verifier', 'ap-sweeper', 'ap-researcher', 'ap-execharness-resolver',
+  'ap-framework-generator',
+]
+const L4_LEAVES = [
+  'ap-fresh-verifier', 'ap-depth-prober', 'ap-framework-validator', 'ap-juror',
+  'ap-goal-checker', 'ap-preflight-probe', 'ap-arbiter', 'ap-re-anchor', 'ap-scribe',
+  'ap-janitor',
+]
+const L4_SPAWNABLE = L4_LEAVES.filter(leaf => leaf !== 'ap-preflight-probe')
+const L3_FANOUT_PERSONAS = new Set(['ap-implementer', 'ap-intake'])
+const LEGAL_CHILDREN_BY_LEVEL = {
+  L0: new Set([...L1_SUPERVISORS, 'ap-preflight-probe', 'ap-intake']),
+  // L1 coordinator: ap-manager for a multi-feature slice, OR L3 executors + L4 leaves
+  // dispatched DIRECTLY for a single bounded feature (L1→L3 legal hop; manager optional).
+  L1: new Set(['ap-manager', ...L3_EXECUTORS, ...L4_SPAWNABLE]),
+  L2: new Set([...L3_EXECUTORS, ...L4_SPAWNABLE]),
+  L3: new Set(L4_SPAWNABLE),
+  L4: new Set(),
+}
+
+// assertLegalChild (FIX-13 defensive): throws when a spawner's child is illegal for
+// its level. An unknown spawner -> throw (fail-closed). An L3 spawner outside
+// L3_FANOUT_PERSONAS -> throw (thin-sprawl: only ap-implementer/ap-intake fan out).
+// The legal path returns true.
+function assertLegalChild(spawnerType, childType, site) {
+  const level = HIERARCHY_LEVEL_OF[spawnerType]
+  const legal = level && LEGAL_CHILDREN_BY_LEVEL[level]
+  if (!legal) {
+    throw new TypeError(`LEGAL-CHILD GUARD: spawner "${spawnerType}" at "${site}" has no known level / legal-child set; cannot validate its children (fail-closed).`)
+  }
+  if (level === 'L3' && !L3_FANOUT_PERSONAS.has(spawnerType)) {
+    throw new TypeError(`LEGAL-CHILD GUARD: L3 persona "${spawnerType}" at "${site}" may not spawn "${childType}" - only ap-implementer/ap-intake fan out; every other L3 does its one job in its own context.`)
+  }
+  if (!legal.has(childType)) {
+    throw new TypeError(`LEGAL-CHILD GUARD: ${level} persona "${spawnerType}" at "${site}" may not spawn "${childType}" - legal children: ${[...legal].join(', ') || '(none - terminal leaf)'}.`)
+  }
+  return true
+}
+
+// conductorToolViolation (FIX-11 belt-and-suspenders): given the tool names the L0
+// conductor emitted, return the offending NON-spawn tools (Agent/Task are the only
+// legal conductor tools). Empty array = clean. Non-array / null input -> [] (no
+// crash). The live ledger linter (conductorToolUseFindings in ledger-check.js) is
+// the primary teeth; this is the second layer wherever the conductor's tool list
+// is observable.
+function conductorToolViolation(toolNames) {
+  if (!Array.isArray(toolNames)) return []
+  return toolNames.filter(name => typeof name === 'string' && name !== 'Agent' && name !== 'Task')
+}
+
+// FIX-14: the gates whose author/writer persona is fixed. GOAL-CHECK's verdict is
+// authored by ap-goal-checker; the DONE-sentinel is written by ap-janitor. Each is
+// a dispatched typed L4 leaf (the F5-07/F5-15 defect: the L2 manager itself did
+// GOAL-CHECK + JANITOR and wrote the sentinel).
+const GATE_ROUTING = { GOALCHECK: 'ap-goal-checker', LEDGERCHECK: 'ap-goal-checker', JANITOR: 'ap-janitor' }
+
+// assertGateRouting (FIX-14 defensive teeth): throws when a routed gate is wired to
+// the wrong persona; permissive (returns true) for a gate this map does not own.
+function assertGateRouting(gate, persona, site) {
+  const expected = GATE_ROUTING[gate]
+  if (!expected) return true
+  if (persona !== expected) {
+    throw new TypeError(`GATE-ROUTING GUARD: ${gate} at "${site}" must be authored by the typed L4 leaf ${expected}, not "${persona}".`)
+  }
+  return true
+}
+// === HIERARCHY-DISPATCH-SLICE:END ===
+
+// === SESSION-SLUG-SLICE:START - test-only export seam; sliced by session-slug.test.js. Self-contained: references only its param + built-ins, NO fs. ===
+// deriveSlug (SPEC-1): a PURE, deterministic kebab-case slug builder over the
+// mission STRING gate.js already holds. NO fs, NO env, NO clock - the same
+// mission always yields the same slug, so the SCRIBE's ledger folder is stable
+// across supervisor relaunches. The SCRIBE picks the session/prompt NUMBER via
+// the ledger-check --resolve-prompt-dir CLI; this only produces the <slug> tail.
+const SLUG_FALLBACK = 'run'      // deterministic fallback when the mission yields no usable words
+const MAX_SLUG_WORDS = 5         // keep the leading handful of words; a 6-word mission drops its trailing word
+const MAX_SLUG_LENGTH = 48       // hard cap so a pathological single token cannot blow the folder name
+function deriveSlug(mission) {
+  if (typeof mission !== 'string') return SLUG_FALLBACK
+  const words = mission
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, MAX_SLUG_WORDS)
+  if (words.length === 0) return SLUG_FALLBACK
+  const joined = words.join('-')
+  if (joined.length <= MAX_SLUG_LENGTH) return joined
+  return joined.slice(0, MAX_SLUG_LENGTH).replace(/-+$/, '')
+}
+// === SESSION-SLUG-SLICE:END ===
+
+// The module-global per-feature spawn ledger the LIVE path uses. recordGateSpawn
+// writes here at each real spawn site; sealDoneProvenance reads it at the single
+// runFeature DONE funnel. Hermetic unit tests inject their own Map instead.
+const featureSpawnLog = new Map()
+
+const PANEL_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['verdict', 'reasons'],
+  properties: {
+    verdict: { type: 'string', enum: ['PASS', 'FAIL'] },
+    reasons: { type: 'array', items: { type: 'string' } },
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+
+const SWEEP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['severity', 'title', 'where', 'impact'],
+        properties: {
+          severity: { type: 'string', enum: ['P0', 'P1', 'P2', 'P3'] },
+          title: { type: 'string' },
+          where: { type: 'string', description: 'file:line' },
+          impact: { type: 'string' },
+        },
+      },
+    },
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+
+const ARBITER_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['decision', 'proceed', 'userRequired'],
+  properties: {
+    decision: { type: 'string' },
+    proceed: { type: 'boolean' },
+    risk: { type: 'string' },
+    userRequired: { type: 'boolean', description: 'true ONLY if irreversible/destructive, real money, a credential only the user holds, or a product-direction call the user must own' },
+    userQuestion: { type: 'string', description: 'if userRequired, the precise question to ask the user; else empty' },
+  },
+}
+
+// ----- mission source ---------------------------------------------------
+// The first useful roadmap author receives the exact mission and stores it in
+// PROMPTS.txt. Every later dispatch receives a cryptographically bound pointer.
+const MISSION = typeof args === 'object' && args && Object.hasOwn(args, 'mission')
+  ? String(args.mission || '')
+  : String(args || '')
+
+// Later steers are appended as exact numbered blocks in PROMPTS.txt. They refine
+// the mission without rewriting its original bytes.
+function resolvePriorSteers() {
+  const fromArg = (typeof args === 'object' && args && args.priorSteers != null) ? args.priorSteers : undefined
+  const fromEnv = (typeof process === 'object' && process && process.env) ? process.env.AUTOPROMPT_PRIOR_STEERS : undefined
+  const raw = fromArg != null ? fromArg : fromEnv
+  if (raw == null) return ''
+  const text = Array.isArray(raw) ? raw.map(String).join('\n') : String(raw)
+  return text.trim()
+}
+const PRIOR_STEERS = resolvePriorSteers()
+
+const LEDGER_DIR = (typeof args === 'object' && args && args.ledgerDir) ? String(args.ledgerDir) : 'autoprompt'
+
+if (!MISSION.trim()) {
+  log('No mission provided. Pass args.mission (the user prompt, verbatim).')
+  return { error: 'missing mission' }
+}
+
+const MODE_RAW = (typeof args === 'object' && args && args.mode) ? String(args.mode).toLowerCase().trim() : DEFAULT_MODE
+const MODE = EXECUTION_MODES[MODE_RAW] ? MODE_RAW : DEFAULT_MODE
+if (MODE !== MODE_RAW) log(`Unknown mode "${MODE_RAW}", falling back to ${DEFAULT_MODE.toUpperCase()}.`)
+const MODE_CFG = EXECUTION_MODES[MODE]
+const TOPOLOGY = resolveTopology(MODE)
+log(`Execution mode: ${MODE.toUpperCase()} (${TOPOLOGY.liveCap == null ? 'unbounded fan-out, bounded by MAX_CONCURRENT' : `bounded fan-out, up to ${TOPOLOGY.liveCap} live per wave`})`)
+log(`Topology: 5-level L0->L4; per-L3 fan-out ${TOPOLOGY.leafCap === null ? 'NO numeric ceiling (bounded by MAX_CONCURRENT + disjointness + real need)' : `<=${TOPOLOGY.leafCap} live per wave`}; L3 tracks ${TOPOLOGY.parallelTracks ? 'PARALLEL' : 'SEQUENTIAL'}; multi-task split at ${TOPOLOGY.multiTaskSplitSite}; L1 never executes (rule 68).`)
+log(`Global max-concurrent ceiling: ${MAX_CONCURRENT} live agent(s) per parallel wave${MAX_CONCURRENT === MAX_CONCURRENT_BASE ? ' (base default)' : ' (user-set)'}.`)
+
+// ----- agents selector (agent-model selection) --------------------------
+// === MODEL-CASTING-DISPATCH-SLICE:START - test-only export seam; sliced by model-casting-dispatch.test.cjs. Self-contained: references only these symbols + built-ins. ===
+const CASTING_ALIAS_BY_TIER = Object.freeze({ R1: 'opus', R2: 'sonnet', R3: 'sonnet', R4: 'haiku', R5: 'haiku' })
+const CASTING_EFFORT_BY_TIER = Object.freeze({ R1: 'xhigh', R2: 'xhigh', R3: 'high', R4: 'medium', R5: 'low' })
+const CASTING_MAXIMUM_EFFORT_PERSONAS = new Set([
+  'ap-scope-coordinator', 'ap-manager', 'ap-reviewer', 'ap-fresh-verifier',
+  'ap-verifier', 'ap-juror', 'ap-goal-checker', 'ap-depth-prober', 'ap-arbiter',
+  'ap-framework-validator', 'ap-re-anchor', 'ap-planner', 'ap-researcher',
+  'ap-scoper', 'ap-synthesizer',
+])
+const CASTING_EFFORT_STATUSES = new Set(['selectable', 'inherited-only', 'unsupported', 'unknown'])
+const INHERITED_CASTING_EFFORT = Object.freeze({
+  status: 'inherited-only', acceptedValues: [], maximum: null, source: 'session-inheritance',
+})
+const CASTING_PERSONAS_BY_TIER = Object.freeze({
+  R1: ['ap-scope-coordinator', 'ap-feature-coordinator', 'ap-sweep-coordinator', 'ap-manager'],
+  R2: ['ap-reviewer', 'ap-fresh-verifier', 'ap-verifier', 'ap-juror', 'ap-goal-checker', 'ap-depth-prober', 'ap-arbiter', 'ap-framework-validator', 'ap-re-anchor'],
+  R3: ['ap-implementer', 'ap-planner', 'ap-researcher', 'ap-scoper', 'ap-synthesizer', 'ap-execharness-resolver', 'ap-framework-generator'],
+  R4: ['ap-preflight-probe', 'ap-intake', 'ap-scribe'],
+  R5: ['ap-sweeper', 'ap-janitor'],
+})
+
+function parseSelectorModels(value) {
+  const models = value.split(',').map(model => model.trim())
+  if (models.some(model => model === '')) throw new TypeError('agents selector contains an empty model identifier')
+  const seen = new Set()
+  for (const model of models) {
+    if (seen.has(model)) throw new TypeError(`agents selector contains duplicate model identifier: ${model}`)
+    seen.add(model)
+  }
+  return models
+}
+
+function parseAgentsSelectorValue(value) {
+  const selector = value == null ? 'off' : String(value).trim()
+  const control = selector.toLowerCase()
+  if (selector === '' || control === 'off') return { mode: 'off', models: [] }
+  if (control === 'auto') return { mode: 'auto', models: [] }
+  if (control.startsWith('auto:')) {
+    const pool = selector.slice(selector.indexOf(':') + 1)
+    return pool.trim() === '' ? { mode: 'auto', models: [] } : { mode: 'auto-list', models: parseSelectorModels(pool) }
+  }
+  return { mode: 'list', models: parseSelectorModels(selector) }
+}
+
+function sameSelector(left, right) {
+  return left.mode === right.mode && left.models.length === right.models.length &&
+    left.models.every((model, index) => model === right.models[index])
+}
+
+function resolveAgentsSelector(workflowArgs, environment) {
+  const hasArgument = typeof workflowArgs === 'object' && workflowArgs && workflowArgs.agents != null
+  const hasEnvironment = environment && environment.AUTOPROMPT_AGENTS != null
+  const fromArgument = hasArgument ? parseAgentsSelectorValue(workflowArgs.agents) : null
+  const fromEnvironment = hasEnvironment ? parseAgentsSelectorValue(environment.AUTOPROMPT_AGENTS) : null
+  if (fromArgument && fromEnvironment && !sameSelector(fromArgument, fromEnvironment)) {
+    throw new TypeError('agents selector does not match AUTOPROMPT_AGENTS from the pre-launch model cast')
+  }
+  return fromArgument || fromEnvironment || parseAgentsSelectorValue('off')
+}
+
+function requireStringArray(value, name) {
+  if (!Array.isArray(value) || value.length === 0 || value.some(item => typeof item !== 'string' || item.trim() === '')) {
+    throw new TypeError(`AUTOPROMPT_AGENT_CASTING ${name} must be a non-empty string array`)
+  }
+  if (new Set(value).size !== value.length) throw new TypeError(`AUTOPROMPT_AGENT_CASTING ${name} must contain unique values`)
+  return value
+}
+
+function expectedAliasModels(models) {
+  if (models.length < 1 || models.length > 3) throw new TypeError('AUTOPROMPT_AGENT_CASTING must select one to three provider models')
+  if (models.length === 1) return { opus: models[0], sonnet: models[0], haiku: models[0] }
+  if (models.length === 2) return { opus: models[0], sonnet: models[0], haiku: models[1] }
+  return { opus: models[0], sonnet: models[1], haiku: models[2] }
+}
+
+function sameStringMap(actual, expected) {
+  return actual && typeof actual === 'object' && Object.keys(expected).every(key => actual[key] === expected[key])
+}
+
+function validateCastingSelection(selector, casting) {
+  if (casting.mode !== selector.mode) throw new TypeError('AUTOPROMPT_AGENT_CASTING mode does not match the agents selector')
+  const names = requireStringArray(casting.names, 'names')
+  const selected = selector.models
+  const matches = selector.mode === 'auto-list'
+    ? names.length === selected.length && selected.every(name => names.includes(name))
+    : selector.mode === 'auto' || (names.length === selected.length && names.every((name, index) => name === selected[index]))
+  if (!matches) throw new TypeError('AUTOPROMPT_AGENT_CASTING selected names do not match the agents selector')
+}
+
+function validateCastingAliases(casting, environment) {
+  const models = requireStringArray(casting.models, 'models')
+  if (models.length !== casting.names.length) {
+    throw new TypeError('AUTOPROMPT_AGENT_CASTING names and models must have equal length')
+  }
+  const expected = expectedAliasModels(models)
+  if (!sameStringMap(casting.aliases, expected)) {
+    throw new TypeError('AUTOPROMPT_AGENT_CASTING aliases do not match the selected provider models')
+  }
+  const liveAliases = {
+    opus: environment.ANTHROPIC_DEFAULT_OPUS_MODEL,
+    sonnet: environment.ANTHROPIC_DEFAULT_SONNET_MODEL,
+    haiku: environment.ANTHROPIC_DEFAULT_HAIKU_MODEL,
+  }
+  for (const alias of Object.keys(expected)) {
+    if (liveAliases[alias] !== expected[alias]) {
+      throw new TypeError(`ANTHROPIC_DEFAULT_${alias.toUpperCase()}_MODEL does not match AUTOPROMPT_AGENT_CASTING`)
+    }
+  }
+}
+
+function validateEffortCapability(effort) {
+  if (!effort || typeof effort !== 'object' || !CASTING_EFFORT_STATUSES.has(effort.status)) {
+    throw new TypeError('AUTOPROMPT_AGENT_CASTING effort status must be selectable, inherited-only, unsupported, or unknown')
+  }
+  if (!Array.isArray(effort.acceptedValues) || effort.acceptedValues.some(value => typeof value !== 'string')) {
+    throw new TypeError('AUTOPROMPT_AGENT_CASTING effort acceptedValues must be a string array')
+  }
+  if (effort.status === 'selectable') {
+    if (typeof effort.maximum !== 'string' || !effort.acceptedValues.includes(effort.maximum)) {
+      throw new TypeError('AUTOPROMPT_AGENT_CASTING selectable effort maximum must be one of acceptedValues')
+    }
+  } else if (effort.maximum !== null) {
+    throw new TypeError('AUTOPROMPT_AGENT_CASTING non-selectable effort maximum must be null')
+  }
+  return effort
+}
+
+function resolveWorkflowCasting(selector, environment) {
+  if (selector.mode === 'off') return { enabled: false, effort: { ...INHERITED_CASTING_EFFORT, acceptedValues: [] } }
+  const raw = environment && environment.AUTOPROMPT_AGENT_CASTING
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    throw new TypeError('custom agent selection requires pre-launch AUTOPROMPT_AGENT_CASTING metadata and omp model configuration')
+  }
+  let casting
+  try { casting = JSON.parse(raw) } catch (error) {
+    throw new TypeError(`AUTOPROMPT_AGENT_CASTING is not valid JSON: ${error.message}`)
+  }
+  if (!casting || typeof casting !== 'object' || casting.enabled !== true) {
+    throw new TypeError('AUTOPROMPT_AGENT_CASTING must be an enabled casting object')
+  }
+  validateCastingSelection(selector, casting)
+  validateCastingAliases(casting, environment)
+  validateEffortCapability(casting.effort)
+  if (!sameStringMap(casting.tierAliases, CASTING_ALIAS_BY_TIER)) {
+    throw new TypeError('AUTOPROMPT_AGENT_CASTING tierAliases do not match the fixed persona routing')
+  }
+  if (environment && typeof environment.CLAUDE_CODE_SUBAGENT_MODEL === 'string' && environment.CLAUDE_CODE_SUBAGENT_MODEL.trim() !== '') {
+    throw new TypeError('CLAUDE_CODE_SUBAGENT_MODEL must be unset when custom agent model casting is enabled')
+  }
+  return casting
+}
+
+function applyPersonaCasting(options, casting) {
+  if (!casting || casting.enabled !== true) return options
+  const persona = options && options.agentType
+  const tier = Object.keys(CASTING_PERSONAS_BY_TIER).find(candidate => CASTING_PERSONAS_BY_TIER[candidate].includes(persona))
+  if (!tier) throw new TypeError(`Persona ${persona} has no model-casting tier`)
+  const cast = { ...options, model: CASTING_ALIAS_BY_TIER[tier] }
+  if (casting.effort.status === 'selectable') {
+    const requestedEffort = CASTING_MAXIMUM_EFFORT_PERSONAS.has(persona)
+      ? casting.effort.maximum
+      : CASTING_EFFORT_BY_TIER[tier]
+    cast.effort = resolveAcceptedCastingEffort(
+      requestedEffort,
+      casting.effort,
+    )
+  } else {
+    delete cast.effort
+  }
+  return cast
+}
+
+function resolveAcceptedCastingEffort(requestedEffort, capability) {
+  if (capability.acceptedValues.includes(requestedEffort)) return requestedEffort
+  return capability.acceptedValues.reduce((closest, candidate) => {
+    const closestDistance = Math.abs(castingEffortRank(closest) - castingEffortRank(requestedEffort))
+    const candidateDistance = Math.abs(castingEffortRank(candidate) - castingEffortRank(requestedEffort))
+    return candidateDistance < closestDistance ? candidate : closest
+  }, capability.maximum)
+}
+
+function castingEffortRank(effort) {
+  return ['low', 'medium', 'high', 'xhigh'].indexOf(effort)
+}
+// === MODEL-CASTING-DISPATCH-SLICE:END ===
+
+const WORKFLOW_ENV = (typeof process === 'object' && process && process.env) ? process.env : {}
+const AGENTS = resolveAgentsSelector(args, WORKFLOW_ENV)
+const MODEL_CASTING = resolveWorkflowCasting(AGENTS, WORKFLOW_ENV)
+log(`Agent selection: ${AGENTS.mode}${AGENTS.models.length ? ` [${AGENTS.models.join(', ')}]` : ''}.`)
+
+// ----- UNATTENDED mode (LAW 3 / binding arbiter F5) ---------------------
+// ATTENDED is the default for a bare interactive run. UNATTENDED is set by the
+// supervisor or an explicit flag, and resolves to a single boolean here. Under
+// UNATTENDED the arbiter's user-required escape is DISABLED at the one push site
+// (it rules and continues, logging an ASSUMED answer); AskUserQuestion is never
+// reached. The supervisor exports AUTOPROMPT_UNATTENDED=1; the env→arg bridge
+// below maps that export onto the boolean so a supervisor-launched run is
+// genuinely UNATTENDED. Either path (args.unattended:true OR the env var set to
+// a truthy "1"/"true") resolves UNATTENDED; the invocation-directive token-strip
+// remains the parent's job (prose). A truthy env value is "1" or "true" (case-
+// insensitive); "0"/"false"/unset is ATTENDED.
+function envFlagTrue(name) {
+  const v = (typeof process === 'object' && process && process.env) ? process.env[name] : undefined
+  if (v == null) return false
+  const s = String(v).trim().toLowerCase()
+  return s === '1' || s === 'true' || s === 'yes'
+}
+const UNATTENDED = (typeof args === 'object' && args && args.unattended === true) || envFlagTrue('AUTOPROMPT_UNATTENDED')
+log(`Attendance: ${UNATTENDED ? 'UNATTENDED (arbiter rules and continues; no user escalation)' : 'ATTENDED (a user-required credential question may surface)'}`)
+
+// IS_RESUME (Pillar 2): set by the supervisor (AUTOPROMPT_RESUME=1 -> threaded
+// as args.resume, OR read straight from the env export here). On a resume the
+// frontier probe is mandatory and honored (it already is); this makes the
+// relaunch explicit and logged for the supervisor.
+const IS_RESUME = (typeof args === 'object' && args && args.resume === true) || envFlagTrue('AUTOPROMPT_RESUME')
+if (IS_RESUME) log('RESUME: supervisor relaunch - frontier probe is mandatory; finished -vN artifacts are never clobbered.')
+
+// SLUG (SPEC-1, EDIT 2): the deterministic ledger-folder slug, stable across
+// relaunches. NO fs here - the SCRIBE resolves the session/prompt NUMBER via the
+// ledger-check --resolve-prompt-dir CLI; this only supplies the <slug> tail.
+const SLUG = deriveSlug(MISSION)
+// LEDGER_CHECK_PATH (SPEC-1, EDIT 4a): the absolute resolver path the SCRIBE/JANITOR
+// RUN. A STRING read of the env var the supervisor exports (same process.env idiom
+// as envFlagTrue/envFlagFalse) - NO require, NO fs, so gate.js stays fs-free. The
+// documented relative fallback is for a direct (non-supervised) run whose CWD is the
+// project root. A wrong path => the resolver command fails => the SCRIBE fails LOUD.
+const LEDGER_CHECK_PATH = ((typeof process === 'object' && process && process.env && process.env.AUTOPROMPT_LEDGER_CHECK) || 'autoprompt-skill/agents/omp/workflow/autoprompt-ledger-check.js')
+
+// TRANSCRIPT_DIR (P-02 handshake teeth): this session's conductor transcript
+// directory, exported by the supervisor (AUTOPROMPT_TRANSCRIPT_DIR) or the harness
+// (CLAUDE_TRANSCRIPT_DIR). When present, the LEDGER-CHECK leaf is handed
+// --transcript-dir so the SKIPPED pre-spawn handshake lint can fire against the real
+// on-disk transcripts. NEVER hard-required - a headless run may have none; there the
+// lint is DISARMED (logged loud) while reconcile + substance checks still run, and
+// the load-time frontmatter prose stays the primary handshake gate.
+const TRANSCRIPT_DIR = ((typeof process === 'object' && process && process.env &&
+  (process.env.AUTOPROMPT_TRANSCRIPT_DIR || process.env.CLAUDE_TRANSCRIPT_DIR)) || '').trim()
+
+// EXPAND_MISSION controls default ambition, not whether useful scope runs.
+// Open-ended work starts provisionally multi-surface. A caller that knows the
+// task is bounded sets AUTOPROMPT_EXPAND_MISSION=0 (or
+// args.expandMission:false): the roadmap author still inspects and classifies
+// the repository, but does not expand beyond the ask and omitted tiers default
+// to T1. The roadmap's authoritative scopeProfile sets the final topology.
+function envFlagFalse(name) {
+  const v = (typeof process === 'object' && process && process.env) ? process.env[name] : undefined
+  if (v == null) return false
+  const s = String(v).trim().toLowerCase()
+  return s === '0' || s === 'false' || s === 'no'
+}
+const EXPAND_MISSION = !((typeof args === 'object' && args && args.expandMission === false) || envFlagFalse('AUTOPROMPT_EXPAND_MISSION'))
+if (!EXPAND_MISSION) log('EXPAND_MISSION off: bounded default - useful roadmap scope still runs, no auto-expansion, omitted-tier fallback is T1 (fix only what is asked).')
+
+// ----- wait-and-retry primitive (LAW 3, binding F1/FIX 2/FIX 3) ---------
+// sleep: injectable so tests run instantly; defaults to a real timer.
+const sleepFn = (typeof sleep === 'function')
+  ? sleep
+  : (ms => new Promise(resolve => setTimeout(resolve, ms)))
+
+// A distinct error for a classified NON-transient throw (a deterministic bug /
+// malformed request). It is never retried; it surfaces loudly so the process
+// exits non-zero and the external supervisor RESUMEs at the frontier.
+class NonTransientError extends Error {
+  constructor(label, cause) {
+    super(`NON-TRANSIENT failure at ${label}: ${cause && cause.message ? cause.message : String(cause)}`)
+    this.name = 'NonTransientError'
+    this.label = label
+    this.cause = cause
+  }
+}
+
+function describeThrow(err) {
+  if (!err) return 'unknown error'
+  const code = err.code ? ` code=${err.code}` : ''
+  const status = (err.status || err.statusCode) ? ` status=${err.status || err.statusCode}` : ''
+  return `${err.name || 'Error'}: ${err.message || String(err)}${code}${status}`
+}
+
+// classifyThrow: a THROWN infra error is transient (retry forever) unless it is
+// clearly deterministic (a programming bug or a malformed/unauthorized request
+// retrying cannot fix), which is 'nonTransient' (loud escalate). It inspects
+// err.status/err.code AND the message string so it is robust to either shape.
+// Unknown throws DEFAULT to transient (never-fatal wins) but are logged loudly.
+function classifyThrow(err) {
+  if (!err) return 'unknown'
+  const status = Number(err.status || err.statusCode || (err.response && err.response.status)) || 0
+  const code = String(err.code || err.type || '')
+  const msg = String((err && err.message) || err || '')
+  // NON-transient FIRST so a deterministic bug never spins forever.
+  if (err instanceof TypeError || err instanceof ReferenceError || err instanceof SyntaxError) return 'nonTransient'
+  if ([400, 401, 403, 404, 422].includes(status)) return 'nonTransient'
+  // transient classes
+  const NETWORK = /ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EPIPE|ESOCKETTIMEDOUT|socket hang ?up/i
+  if (NETWORK.test(code) || NETWORK.test(msg)) return 'transient'
+  if ([408, 409, 425, 429, 500, 502, 503, 504].includes(status)) return 'httpTransient'
+  if (/rate[_ -]?limit|rate-?limited|usage limit|quota|overloaded|capacity|retry-?after|too many requests/i.test(code + ' ' + msg)) return 'rateUsage'
+  if (/timed out|timeout|AbortError/i.test(code + ' ' + msg) || err.name === 'AbortError') return 'timeout'
+  // default: never fatal, but loud.
+  return 'unknown'
+}
+
+// withRetry: the single choke point. Returned negative verdicts pass through;
+// only thrown infrastructure failures retry. Exhaustion is loud and resumable.
+async function withRetry(thunk, label) {
+  const startedAt = Date.now()
+  for (
+    let attempt = 1;
+    attempt <= RETRY_MAX_ATTEMPTS;
+    attempt++
+  ) {
+    try {
+      return await thunk()
+    } catch (err) {
+      const kind = classifyThrow(err)
+      if (kind === 'nonTransient') {
+        log(
+          `NON-TRANSIENT throw at ${label} ` +
+          `(attempt ${attempt}): ${describeThrow(err)} - ` +
+          `escalating to supervisor, NOT retrying`,
+        )
+        throw new NonTransientError(label, err)
+      }
+
+      const elapsedMs = Math.max(0, Date.now() - startedAt)
+      const retry = retryBudgetVerdict({
+        attempt,
+        elapsedMs,
+        maxAttempts: RETRY_MAX_ATTEMPTS,
+        maxElapsedMs: RETRY_MAX_ELAPSED_MS,
+      })
+      if (!retry.canRetry) {
+        log(
+          `TRANSIENT budget exhausted at ${label}: ` +
+          `${retry.reason}; last error ${describeThrow(err)}`,
+        )
+        throw new NonTransientError(
+          label,
+          new Error(retry.reason),
+        )
+      }
+
+      const base = Math.min(
+        RETRY_CAP_MS,
+        RETRY_BASE_MS * RETRY_FACTOR ** (attempt - 1),
+      )
+      const jittered = Math.round(
+        base *
+        (
+          1 +
+          (
+            ((attempt * 7919) % 100) / 100 -
+            0.5
+          ) * 2 * RETRY_JITTER
+        ),
+      )
+      log(
+        `TRANSIENT at ${label} (attempt ${attempt}, ${kind}): ` +
+        `${describeThrow(err)} - waiting ${jittered}ms then ` +
+        `re-dispatching the SAME call`,
+      )
+      await sleepFn(jittered)
+    }
+  }
+  throw new NonTransientError(
+    label,
+    new Error('transient retry budget exhausted'),
+  )
+}
+
+// Rebind agent so every useful, assurance, build, resume, and record dispatch
+// inherits the same transient handling, casting policy, and run binding.
+// === AUTOPROMPT-RUN-BINDING-SLICE:START - pure run-envelope helpers. ===
+function formatRunMarker(nonce, promptHash) {
+  return `AUTOPROMPT-RUN-MARKER: runtime=autoprompt-gate-v1 nonce=${nonce} prompt=${promptHash}`
+}
+
+function assertRunBinding(prompt, label, expectedMarker) {
+  const lines = typeof prompt === 'string' ? prompt.split(/\r?\n/) : []
+  if (!lines.includes(expectedMarker)) {
+    throw new TypeError(`AUTOPROMPT-RUN GUARD: spawn at "${label}" lacks the active run marker; ap-* personas are internal to Autoprompt and cannot be dispatched from an ordinary request.`)
+  }
+  return true
+}
+
+function activationNonce(environment) {
+  const supplied = environment && environment.AUTOPROMPT_RUN_NONCE
+  if (supplied !== undefined && supplied !== null && supplied !== '') {
+    if (typeof supplied !== 'string' || !/^NONCE-[A-Za-z0-9_-]+$/.test(supplied)) {
+      throw new TypeError(`AUTOPROMPT activation nonce is malformed: ${JSON.stringify(supplied)}`)
+    }
+    return supplied
+  }
+  const getBuiltin =
+    typeof process === 'object' && process &&
+    typeof process.getBuiltinModule === 'function'
+      ? process.getBuiltinModule.bind(process)
+      : null
+  const crypto = getBuiltin &&
+    (getBuiltin('node:crypto') || getBuiltin('crypto'))
+  if (crypto && typeof crypto.randomBytes === 'function') {
+    return `NONCE-${crypto.randomBytes(16).toString('hex')}`
+  }
+  throw new TypeError('AUTOPROMPT activation identity is unavailable: no cryptographically strong random source')
+}
+// === AUTOPROMPT-RUN-BINDING-SLICE:END ===
+
+function autopromptRunMarker() {
+  const pointer = missionPointerBinding()
+  return formatRunMarker(RUN_NONCE, pointer.hash)
+}
+
+const rawAgent = agent
+agent = (prompt, opts) => {
+  const label = (opts && opts.label) || 'agent'
+  assertTypedPersona(opts && opts.agentType, label)
+  assertRunBinding(prompt, label, autopromptRunMarker())
+  const dispatchOptions = applyPersonaCasting(opts, MODEL_CASTING)
+  return withRetry(() => rawAgent(prompt, dispatchOptions), label)
+}
+
+// The supervisor mints this cryptographically strong activation identity and
+// re-exports it unchanged across child relaunches. Direct harness execution
+// mints one locally. Concurrent identical missions therefore never share
+// artifact directories or completion sentinels. There is no deterministic
+// fallback: without a CSPRNG the run fails closed instead of risking a
+// collision between two identical concurrent missions.
+const RUN_NONCE = activationNonce(
+  typeof process === 'object' && process ? process.env : null,
+)
+const RUN_TAG = `run-${RUN_NONCE.slice('NONCE-'.length)}`
+const ARTIFACT_DIR = `${LEDGER_DIR}/.artifacts/${RUN_TAG}`
+let canaryTrips = 0
+
+// === CANARY-CONTRACT-SLICE:START - test-only export seam; sliced by canary-contract.test.js. Self-contained: references only these symbols + built-ins. ===
+// Legacy full-mission validation remains for the first useful roadmap author and
+// old resume briefs. New later dispatches use missionPointer() and are validated
+// cryptographically by the ledger checker.
+//
+// RUN-NONCE canary, INVERTED + sentinel-exempt + fail-closed. A trip means
+// an ACTUAL spawn-returned verdict echoed a MISSING / empty / whitespace / mismatched
+// nonce (discard + re-spawn header-restored, never accept). null/non-object fails
+// closed (trip). A LOCAL_SENTINEL-marked, harness-built default (a fresh-run frontier
+// default, a null-probe fallback) NEVER went through a spawn, so it carries no nonce
+// by construction and is EXEMPT - exempting it before the missing-nonce check is what
+// stops a false trip on every healthy fresh run. The marker is a Symbol so it never
+// appears in the JSON a spawn returns under additionalProperties:false; only the
+// harness can stamp it. Belt-only by design: ZERO schema edits - each canaried schema
+// keeps its OPTIONAL nonce slot (what the predicate reads); routing nonce into a
+// schema `required` would surface as a 4xx/throw that classifyThrow escalates to a
+// hard run-kill or unbounded retry. The real teeth is this in-SUT predicate.
+
+// The EXACT mission-block label brief() inlines at parts[2]. Lifted to a shared const
+// referenced by BOTH brief() and the validator so the two can never drift (the
+// lockstep tripwire the test asserts).
+const MISSION_BLOCK_LABEL = 'ORIGINAL MISSION (the user prompt, verbatim, the constitution for this work; it OUTRANKS every plan, artifact, and reviewer note below; verify against THIS text, never against what another agent told you):'
+const MISSION_POINTER_LABEL = 'MISSION POINTER: read the exact prompt ledger before acting; stop if its hash or byte length differs.'
+
+// Marks a harness-built default object (never spawn-returned, so no nonce by
+// construction) so canaryTrippedCore can exempt it. A Symbol, not a string field, so
+// it is invisible to the JSON a spawn returns and unreachable by additionalProperties.
+const LOCAL_SENTINEL = Symbol('localSentinel')
+
+// FIX-08: substring-containment validator. Returns the assembled brief unchanged when
+// it CONTAINS the verbatim mission at the assembled position; else throws a
+// deterministic TypeError naming the role. Parameterized on mission/label (not the
+// module MISSION) so the test can require it standalone. No trim: brief() embeds the
+// mission verbatim, and trimming would weaken the guard.
+function assertMissionBlock(assembled, mission, role, label) {
+  if (typeof assembled === 'string' && assembled.includes(label + '\n' + mission + '\n')) return assembled
+  throw new TypeError(`MISSION-VERBATIM GUARD: brief for "${role}" does not contain the verbatim ORIGINAL MISSION at the assembled position (LABEL + mission + newline); a paraphrased or dropped mission must never reach a spawn. Emit the mission byte-for-byte.`)
+}
+
+// FIX-09: the inverted, sentinel-exempt, fail-closed canary predicate. true == trip.
+// Parameterized on runNonce for unit-testability; the live wrapper passes RUN_NONCE.
+function canaryTrippedCore(gateResult, runNonce) {
+  if (!gateResult || typeof gateResult !== 'object') return true   // fail-closed: null/non-object trips
+  if (gateResult[LOCAL_SENTINEL] === true) return false            // harness-built default, never spawned: EXEMPT
+  const echoed = typeof gateResult.nonce === 'string' ? gateResult.nonce.trim() : ''
+  return echoed === '' || echoed !== runNonce                      // missing/empty OR mismatch: trip
+}
+// === CANARY-CONTRACT-SLICE:END ===
+
+// The EXACT PROMPTS-SO-FAR label brief() inlines when PRIOR_STEERS is non-empty.
+// Lifted to a shared const (mirroring MISSION_BLOCK_LABEL) so the steer-region
+// framing is ONE source of truth and the ledger-check text-diff canary
+// (missionFidelityFindings) can lock to it via a source-substring tripwire. Placed
+// OUTSIDE the canary-contract slice (which ends above and is self-contained) so the
+// sliced bytes stay byte-identical and canary-contract.test.js is provably untouched.
+const PRIOR_STEERS_BLOCK_LABEL = "PROMPTS-SO-FAR (the user's later steers in this session; they ride ALONGSIDE the ORIGINAL MISSION and refine HOW to do it, but the ORIGINAL MISSION above OUTRANKS them - a steer can never override what the mission asks):"
+
+function promptLedgerText() {
+  const prompts = [`=== PROMPT 1 ===\n${MISSION}`]
+  if (PRIOR_STEERS) prompts.push(`=== PROMPT 2 ===\n${PRIOR_STEERS}`)
+  return prompts.join('\n')
+}
+
+function utf8Bytes(text) {
+  return unescape(encodeURIComponent(text)).length
+}
+
+function sha256Hex(text) {
+  const bytes = unescape(encodeURIComponent(text))
+  const words = []
+  const bitLength = bytes.length * 8
+  for (let i = 0; i < bytes.length; i++) words[i >> 2] = (words[i >> 2] || 0) | bytes.charCodeAt(i) << (24 - (i % 4) * 8)
+  words[bitLength >> 5] = (words[bitLength >> 5] || 0) | 0x80 << (24 - bitLength % 32)
+  words[((bitLength + 64 >> 9) << 4) + 15] = bitLength
+  const constants = sha256Constants()
+  let hash = [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]
+  for (let offset = 0; offset < words.length; offset += 16) hash = sha256Block(hash, words, offset, constants)
+  return hash.map(value => (value >>> 0).toString(16).padStart(8, '0')).join('')
+}
+
+function sha256Constants() {
+  const constants = []
+  for (let candidate = 2; constants.length < 64; candidate++) {
+    let isPrime = true
+    for (let divisor = 2; divisor * divisor <= candidate; divisor++) if (candidate % divisor === 0) { isPrime = false; break }
+    if (isPrime) constants.push(Math.floor((Math.pow(candidate, 1 / 3) % 1) * 0x100000000))
+  }
+  return constants
+}
+
+function rotateRight(value, count) {
+  return value >>> count | value << (32 - count)
+}
+
+function sha256Block(initial, words, offset, constants) {
+  const schedule = new Array(64)
+  for (let i = 0; i < 16; i++) schedule[i] = words[offset + i] | 0
+  for (let i = 16; i < 64; i++) {
+    const s0 = rotateRight(schedule[i - 15], 7) ^ rotateRight(schedule[i - 15], 18) ^ schedule[i - 15] >>> 3
+    const s1 = rotateRight(schedule[i - 2], 17) ^ rotateRight(schedule[i - 2], 19) ^ schedule[i - 2] >>> 10
+    schedule[i] = schedule[i - 16] + s0 + schedule[i - 7] + s1 | 0
+  }
+  let [a, b, c, d, e, f, g, h] = initial
+  for (let i = 0; i < 64; i++) {
+    const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25)
+    const choice = e & f ^ ~e & g
+    const temp1 = h + sum1 + choice + constants[i] + schedule[i] | 0
+    const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22)
+    const majority = a & b ^ a & c ^ b & c
+    const temp2 = sum0 + majority | 0
+    h = g; g = f; f = e; e = d + temp1 | 0; d = c; c = b; b = a; a = temp1 + temp2 | 0
+  }
+  return initial.map((value, index) => value + [a, b, c, d, e, f, g, h][index] | 0)
+}
+
+// === DURABLE-DISPATCH-BARRIER-SLICE:START ===
+function publicationIdentityReasons(publication, expected) {
+  const reasons = []
+  const fields = [
+    ['transition', 'transition does not match'],
+    ['featureId', 'feature id does not match'],
+    ['artifactPath', 'artifact path does not match'],
+    ['artifactHash', 'artifact hash does not match the expected binding'],
+    ['artifactBytes', 'artifact byte count does not match'],
+    ['nonce', 'nonce does not match the active run'],
+    ['producerGate', 'producer gate does not match'],
+    ['producerPersona', 'producer persona does not match'],
+    ['verdict', 'producer verdict does not match'],
+    ['ledgerPath', 'ledger path does not match'],
+  ]
+  for (const [field, message] of fields) {
+    if (
+      expected[field] !== undefined &&
+      publication[field] !== expected[field]
+    ) reasons.push(`prerequisite ${message}${field === 'artifactPath' ? ` ${expected[field]}` : ''}`)
+  }
+  return reasons
+}
+
+function publicationShapeReasons(publication) {
+  const reasons = []
+  if (!publication || typeof publication !== 'object') {
+    return ['prerequisite publication receipt is missing']
+  }
+  if (publication.artifactExists !== true) {
+    reasons.push('prerequisite artifact is not durably present')
+  }
+  if (/\.tmp$/i.test(publication.artifactPath || '')) {
+    reasons.push('prerequisite artifact path is temporary')
+  }
+  if (!/^sha256:[a-f0-9]{64}$/.test(publication.artifactHash || '')) {
+    reasons.push('prerequisite artifact hash is missing or malformed')
+  }
+  if (!Number.isInteger(publication.artifactBytes) || publication.artifactBytes < 1) {
+    reasons.push('prerequisite artifact byte count is missing or invalid')
+  }
+  return reasons
+}
+
+function durableLedgerReasons(publication, expected, hashText) {
+  const reasons = []
+  if (publication.ledgerRowDurable !== true) {
+    return ['prerequisite ledger row is not durably present']
+  }
+  if (typeof publication.ledgerRow !== 'string' || publication.ledgerRow === '') {
+    return ['prerequisite ledger row bytes are missing']
+  }
+  const actualHash = `sha256:${hashText(publication.ledgerRow)}`
+  if (publication.ledgerRowHash !== actualHash) {
+    reasons.push('prerequisite ledger row hash does not match its exact bytes')
+  }
+  const bindings = [
+    ['transition', publication.transition, 'transition'],
+    ['feature', publication.featureId, 'feature id'],
+    ['path', publication.artifactPath, 'artifact path'],
+    ['hash', publication.artifactHash, 'hash'],
+    ['bytes', publication.artifactBytes, 'bytes'],
+    ['nonce', publication.nonce, 'nonce'],
+    ['gate', publication.producerGate, 'gate'],
+    ['persona', publication.producerPersona, 'persona'],
+    ['verdict', publication.verdict, 'verdict'],
+  ]
+  // Exact field-token binding: substring inclusion would accept a suffixed
+  // value (nonce=NONCE-x-extra), a value hidden inside another field
+  // (xpath=nonce=NONCE-x), or a conflicting duplicate token. Each bound field
+  // must appear as EXACTLY ONE <name>=<value> token whose value matches.
+  const rowTokens = publication.ledgerRow.split(/\s+/).filter(token => token !== '')
+  for (const [name, value, label] of bindings) {
+    if (value === undefined) continue
+    const fieldTokens = rowTokens.filter(token => {
+      const eq = token.indexOf('=')
+      return eq > 0 && token.slice(0, eq) === name
+    })
+    if (
+      fieldTokens.length !== 1 ||
+      fieldTokens[0].slice(fieldTokens[0].indexOf('=') + 1) !== String(value)
+    ) {
+      reasons.push(`durable ledger row does not bind ${label}`)
+    }
+  }
+  return reasons
+}
+
+function publicationBarrierReasons(publication, expected, hashText) {
+  const shapeReasons = publicationShapeReasons(publication)
+  if (!publication || typeof publication !== 'object') return shapeReasons
+  return [
+    ...shapeReasons,
+    ...publicationIdentityReasons(publication, expected || {}),
+    ...durableLedgerReasons(publication, expected || {}, hashText),
+  ]
+}
+// === DURABLE-DISPATCH-BARRIER-SLICE:END ===
+
+function publicationExpected(
+  transition,
+  artifactPath,
+  artifactHash,
+  artifactBytes,
+  producerGate,
+  producerPersona,
+  verdict,
+  featureId,
+  sourceArtifact,
+) {
+  return {
+    transition,
+    artifactPath,
+    artifactHash,
+    artifactBytes,
+    nonce: RUN_NONCE,
+    producerGate,
+    producerPersona,
+    verdict,
+    ledgerPath: `${LEDGER_DIR}/GATELOG.md`,
+    ...(featureId ? { featureId } : {}),
+    ...(sourceArtifact ? { sourceArtifact } : {}),
+  }
+}
+
+function readUtf8File(fileSystem, filePath) {
+  try {
+    return {
+      text: fileSystem.readFileSync(filePath, 'utf8'),
+      errorCode: '',
+    }
+  } catch (error) {
+    return {
+      text: null,
+      errorCode:
+        error && error.code
+          ? String(error.code)
+          : 'read failed',
+    }
+  }
+}
+
+function observeArtifact(fileSystem, artifactPath) {
+  const read = readUtf8File(fileSystem, artifactPath)
+  if (typeof read.text !== 'string') {
+    return {
+      exists: false,
+      hash: '',
+      bytes: null,
+      errorCode: read.errorCode,
+    }
+  }
+  return {
+    exists: true,
+    hash: `sha256:${sha256Hex(read.text)}`,
+    bytes: utf8Bytes(read.text),
+    errorCode: '',
+  }
+}
+
+function readDurablePublication(publication, expected) {
+  const inspected = {
+    ...publication,
+    artifactExists: false,
+    ledgerRowDurable: false,
+  }
+  const getBuiltin =
+    typeof process === 'object' &&
+    process &&
+    typeof process.getBuiltinModule === 'function'
+      ? process.getBuiltinModule.bind(process)
+      : null
+  if (!getBuiltin) {
+    inspected.inspectionError =
+      'filesystem inspection is unavailable'
+    return inspected
+  }
+  const fileSystem =
+    getBuiltin('node:fs') || getBuiltin('fs')
+  if (!fileSystem) {
+    inspected.inspectionError =
+      'filesystem inspection is unavailable'
+    return inspected
+  }
+
+  const artifact = observeArtifact(
+    fileSystem,
+    publication.artifactPath,
+  )
+  inspected.artifactExists = artifact.exists
+  inspected.observedArtifactHash = artifact.hash
+  inspected.observedArtifactBytes = artifact.bytes
+  inspected.artifactReadError = artifact.errorCode
+
+  const ledger = readUtf8File(
+    fileSystem,
+    publication.ledgerPath,
+  )
+  inspected.ledgerRowDurable =
+    typeof ledger.text === 'string' &&
+    ledger.text.split(/\r?\n/).includes(publication.ledgerRow)
+  inspected.ledgerReadError = ledger.errorCode
+
+  if (expected && expected.sourceArtifact) {
+    const source = observeArtifact(
+      fileSystem,
+      expected.sourceArtifact.path,
+    )
+    inspected.sourceArtifactExists = source.exists
+    inspected.observedSourceArtifactHash = source.hash
+    inspected.observedSourceArtifactBytes = source.bytes
+    inspected.sourceArtifactReadError = source.errorCode
+  }
+  return inspected
+}
+
+function requireDurablePublication(
+  publication,
+  expected,
+  transition,
+) {
+  const inspected = readDurablePublication(
+    publication || {},
+    expected,
+  )
+  const reasons = publicationBarrierReasons(
+    inspected,
+    expected,
+    sha256Hex,
+  )
+  if (typeof inspected.inspectionError === 'string') {
+    reasons.push(inspected.inspectionError)
+  }
+  if (
+    typeof inspected.observedArtifactHash === 'string' &&
+    inspected.observedArtifactHash !== '' &&
+    inspected.observedArtifactHash !== publication.artifactHash
+  ) {
+    reasons.push(
+      'prerequisite artifact hash differs from durable bytes',
+    )
+  }
+  if (
+    Number.isInteger(inspected.observedArtifactBytes) &&
+    inspected.observedArtifactBytes !== publication.artifactBytes
+  ) {
+    reasons.push(
+      'prerequisite artifact byte count differs from durable bytes',
+    )
+  }
+  const sourceArtifact = expected && expected.sourceArtifact
+  if (sourceArtifact) {
+    if (inspected.sourceArtifactExists !== true) {
+      reasons.push(
+        'prerequisite source artifact is not durably present',
+      )
+    }
+    if (
+      typeof sourceArtifact.hash === 'string' &&
+      inspected.observedSourceArtifactHash !== sourceArtifact.hash
+    ) {
+      reasons.push(
+        'prerequisite source artifact hash does not match the expected binding',
+      )
+    }
+    if (
+      Number.isInteger(sourceArtifact.bytes) &&
+      inspected.observedSourceArtifactBytes !== sourceArtifact.bytes
+    ) {
+      reasons.push(
+        'prerequisite source artifact byte count does not match the expected binding',
+      )
+    }
+    if (
+      sourceArtifact.mustMatchFinal === true &&
+      inspected.observedSourceArtifactHash !==
+        inspected.observedArtifactHash
+    ) {
+      reasons.push(
+        'frozen artifact differs from the approved source artifact',
+      )
+    }
+  }
+  if (reasons.length) {
+    throw new TypeError(
+      `BLOCKED ${transition}: ${reasons.join('; ')}`,
+    )
+  }
+  return inspected
+}
+
+function publicationInstruction(
+  transition,
+  artifactPath,
+  producerGate,
+  producerPersona,
+  verdict,
+  featureId,
+) {
+  const featureBinding = featureId
+    ? ` feature=${featureId}`
+    : ''
+  return `After atomically publishing "${artifactPath}", re-read its final bytes, compute SHA-256 and UTF-8 byte count, and append exactly one PREREQUISITE row to "${LEDGER_DIR}/GATELOG.md" with transition=${transition}${featureBinding} path=${artifactPath} hash=<computed> bytes=<computed> nonce=${RUN_NONCE} gate=${producerGate} persona=${producerPersona} verdict=${verdict}. Flush and re-read that row. Return publication {transition${featureId ? `, featureId: "${featureId}"` : ''}, artifactPath, artifactExists, artifactHash, artifactBytes, nonce, producerGate, producerPersona, verdict, ledgerPath, ledgerRow, ledgerRowHash, ledgerRowDurable}; artifactExists and ledgerRowDurable may be true only after those re-reads, and ledgerRowHash is SHA-256 of the exact appended row bytes.`
+}
+
+function missionPointerBinding() {
+  const ledger = promptLedgerText()
+  return {
+    path: `${LEDGER_DIR}/PROMPTS.txt`,
+    hash: `sha256:${sha256Hex(ledger)}`,
+    bytes: utf8Bytes(ledger),
+    nonce: RUN_NONCE,
+  }
+}
+
+function missionPointer() {
+  const pointer = missionPointerBinding()
+  return `${MISSION_POINTER_LABEL}\npath=${pointer.path} hash=${pointer.hash} bytes=${pointer.bytes} nonce=${pointer.nonce}`
+}
+
+function assembleBrief(role, body, artifactPath, includeMission) {
+  const parts = [`You are ${role}.`, '']
+  if (includeMission) {
+    parts.push(MISSION_BLOCK_LABEL, MISSION, '')
+    if (PRIOR_STEERS) parts.push(PRIOR_STEERS_BLOCK_LABEL, PRIOR_STEERS, '')
+  } else {
+    parts.push(missionPointer(), '')
+  }
+  parts.push(
+    autopromptRunMarker(),
+    `RUN-NONCE: ${RUN_NONCE} (echo this token verbatim in your report; it proves your brief was not corrupted by a context compaction or a crossed wire)`,
+    '',
+    'AUTOPROMPT WORKER CONTRACT: Your registered persona file and this task brief are already your complete operating context. Do not load, invoke, or re-invoke the Autoprompt skill, and do not start a nested Autoprompt run. Execute only your assigned persona and brief. If this persona may spawn, dispatch only a registered ap-* persona.',
+    '',
+    body,
+  )
+  if (artifactPath) {
+    parts.push('', `ARTIFACT (required): before returning your report, write your full output verbatim to "${artifactPath}" (create parent directories if needed). Write it ATOMICALLY - write "${artifactPath}.tmp" then \`mv\` (rename) it onto "${artifactPath}" - so a crash mid-write never leaves a half-written checkpoint a resume probe could mistrust; never overwrite an existing finished -vN artifact, write the next -v(N+1) instead. Artifacts are the run's checkpoints: they stay on disk for the whole session and only a janitor deletes them at the very end. Write the file even when your verdict is negative.`)
+  }
+  return assertSingleBlock(parts.join('\n'), role)
+}
+
+function brief(role, body, artifactPath) {
+  const assembled = assembleBrief(role, body, artifactPath, true)
+  return assertMissionBlock(assembled, MISSION, role, MISSION_BLOCK_LABEL)
+}
+
+function compactBrief(role, body, artifactPath) {
+  return assembleBrief(role, body, artifactPath, false)
+}
+
+// === SERIAL-DISPATCH-SLICE:START - test-only export seam; sliced by remaining-harness.test.js.
+// Self-contained: references only its params + built-ins. ===
+//
+// P-22 (non-blocking dispatch BY CONSTRUCTION): when the orchestrator holds a wave of
+// INDEPENDENT ready work it must spawn-all-then-collect (parallel), never spawn-wait-spawn
+// (serial). fanout() IS that primitive - it runs an independent wave through a single
+// parallel() call - and it records every wave it runs into dispatchLedger. serialDispatch
+// Findings replays that record and flags any wave that ran >=2 independent thunks SERIALLY
+// while the execution mode supported concurrent fan-out - the F-5 "firing N then fired 1"
+// defect made a mechanical in-harness tripwire. Two arms:
+//   FLAG arm (legacy): the wave was dispatched with isParallel!==true while the mode
+//     supports parallelism - a serial DECISION at the choke point.
+//   OBSERVED arm: the wave record carries the peak concurrency the runtime actually
+//     reached (fanout measures it around every thunk). A parallel-FLAGGED wave whose
+//     observed peak never reached the achievable width ran spawn-wait-spawn behind a
+//     blocking spawn - the run_in_background:false / "Review Wave (concurrent)"-over-
+//     sequential-reality collapse, invisible to the flag arm. Records WITHOUT observed
+//     evidence (historical, hand-built) are judged by the flag arm only and never
+//     retro-fail. A wave chunked by the DECLARED live cap (peak === achievableWidth <
+//     count) is not a violation. A trip BLOCKS the DONE seal. PURE, total: a
+//     non-object/short wave -> no trip.
+const SERIAL_DISPATCH_MIN_WAVE = 2      // a wave of >= this many independent thunks must go parallel
+function serialDispatchViolation(wave) {
+  if (!wave || typeof wave !== 'object') return false
+  const count = Number.isFinite(wave.count) ? wave.count : 0
+  if (count < SERIAL_DISPATCH_MIN_WAVE || wave.parallelSupported !== true) return false
+  if (wave.isParallel !== true) return true
+  if (Number.isFinite(wave.peakLive) && Number.isFinite(wave.achievableWidth) &&
+      wave.achievableWidth >= SERIAL_DISPATCH_MIN_WAVE) {
+    return wave.peakLive < wave.achievableWidth
+  }
+  return false
+}
+function serialDispatchFindings(waves) {
+  const findings = []
+  for (const w of (Array.isArray(waves) ? waves : [])) {
+    if (!serialDispatchViolation(w)) continue
+    const at = w.label ? ` at ${w.label}` : ''
+    const observed = w.isParallel === true && Number.isFinite(w.peakLive) && Number.isFinite(w.achievableWidth)
+    findings.push({
+      severity: 'P1', rule: 'serialDispatchFindings',
+      title: observed
+        ? `SERIAL-DISPATCH of independent work${at}: observed peak concurrency ${w.peakLive} of ${w.achievableWidth} achievable - ${w.count} independent ready thunks were held behind blocking spawns (spawn-wait-spawn) though the wave was dispatched parallel-flagged and the mode supports concurrent fan-out - independent work must be spawn-all-then-collect (P-22 / F-5 never-serialize).`
+        : `SERIAL-DISPATCH of independent work${at}: ${w.count} independent ready thunks were dispatched SERIALLY (spawn-wait-spawn) though the execution mode supports concurrent fan-out - independent work must be spawn-all-then-collect (P-22 / F-5 never-serialize).`,
+    })
+  }
+  return findings
+}
+// === SERIAL-DISPATCH-SLICE:END ===
+
+// The module-global dispatch ledger the LIVE path fills: fanout() pushes one record per
+// wave it runs; the DONE seal replays it through serialDispatchFindings so a serial dispatch
+// of independent work cannot reach DONE. Hermetic unit tests build their own wave arrays.
+const dispatchLedger = []
+
+// Sentinel marker: a thunk that classified a NON-transient throw wraps it in
+// this instead of letting the wave's catch flatten it to an indistinguishable
+// null. A LEGITIMATE null return (a skipped/abandoned agent) stays null; only a
+// genuine non-transient escalation is tagged, so fanout can tell the two apart
+// and re-propagate the escalation to the driver (loud exit -> supervisor RESUME).
+const NON_TRANSIENT_SENTINEL = Symbol('nonTransientEscalation')
+
+// Sequential-or-parallel fan-out, per the execution mode. A transient throw is
+// already waited out UNBOUNDED inside each thunk by withRetry, so it never
+// reaches here. A NON-transient throw (a bug, or 4xx) MUST escalate exactly as
+// it does at a sequential agent() call: we capture it as a tagged sentinel
+// (surviving any parallel() primitive that swallows throws to null), then
+// re-throw it after the wave so the driver takes the loud escalate path. A
+// thunk that legitimately RETURNS null is preserved as null, never escalated.
+async function fanout(thunks, isParallel, label) {
+  if (!thunks.length) return []   // empty wave: never depends on parallel([])'s contract
+  // Effective per-wave cap = the GLOBAL MAX_CONCURRENT ceiling AND the per-mode
+  // MODE_LIVE_CAP (the REAL teeth): a TOKENSAVER wave never exceeds 6 live agents,
+  // WIDE/CUSTOM never exceed MAX_CONCURRENT. A null MODE_LIVE_CAP[MODE] means no
+  // per-mode cap, so only the global ceiling applies. A wave wider than the cap is
+  // split into sequential chunks of `cap`, each chunk run in parallel - without
+  // this, "unbounded" WIDE could spawn an arbitrarily wide wave.
+  const cap = Math.min(MAX_CONCURRENT, (MODE_LIVE_CAP[MODE] == null ? MAX_CONCURRENT : MODE_LIVE_CAP[MODE]))
+  // P-22: record the wave's shape so the DONE seal can prove independent work was
+  // spawn-all-then-collect (parallel), never spawn-wait-spawn. parallelSupported is the
+  // mode's own parallel flag; a wave of >=2 thunks dispatched with isParallel!==true while
+  // the mode supports parallelism is the serial-when-parallel-possible defect.
+  // achievableWidth is the width a genuinely concurrent runtime MUST reach
+  // (min(count, cap)); peakLive (filled in after the wave) is the peak concurrency the
+  // runtime ACTUALLY reached - the observed-shape evidence that catches a
+  // parallel-flagged wave that physically ran spawn-wait-spawn.
+  const record = {
+    count: thunks.length,
+    isParallel: !!isParallel,
+    parallelSupported: !!(typeof MODE_CFG === 'object' && MODE_CFG && MODE_CFG.parallelFeatures),
+    label: typeof label === 'string' ? label : '',
+    achievableWidth: Math.min(thunks.length, cap),
+    peakLive: 0,
+  }
+  dispatchLedger.push(record)
+  let liveNow = 0
+  let peakLive = 0
+  const guarded = thunks.map(t => async () => {
+    // A genuinely concurrent parallel() invokes EVERY thunk before the first one
+    // settles (invocation is synchronous; settlement always takes a later microtask),
+    // so peakLive reaches achievableWidth. A serial spawn-wait-spawn primitive never
+    // holds more than one live thunk - the measured peak is the concurrency proof.
+    liveNow += 1
+    if (liveNow > peakLive) peakLive = liveNow
+    try { return await t() }
+    catch (error) {
+      if (error instanceof NonTransientError) {
+        return { [NON_TRANSIENT_SENTINEL]: error }
+      }
+      if (classifyThrow(error) === 'nonTransient') {
+        return {
+          [NON_TRANSIENT_SENTINEL]: new NonTransientError(
+            label || 'fanout',
+            error,
+          ),
+        }
+      }
+      throw error
+    } finally {
+      liveNow -= 1
+    }
+  })
+  let raw
+  if (!isParallel) {
+    raw = await runSequential(guarded)
+  } else if (guarded.length <= cap) {
+    raw = await parallel(guarded)
+  } else {
+    raw = []
+    for (let i = 0; i < guarded.length; i += cap) {
+      raw.push(...await parallel(guarded.slice(i, i + cap)))
+    }
+  }
+  record.peakLive = peakLive
+  const escalation = raw.find(r => r && r[NON_TRANSIENT_SENTINEL])
+  if (escalation) throw escalation[NON_TRANSIENT_SENTINEL]
+  return raw
+}
+
+// Sequential fan-out helper: run thunks one at a time, preserving order. A
+// returned null stays null; a thrown error propagates (the guarded wrapper
+// above has already converted a non-transient escalation into a sentinel value,
+// so nothing genuinely throws here except a defensive re-throw).
+async function runSequential(thunks) {
+  const results = []
+  for (const t of thunks) results.push(await t())
+  return results
+}
+
+// Canary check (FIX-09): the live one-arg wrapper over canaryTrippedCore (in the
+// CANARY-CONTRACT-SLICE). A trip means an ACTUAL spawn-returned verdict echoed a
+// MISSING/empty/whitespace/mismatched nonce, OR is null/non-object (fail-closed) -
+// the caller DISCARDS and re-spawns (brief() restores the header). A
+// LOCAL_SENTINEL-marked, harness-built default is exempt (it never went through a
+// spawn). Belt-only on the schema side: nonce stays OPTIONAL on every canaried
+// schema; do NOT move it to `required` - that would route a missing echo through
+// the injected runtime's validation into a 4xx/throw that classifyThrow escalates
+// to a hard run-kill or unbounded retry. The teeth is THIS in-SUT predicate.
+function canaryTripped(gateResult) {
+  return canaryTrippedCore(gateResult, RUN_NONCE)
+}
+
+// Group features into ascending-phase buckets. Within a bucket, all features
+// are independent (disjoint boundaries); dependsOn edges that cross buckets
+// are satisfied because lower phases complete before higher ones run.
+function phasesOf(features) {
+  return dependencyWaves(features)
+}
+
+// Validate dependsOn edges: every referenced id must exist, and the
+// dependency graph must be acyclic (a cycle would deadlock phase advancement).
+function validateDependencies(features) {
+  const ids = new Set(features.map(f => f.id))
+  for (const f of features) {
+    for (const dep of f.dependsOn || []) {
+      if (!ids.has(dep)) return { ok: false, reason: `${f.id} dependsOn unknown feature "${dep}"` }
+    }
+  }
+  // DFS cycle detection over the dependsOn edges.
+  const WHITE = 0, GREY = 1, BLACK = 2
+  const color = {}
+  for (const f of features) color[f.id] = WHITE
+  const byIdLocal = {}
+  for (const f of features) byIdLocal[f.id] = f
+  function visit(id, trail) {
+    color[id] = GREY
+    for (const dep of (byIdLocal[id].dependsOn) || []) {
+      if (color[dep] === GREY) return `${[...trail, id, dep].join(' -> ')}`
+      if (color[dep] === WHITE) {
+        const cyc = visit(dep, [...trail, id])
+        if (cyc) return cyc
+      }
+    }
+    color[id] = BLACK
+    return null
+  }
+  for (const f of features) {
+    if (color[f.id] === WHITE) {
+      const cyc = visit(f.id, [])
+      if (cyc) return { ok: false, reason: `dependsOn cycle: ${cyc}` }
+    }
+  }
+  try {
+    dependencyWaves(features)
+  } catch (error) {
+    return { ok: false, reason: error.message }
+  }
+  return { ok: true }
+}
+
+// Budget guard: stop opening NEW work when the token target is nearly spent,
+// rather than burning to zero (the cloud-budget-exhausted failure mode).
+function canSpawnNewWork() {
+  if (!budget || !budget.total) return true
+  return budget.remaining() > MIN_BUDGET_TO_SPAWN
+}
+
+// ----- arbiter: rules and continues; transient calls are waited out by the --
+// ----- withRetry primitive (no give-up). Under UNATTENDED it never escalates --
+const userQuestions = []  // arbiter-escalated questions genuinely needing the user (attended only)
+const assumed = []         // unattended ASSUMED answers, recorded for observability
+const allSuggestions = []  // reviewer suggestions retained in the compact run summary
+let arbiterCount = 0
+
+async function arbiter(decisionBody, phaseName) {
+  arbiterCount++
+  const ruling = await agent(
+    compactBrief('an independent arbiter, questions route to you BEFORE the user; be ~99% autonomous',
+      `THE QUESTION / DECISION:\n${decisionBody}\n\n` +
+      (UNATTENDED
+        ? `THIS RUN IS UNATTENDED: the user is unreachable by design. You may NOT set userRequired:true. Choose the option that best serves the mission, set proceed accordingly, and record your assumed answer in decision (prefix it "ASSUMED: "). Ruling and continuing is the only valid output.\n`
+        : '') +
+      `Two jobs: decide it if a competent senior engineer could (almost everything, pick what best serves the mission and clean code and 95% coverage), and judge whether it GENUINELY requires the user. ` +
+      `It is userRequired ONLY if irreversible/destructive, spends real money/quota, needs a credential only the user holds, or is a product-direction call the user must own, not a technical choice an engineer would just make. If userRequired, do not guess; set userQuestion to the precise question. ` +
+      `Set proceed=true to continue/accept, false to stop/drop. State the one risk you accept. Your ruling is binding.`,
+      `${ARTIFACT_DIR}/arbiter-${arbiterCount}.md`),
+    { label: `arbiter ${arbiterCount}`, phase: phaseName || 'Build', schema: ARBITER_SCHEMA, agentType: PERSONA.arbiter },
+  )
+  if (ruling.userRequired && ruling.userQuestion) {
+    if (UNATTENDED) {
+      ruling.userRequired = false
+      ruling.proceed = true   // rule AND continue: the user is unreachable, the arbiter assumes the mission-serving answer and proceeds
+      assumed.push(ruling.userQuestion)
+      log(`ARBITER (unattended): ASSUMED an answer instead of asking - ${ruling.userQuestion}`)
+    } else {
+      userQuestions.push(ruling.userQuestion)
+      log(`ARBITER flagged a user-required question (surfaced, not guessed): ${ruling.userQuestion}`)
+    }
+  }
+  return { ...ruling, errored: false }
+}
+
+// ----- gate loops -------------------------------------------------------
+async function planUntilApproved(feature, tierCfg) {
+  const ph = 'Plan'
+  const fullLoop = !tierCfg || tierCfg.planLoop !== false  // T3 default: full G1-G2-G3 loop
+  const finalPlanPath = `${ARTIFACT_DIR}/${feature.id}-plan-final.md`
+  let plan = null
+  let lastReasons = []
+  let planAttempts = 0
+  let freshRejects = 0
+
+  // TIER T2: a single plan DRAFT precedes the build - no plan-review / fresh-
+  // verify SMASH loop (that depth is the T3 ceiling). The draft is the contract
+  // the implementer reads; the IMPL-REVIEW + VERIFY gates still police it.
+  if (!fullLoop) {
+    assertExecLevel(PERSONA.planner, `${feature.id} plan-draft`)
+    const drafted = await agent(
+      compactBrief('a planner, produce a concise implementation plan, no production code',
+        `YOUR FEATURE: ${feature.name} (${feature.id}), boundary: ${feature.boundary}\n` +
+        `CATEGORY: ${feature.category}${feature.tag ? `\nPLAYBOOK TAG: ${feature.tag}` : ''}\n` +
+        `Look at the real artifact before planning (read files, run the failing case). See PLAYBOOKS.md.\n` +
+        `Deliver a focused plan: success in the mission's terms; the changes file-by-file; edge/unhappy paths; a test strategy that proves behavior; the one real design choice this feature carries. ` +
+        publicationInstruction(
+          'plan-to-implementation',
+          finalPlanPath,
+          'G1-DRAFT',
+          PERSONA.planner,
+          'APPROVED',
+          feature.id,
+        ),
+        finalPlanPath),
+      { label: `${feature.id} plan-draft`, phase: ph, schema: PLAN_DRAFT_SCHEMA, agentType: PERSONA.planner },
+    )
+    recordGateSpawn(feature, 'G1', PERSONA.planner, featureSpawnLog)
+    requireDurablePublication(
+      drafted.publication,
+      publicationExpected(
+        'plan-to-implementation',
+        drafted.publication.artifactPath,
+        drafted.publication.artifactHash,
+        drafted.publication.artifactBytes,
+        'G1-DRAFT',
+        PERSONA.planner,
+        'APPROVED',
+        feature.id,
+      ),
+      'plan-to-implementation',
+    )
+    plan = drafted.plan
+    return { plan, ok: true, planPublication: drafted.publication }
+  }
+
+  while (planAttempts < PLAN_ATTEMPT_BUDGET) {
+    planAttempts++
+    assertExecLevel(PERSONA.planner, `${feature.id} plan #${planAttempts}`)
+    plan = await agent(
+      compactBrief('a planner, produce an implementation/research plan, no production code',
+        `YOUR FEATURE: ${feature.name} (${feature.id}), boundary: ${feature.boundary}\n` +
+        `CATEGORY: ${feature.category}${feature.tag ? `\nPLAYBOOK TAG: ${feature.tag}` : ''}\n` +
+        `Look at the real artifact before planning (read files, fetch pages, run the failing case). See PLAYBOOKS.md for the decomposition spine and playbook tags.\n` +
+        (lastReasons.length ? `A prior plan was rejected. Fix these and resubmit:\n- ${lastReasons.join('\n- ')}\n` : '') +
+        `Deliver the full plan: success in the mission's terms; every change file-by-file; edge/unhappy paths; test strategy that proves behavior; real-system steps; risks; a coverage argument for why this is 100% against the mission.`,
+        `${ARTIFACT_DIR}/${feature.id}-plan-v${planAttempts}.md`),
+      { label: `${feature.id} plan #${planAttempts}`, phase: ph, agentType: PERSONA.planner },
+    )
+    recordGateSpawn(feature, 'G1', PERSONA.planner, featureSpawnLog)
+
+    // EDIT A (gate-DAG {G2‖G3}): G2 plan-review and G3 fresh-verify are
+    // INDEPENDENT (both consume only mission+plan; neither reads the other), so
+    // they dispatch CONCURRENTLY via the existing fanout helper - sequential in
+    // TOKENSAVER (one-live-at-a-time invariant untouched), concurrent in
+    // BILLIONAIRE (capped by MAX_CONCURRENT). Running them concurrently makes G3
+    // blind to G2 BY CONSTRUCTION: G2's verdict does not exist when G3 runs.
+    // NO short-circuit/cancel (§3(a) REJECT): both siblings run to completion and
+    // the loser is discarded at the join - recordGateSpawn fires for both.
+    const planPath = `${ARTIFACT_DIR}/${feature.id}-plan-v${planAttempts}.md`
+    const g2thunk = async () => {
+      const review = await agent(
+        compactBrief('a plan reviewer, you did NOT write this plan',
+          `PLAN UNDER REVIEW: read "${planPath}".\n` +
+          `Check coverage vs the exact mission ledger, coverage vs reality, edge cases, behavior-proving tests, scope creep, and foolproofness. ` +
+          `Return SMASH with numbered reasons and the affected section, or PASS only if you would stake your name on complete mission coverage.` +
+          packPointer(feature),
+          `${ARTIFACT_DIR}/${feature.id}-plan-review-v${planAttempts}.md`),
+        { label: `${feature.id} plan-review #${planAttempts}`, phase: ph, schema: REVIEW_SCHEMA, agentType: PERSONA.reviewer },
+      )
+      recordGateSpawn(feature, 'G2', PERSONA.reviewer, featureSpawnLog)
+      return review
+    }
+    const g3thunk = async () => freshVerifyOnly(feature, planPath)  // records G3 internally; reports APPROVE/REJECT only, NO freeze
+    const [review, fresh] = await fanout([g2thunk, g3thunk], MODE_CFG.parallelFeatures)
+
+    if (review && Array.isArray(review.suggestions)) {
+      for (const s of review.suggestions) allSuggestions.push(`${feature.id} (${ph}): ${s}`)
+    }
+    if (canaryTripped(review)) {
+      canaryTrips++
+      log(`CANARY: nonce mismatch at ${feature.id} plan-review #${planAttempts}; treating verdict as untrusted (SMASH)`)
+      lastReasons = ['canary trip: brief nonce mismatch, re-running the plan gate']
+      continue
+    }
+
+    // JOIN: the parent freezes IFF G2=PASS && G3=APPROVE (correctness wall §4 -
+    // a SMASHed plan is never frozen; the freeze is enforced by the orchestrator,
+    // not the blind G3 agent).
+    if (review && review.verdict === 'PASS' && fresh && fresh.approved) {
+      const frozen = await writeFrozenPlan(feature, planPath)
+      const planPublication = requireDurablePublication(
+        frozen.publication,
+        publicationExpected(
+          'plan-to-implementation',
+          frozen.publication.artifactPath,
+          frozen.publication.artifactHash,
+          frozen.publication.artifactBytes,
+          'G1-FREEZE',
+          PERSONA.scribe,
+          'APPROVED',
+          feature.id,
+          {
+            path: planPath,
+            hash: frozen.publication.artifactHash,
+            bytes: frozen.publication.artifactBytes,
+            mustMatchFinal: true,
+          },
+        ),
+        'plan-to-implementation',
+      )
+      return {
+        plan: frozen.plan || plan,
+        ok: true,
+        planPublication,
+      }
+    }
+    // G2 SMASH precedence: if G2 is not PASS, loop on G2 reasons (the G3 result
+    // is discarded - G2 is the authoritative plan-review gate).
+    if (!review || review.verdict !== 'PASS') {
+      lastReasons = (review && review.reasons) || ['reviewer returned no usable verdict']
+      if (planAttempts % MAX_PLAN_CYCLES === 0) {
+        const ruling = await arbiter(`Plan for ${feature.id} (${feature.name}) SMASHED ${MAX_PLAN_CYCLES}x. Read the candidate at "${planPath}". Outstanding reasons:\n- ${lastReasons.join('\n- ')}\nDecide: good enough to build, keep iterating, or drop the feature?`, ph)
+        if (ruling.proceed) continue
+      }
+      continue
+    }
+    // G2 PASS but G3 REJECT: loop on G3 reasons under the separate fresh budget.
+    freshRejects++
+    lastReasons = (fresh && fresh.reasons) || ['fresh verifier rejected without stated reason']
+    if (freshRejects >= MAX_FRESH_CYCLES) {
+      const ruling = await arbiter(`Plan for ${feature.id} passed review but a fresh verifier REJECTED it ${freshRejects}x. Read the candidate at "${planPath}". Reasons:\n- ${lastReasons.join('\n- ')}\nDecide: build it, or send back for re-scope?`, ph)
+      if (ruling.proceed) continue
+      freshRejects = 0
+    }
+  }
+
+  return { plan, ok: false, reasons: lastReasons.length ? lastReasons : ['plan attempt budget exhausted'] }
+}
+
+async function freshVerify(feature, planPath) {
+  assertExecLevel(PERSONA.freshVerifier, `${feature.id} fresh-verify`)
+  const fresh = await agent(
+    compactBrief('a fresh verifier, you have seen NO prior discussion, only the mission and this plan',
+      `PROPOSED PLAN: read "${planPath}". The planner report for this attempt is the candidate; do not read any review verdict.\n` +
+      `Read the real repository yourself before deciding. Answer: does the plan deliver everything the exact mission ledger asks? Is any step hand-wavy, untested, or assuming success? Below complete satisfaction means REJECT with the specific gap.\n` +
+      `If APPROVE, copy the candidate plan bytes to "${ARTIFACT_DIR}/${feature.id}-plan-final.md" as the frozen contract. If APPROVE, ` +
+      publicationInstruction(
+        'plan-to-implementation',
+        `${ARTIFACT_DIR}/${feature.id}-plan-final.md`,
+        'G3-FREEZE',
+        PERSONA.freshVerifier,
+        'APPROVED',
+        feature.id,
+      ),
+      `${ARTIFACT_DIR}/${feature.id}-fresh-verify.md`),
+    { label: `${feature.id} fresh-verify`, phase: 'Plan', schema: FRESH_SCHEMA, agentType: PERSONA.freshVerifier },
+  )
+  recordGateSpawn(feature, 'G3', PERSONA.freshVerifier, featureSpawnLog)
+  if (canaryTripped(fresh)) {
+    canaryTrips++
+    log(`CANARY: nonce mismatch at ${feature.id} fresh-verify; treating verdict as REJECT`)
+    return { approved: false, reasons: ['canary trip: brief nonce mismatch, re-anchoring the plan'] }
+  }
+  if (fresh && fresh.verdict === 'APPROVE') {
+    const planPublication = requireDurablePublication(
+      fresh.publication,
+      publicationExpected(
+        'plan-to-implementation',
+        fresh.publication && fresh.publication.artifactPath,
+        fresh.publication && fresh.publication.artifactHash,
+        fresh.publication && fresh.publication.artifactBytes,
+        'G3-FREEZE',
+        PERSONA.freshVerifier,
+        'APPROVED',
+        feature.id,
+      ),
+      'plan-to-implementation',
+    )
+    return {
+      approved: true,
+      reasons: fresh.reasons || [],
+      planPublication,
+    }
+  }
+  return { approved: false, reasons: (fresh && fresh.reasons) || [] }
+}
+
+// EDIT B (gate-DAG): freshVerifyOnly is the G3 leaf for the T3 {G2‖G3} JOIN - it
+// runs the blind fresh-verify and reports APPROVE/REJECT ONLY; it does NOT write
+// the frozen `-plan-final.md`. The freeze moves OUT of the blind G3 agent into
+// the parent join (writeFrozenPlan), so G3 can never freeze a plan G2 has not
+// also passed, and - running CONCURRENTLY with G2 - G3 is blind to G2's verdict
+// BY CONSTRUCTION (G2's verdict does not exist when G3 runs). freshVerify (above)
+// keeps its inline freeze for the T1-debug path (debugFreshVerify), whose G3 is
+// dependent on its own G1 draft and is NOT part of a G2‖G3 join (R3 asymmetry).
+async function freshVerifyOnly(feature, planPath) {
+  assertExecLevel(PERSONA.freshVerifier, `${feature.id} fresh-verify`)
+  const fresh = await agent(
+    compactBrief('a fresh verifier, you have seen NO prior discussion, only the mission and this plan',
+      `PROPOSED PLAN: read "${planPath}".\n` +
+      `Read the real repository yourself before deciding. Answer: does the plan deliver everything the exact mission ledger asks? Is any step hand-wavy, untested, or assuming success? Below complete satisfaction means REJECT with the specific gap.\n` +
+      `Report APPROVE or REJECT only - you do NOT freeze the plan; the parent freezes it on the joint verdict.` +
+      packPointer(feature),
+      `${ARTIFACT_DIR}/${feature.id}-fresh-verify.md`),
+    { label: `${feature.id} fresh-verify`, phase: 'Plan', schema: FRESH_SCHEMA, agentType: PERSONA.freshVerifier },
+  )
+  recordGateSpawn(feature, 'G3', PERSONA.freshVerifier, featureSpawnLog)
+  if (canaryTripped(fresh)) {
+    canaryTrips++
+    log(`CANARY: nonce mismatch at ${feature.id} fresh-verify; treating verdict as REJECT`)
+    return { approved: false, reasons: ['canary trip: brief nonce mismatch, re-anchoring the plan'] }
+  }
+  return { approved: !!fresh && fresh.verdict === 'APPROVE', reasons: (fresh && fresh.reasons) || [] }
+}
+
+// writeFrozenPlan (EDIT B): the parent-side freeze. Called by the {G2‖G3} join
+// in planUntilApproved ONLY when G2=PASS && G3=APPROVE - never by the blind G3
+// agent. gate.js is fs-free, so the write is performed by a typed write-only L4
+// leaf (no judgement, no verdict): it copies the approved plan verbatim into the
+// frozen contract `-plan-final.md` the late jurors read. This is the orchestrator
+// enforcing the freeze condition, not the agent - a SMASHed plan can never be
+// frozen (correctness wall §4: "a SMASHed plan must NOT be frozen").
+async function writeFrozenPlan(feature, planPath) {
+  const finalPlanPath =
+    `${ARTIFACT_DIR}/${feature.id}-plan-final.md`
+  return agent(
+    compactBrief('a plan-freeze writer; you make NO judgement, you only copy the jointly approved plan as the frozen contract',
+      `The plan at "${planPath}" passed plan-review and fresh verification. Copy those exact bytes to "${finalPlanPath}" with no edits or commentary; it becomes the frozen contract read by implementation and later assurance. ` +
+      publicationInstruction(
+        'plan-to-implementation',
+        finalPlanPath,
+        'G1-FREEZE',
+        PERSONA.scribe,
+        'APPROVED',
+        feature.id,
+      ),
+      finalPlanPath),
+    { label: `${feature.id} freeze-plan`, phase: 'Plan', schema: PLAN_DRAFT_SCHEMA, agentType: PERSONA.scribe },
+  )
+}
+
+// FIX-07 consumer: a G1 plan draft (forces the issue-derived repro + a FALSIFIABLE
+// root-cause hypothesis BEFORE a fix layer) then a G3 fresh-verify that re-derives
+// the root cause from mission+plan only. A REJECT loops back to a fresh draft; an
+// exhausted loop arbitrates, and a denial returns ok:false -> BLOCKED_AT_PLAN (no
+// fix is implemented). This is the proportionality-narrow form: only a debug
+// feature on a freshVerifyDebug tier (T1) reaches here. It adds G1+G3 only (NOT
+// the G2 plan-review - that depth stays the T3 ceiling, per FIX-07's "does NOT
+// make every T1 heavy").
+async function debugFreshVerify(feature, tier, tierCfg) {
+  const ph = 'Plan'
+  let plan = null
+  let lastReasons = []
+  let freshRejects = 0
+  let attempts = 0
+  while (attempts < PLAN_ATTEMPT_BUDGET) {
+    attempts++
+    assertExecLevel(PERSONA.planner, `${feature.id} debug-plan #${attempts}`)
+    const debugPlanPath = `${ARTIFACT_DIR}/${feature.id}-plan-v${attempts}.md`
+    plan = await agent(
+      compactBrief('a planner, produce a debug plan, no production code',
+        `YOUR FEATURE: ${feature.name} (${feature.id}), boundary: ${feature.boundary}\n` +
+        `CATEGORY: ${feature.category}\nPLAYBOOK TAG: debug\n` +
+        `Follow the debug playbook (PLAYBOOKS.md): FIRST capture an issue-derived RED repro you actually ran, THEN state a FALSIFIABLE root-cause hypothesis and enumerate >=2 competing causes (one explicitly elsewhere than the obvious file). Choose a fix LAYER only AFTER the repro + hypothesis are on record - never lock a root cause inside scope.\n` +
+        (lastReasons.length ? `A prior plan was REJECTED by the fresh verifier. Fix these and resubmit:\n- ${lastReasons.join('\n- ')}\n` : '') +
+        `Deliver: the issue-derived repro (captured red), the falsifiable hypothesis + competing causes, the chosen fix layer with why, file-by-file changes, unhappy paths, a test strategy proving behavior, a coverage argument.`,
+        debugPlanPath),
+      { label: `${feature.id} debug-plan #${attempts}`, phase: ph, agentType: PERSONA.planner },
+    )
+    recordGateSpawn(feature, 'G1', PERSONA.planner, featureSpawnLog)
+
+    const fresh = await freshVerify(feature, debugPlanPath)   // records G3, sees mission+plan only
+    if (fresh.approved) {
+      return {
+        plan,
+        ok: true,
+        planPublication: fresh.planPublication,
+      }
+    }
+    freshRejects++
+    lastReasons = fresh.reasons
+    if (freshRejects >= MAX_FRESH_CYCLES) {
+      const ruling = await arbiter(`Debug fix for ${feature.id} had its plan REJECTED by an independent fresh verifier ${freshRejects}x. Read the candidate at "${debugPlanPath}". Reasons:\n- ${lastReasons.join('\n- ')}\nDecide: build it, or send back for re-scope?`, ph)
+      if (ruling.proceed) continue
+      freshRejects = 0
+    }
+  }
+  return { plan, ok: false, reasons: lastReasons.length ? lastReasons : ['debug fresh-verify budget exhausted'] }
+}
+
+// F-DEPTH G3.5 DEPTH-LOCK runner. AFTER the plan is frozen (the fix LAYER is
+// known) and BEFORE G4, a debug feature spawns the ap-depth-prober L4 leaf with
+// the issue text + repo + the PROPOSED fix layer LAST/sealed. The prober derives
+// D1-D5 from the issue text FIRST, blind to the proposed layer, and reports its
+// independently-derived D3 deepest-cause + whether the D4 repro is RED unpatched.
+// The verdict is RECOMPUTED via depthLockPass (never trusted from the string):
+// PASS only when frozenLayer === d3 AND reproRed === true. A FAIL returns
+// { pass:false, depthMiss:true, reasons } so the supervisor re-enters at G1 with
+// `depth-miss` (mirrors the BLOCKED_AT_PLAN shape). Proportionality-narrow: only
+// debug features reach here; the gate is never skipped at any tier (light single
+// prober at T0/T1, adversarial at T2/T3) - speed is never bought by thinning it.
+async function depthLock(feature, plan, frozenLayer) {
+  assertExecLevel(PERSONA.depthProber, `${feature.id} depth-lock`)
+  const prober = await agent(
+    compactBrief('a depth prober; you have seen NO prior discussion. Derive the bug\'s deepest-cause function from the ISSUE TEXT alone, BLIND to the proposed fix layer; default-FAIL',
+      `YOUR FEATURE: ${feature.name} (${feature.id}), boundary: ${feature.boundary}\nPLAYBOOK TAG: debug\n` +
+      `Derive, from the ISSUE TEXT + the REAL code FIRST (blind to the proposed fix layer): ` +
+      `D1 the HOME FUNCTION where the behavior is DECIDED (file:function + why); ` +
+      `D2 a WHOLE-CONTRACT INPUT-CLASS table (every input/param/branch/invariant; the gold-revealing class MUST appear, issue-derived); ` +
+      `D3 the single DEEPEST point that fixes ALL D2 classes (flag any shallower layer verbatim "SHALLOW - deeper cause at <file:function>"); ` +
+      `D4 the most adversarial maintainer assertion from the issue TITLE+TEXT alone - a binding repro you may NOT phrase in terms of the patch's own mechanism, proven RED against UNPATCHED code (capture the real red output). ` +
+      `ONLY THEN read the PROPOSED FIX LAYER (sealed, last) to compare against your own D3 - never to seed D1-D3.\n\n` +
+      `PROPOSED FIX LAYER (read LAST, for comparison only): ${frozenLayer || '(none recorded)'}\n\n` +
+      `Report d3DeepestCause (file.py::function) and reproRed (true only with captured red on record). VERDICT PASS only when the proposed layer EQUALS your D3 AND the D4 repro is RED unpatched; else REJECT - depth-miss.`,
+      `${ARTIFACT_DIR}/${feature.id}-depth-lock.md`),
+    { label: `${feature.id} depth-lock`, phase: 'Plan', schema: DEPTH_SCHEMA, agentType: PERSONA.depthProber },
+  )
+  recordGateSpawn(feature, 'G3.5', PERSONA.depthProber, featureSpawnLog)
+  if (canaryTripped(prober)) {
+    canaryTrips++
+    log(`CANARY: nonce mismatch at ${feature.id} depth-lock; treating verdict as depth-miss`)
+    return { pass: false, depthMiss: true, reasons: ['canary trip: brief nonce mismatch at DEPTH-LOCK'] }
+  }
+  const d3 = prober && typeof prober.d3DeepestCause === 'string' ? prober.d3DeepestCause : ''
+  const reproRed = prober && prober.reproRed === true
+  const pass = depthLockPass(frozenLayer, d3, reproRed)
+  if (pass) return { pass: true, d3, reproRed }
+  const reasons = (prober && Array.isArray(prober.reasons) && prober.reasons.length)
+    ? prober.reasons
+    : [`depth-miss: frozen fix-layer "${frozenLayer}" != independently-derived deepest-cause "${d3 || '(none)'}"${reproRed ? '' : '; D4 repro not proven RED unpatched'}`]
+  return { pass: false, depthMiss: true, d3, reproRed, reasons }
+}
+
+// extractFixLayer (F-DEPTH): pull the chosen fix LAYER (file.py::function) from a
+// frozen plan body. The debug planner records it as "fix layer ... <file>::<fn>"
+// or a bare file.py::function token. Returns '' when none is found (the prober
+// then compares against an empty proposed layer - a default-FAIL depth-miss).
+const FIXLAYER_TOKEN_RE = /([A-Za-z0-9_./-]+\.py::[A-Za-z0-9_.]+)/
+function extractFixLayer(plan) {
+  if (typeof plan !== 'string') return ''
+  const m = FIXLAYER_TOKEN_RE.exec(plan)
+  return m ? m[1] : ''
+}
+
+// resolvePlan: the single plan-entry funnel all three runFeatureInner sites use,
+// so a debug-T1 routes through debugFreshVerify (G1+G3) wherever a plan is
+// resolved - the freshVerifyDebug flag is CONSUMED here, never dead. A
+// plan-bearing tier (T2/T3) keeps planUntilApproved; a debug feature on a
+// freshVerifyDebug tier gets the fresh-verify; everything else takes the
+// synthetic no-plan placeholder exactly as before. F-DEPTH: AFTER the plan is
+// frozen (the fix layer is known) and BEFORE G4, a debug feature runs G3.5
+// DEPTH-LOCK; a depth-miss returns ok:false depthMiss:true so the supervisor
+// re-enters at G1 (no fix is implemented over a wrong-layer plan).
+async function resolvePlan(feature, tier, tierCfg) {
+  let planResult
+  if (feature.roadmapPlan && feature.requiresDetailedPlan !== true && feature.tag !== 'debug') {
+    planResult = { plan: feature.roadmapPlan, ok: true }
+  } else if (tierCfg.plan) planResult = await planUntilApproved(feature, tierCfg)
+  else if (debugFreshVerifyRequired(feature, tierCfg)) planResult = await debugFreshVerify(feature, tier, tierCfg)
+  else planResult = { plan: `(${tier} tier: no separate plan phase; the implementer works directly from the mission and the feature boundary "${feature.boundary}")`, ok: true }
+  if (!planResult.ok) return planResult
+  const lock = await lockDebugPlan(feature, planResult.plan)
+  if (!lock.ok) return { ...planResult, ok: false, depthMiss: true, reasons: lock.reasons }
+  return planResult
+}
+
+// lockDebugPlan (F-DEPTH G3.5, shared by resolvePlan AND the resume branches): run
+// DEPTH-LOCK for a debug feature against a (fresh or resume-frozen) plan. A pass
+// records the LIVE depth-lock result on the feature reference that flows into every
+// result -> summary.features -> the SCRIBE GATELOG brief, which emits `fixlayer=`/
+// `tag=debug` onto the real G3.5 row + FEATURE-META BY CONSTRUCTION (plan R1). This
+// is what gives depthLockFindings ARM A/B/C real inputs on a real run, and what
+// closes the RESUME BYPASS: a debug feature resumed past plan-freeze re-runs the gate
+// rather than sealing DONE with DEPTH-LOCK skipped. A non-debug feature is a no-op.
+async function lockDebugPlan(feature, plan) {
+  if (!feature || feature.tag !== 'debug') return { ok: true }
+  const frozenLayer = extractFixLayer(plan)
+  const lock = await depthLock(feature, plan, frozenLayer)
+  if (!lock.pass) return { ok: false, reasons: lock.reasons }
+  feature.depthLock = { frozenLayer, d3: lock.d3 || '', reproRed: lock.reproRed === true }
+  return { ok: true }
+}
+
+function diffScope(feature) {
+  return `Scope your inspection to this feature's boundary (${feature.boundary}); run \`git diff -- <those paths>\` so you review THIS feature, not work from parallel features on the shared tree.`
+}
+
+// Gates receive the same compact roadmap and mission pointers. A separate
+// context-pack worker would add a full agent round trip before useful work; each
+// gate reads only the boundary evidence it needs directly.
+function packPointer() {
+  return ''
+}
+
+// A panel/sweep reason "names a blocker" if it cites a P0 or P1. Such a reason
+// is never arbitrable into DONE (Pillar B M1/N2): the arbiter may log it
+// PARTIAL but can never declare an open P0/P1 shippable.
+function panelNamesBlocker(reasons) {
+  return (reasons || []).some(r => /\bP0\b|\bP1\b/i.test(String(r)))
+}
+
+// === ADAPTIVE-SCOPE-SLICE:START - pure topology and roadmap derivation. ===
+const MAX_FEATURES = 12            // refuse runaway roadmap decomposition (cost guard)
+const SCOPE_TOPOLOGY = Object.freeze({
+  bounded: Object.freeze({ profile: 'bounded', scouts: 0, totalAgents: 3, sequentialRounds: 2 }),
+  'multi-surface': Object.freeze({ profile: 'multi-surface', scouts: 2, totalAgents: 5, sequentialRounds: 3 }),
+  'unusually-large': Object.freeze({ profile: 'unusually-large', scouts: 5, totalAgents: 9, sequentialRounds: 4 }),
+})
+
+function scopeTopology(profile) {
+  return { ...(SCOPE_TOPOLOGY[profile] || SCOPE_TOPOLOGY['multi-surface']) }
+}
+
+function sameMissionPointer(actual, expected) {
+  if (!expected) return true
+  return actual.path === expected.path && actual.hash === expected.hash &&
+    actual.bytes === expected.bytes && actual.nonce === expected.nonce
+}
+
+function validateRoadmapStructure(roadmap, expectedMissionPointer) {
+  const items = roadmap && Array.isArray(roadmap.items) ? roadmap.items : []
+  if (items.length === 0) return ['roadmap has no items']
+  if (items.length > MAX_FEATURES) {
+    return [`roadmap has ${items.length} items, exceeding the supported limit of ${MAX_FEATURES} - split the mission into separate runs instead of dropping lanes`]
+  }
+  const mission = roadmap && roadmap.missionPointer
+  if (!mission || typeof mission.path !== 'string' || !/^sha256:[a-f0-9]{64}$/.test(mission.hash || '') ||
+      !Number.isInteger(mission.bytes) || mission.bytes < 1 || typeof mission.nonce !== 'string' || mission.nonce === '') {
+    return ['roadmap mission pointer has no complete path/hash/bytes/nonce binding']
+  }
+  if (!sameMissionPointer(mission, expectedMissionPointer)) return ['roadmap mission pointer does not match the canonical prompt ledger']
+  if (typeof roadmap.repositoryIntel !== 'string' || roadmap.repositoryIntel.trim() === '') return ['roadmap has no repository intelligence']
+  if (!Array.isArray(roadmap.toolDecisions) || roadmap.toolDecisions.length === 0) return ['roadmap has no tool decisions']
+  if (!Array.isArray(roadmap.frameworkDecisions) || roadmap.frameworkDecisions.length === 0) return ['roadmap has no framework decisions']
+  if (roadmap.scopeProfile === 'unusually-large' &&
+      (typeof roadmap.escalationReason !== 'string' || roadmap.escalationReason.trim() === '')) {
+    return ['unusually-large scope has no concrete escalation reason']
+  }
+  const ids = new Set()
+  const boundaries = new Map()
+  for (const item of items) {
+    const id = item && typeof item.id === 'string' ? item.id.trim() : ''
+    if (id === '') return ['roadmap item has no stable id']
+    if (ids.has(id)) return [`roadmap has duplicate item id ${id}`]
+    ids.add(id)
+    if (typeof item.framework !== 'string' || item.framework.trim() === '') return [`${id} has no framework`]
+    const boundary = typeof item.boundary === 'string' ? item.boundary.trim() : ''
+    if (boundary === '') return [`${id} has no owned boundary`]
+    const owner = boundaries.get(boundary)
+    if (owner) return [`${id} overlaps ${owner} on owned boundary ${boundary}`]
+    boundaries.set(boundary, id)
+    if (!Array.isArray(item.dependsOn)) return [`${id} dependencies are not an array`]
+    if (!Number.isInteger(item.launchGroup) || item.launchGroup < 0) return [`${id} has no valid launch group`]
+    if (typeof item.integrationLane !== 'string' || item.integrationLane.trim() === '') return [`${id} has no integration lane`]
+    if (typeof item.coverageRequirement !== 'string' || !/95%/.test(item.coverageRequirement)) return [`${id} has no >=95% coverage contract`]
+  }
+  return []
+}
+
+function dependencyWaves(features) {
+  const list = Array.isArray(features) ? features : []
+  const byId = new Map(list.map(feature => [feature.id, feature]))
+  const pending = new Set(byId.keys())
+  const completed = new Set()
+  const waves = []
+  for (const feature of list) {
+    for (const dependency of feature.dependsOn || []) {
+      if (!byId.has(dependency)) throw new TypeError(`${feature.id} dependsOn unknown feature "${dependency}"`)
+    }
+  }
+  while (pending.size) {
+    const ready = list.filter(feature => pending.has(feature.id) &&
+      (feature.dependsOn || []).every(dependency => completed.has(dependency)))
+    if (ready.length === 0) throw new TypeError(`dependsOn cycle: ${[...pending].join(' -> ')}`)
+    waves.push(ready)
+    for (const feature of ready) {
+      pending.delete(feature.id)
+      completed.add(feature.id)
+    }
+  }
+  return waves
+}
+
+function roadmapPointer(binding) {
+  const path = binding && binding.roadmapPath
+  const hash = binding && binding.roadmapHash
+  const bytes = binding && binding.roadmapBytes
+  const nonce = binding && binding.runNonce
+  if (typeof path !== 'string' || path === '' || !/^sha256:[a-f0-9]{64}$/.test(hash || '') ||
+      !Number.isInteger(bytes) || bytes < 1 || typeof nonce !== 'string' || nonce === '') {
+    throw new TypeError('roadmap pointer has no complete cryptographic binding')
+  }
+  return `ROADMAP POINTER: path=${path} hash=${hash} bytes=${bytes} nonce=${nonce}`
+}
+
+function roadmapPlan(item) {
+  return [
+    `Done means: ${item.doneMeans}`,
+    `Implementation: ${(item.implementationSteps || []).join('; ')}`,
+    `Unhappy paths: ${(item.unhappyPaths || []).join('; ')}`,
+    `Tests first: ${(item.testsFirst || []).join('; ')}`,
+    `Verification: ${(item.verification || []).join('; ')}`,
+  ].join('\n')
+}
+
+function deriveRoadmapFeatures(roadmap) {
+  return (roadmap.items || []).map((item, index) => ({
+    id: item.id || `F${index + 1}`,
+    name: item.title,
+    category: item.category || 'backend',
+    tag: item.tag,
+    tier: ['T0', 'T1', 'T2', 'T3'].includes(item.tier) ? item.tier : 'T2',
+    framework: item.framework,
+    boundary: item.boundary,
+    dependsOn: Array.isArray(item.dependsOn) ? item.dependsOn : [],
+    phase: Number.isInteger(item.launchGroup) ? item.launchGroup : 0,
+    acceptanceCriteria: Array.isArray(item.acceptanceCriteria) ? item.acceptanceCriteria : [],
+    requiresDetailedPlan: item.requiresDetailedPlan === true,
+    roadmapPlan: roadmapPlan(item),
+    roadmapPath: roadmap.roadmapPath,
+    roadmapHash: roadmap.roadmapHash,
+    roadmapBytes: roadmap.roadmapBytes,
+  }))
+}
+
+function scoutEvidencePointer(index, artifactDir) {
+  return `${artifactDir}/roadmap-scout-${index + 1}.md`
+}
+
+function scoutEvidencePointers(reports, artifactDir) {
+  return (Array.isArray(reports) ? reports : []).map((report, index) => {
+    const isValidHash = report && typeof report.evidenceHash === 'string' && /^sha256:[a-f0-9]{64}$/.test(report.evidenceHash)
+    const isValidBytes = report && Number.isInteger(report.evidenceBytes) && report.evidenceBytes > 0
+    const hash = isValidHash ? report.evidenceHash : '(missing)'
+    const bytes = isValidBytes ? report.evidenceBytes : '(missing)'
+    return `- scout ${index + 1}: read "${scoutEvidencePointer(index, artifactDir)}" hash=${hash} bytes=${bytes}`
+  }).join('\n')
+}
+
+function validateScoutReports(
+  reports,
+  expectedCount,
+  runNonce,
+  expectedResearch = [],
+) {
+  const list = Array.isArray(reports) ? reports : []
+  const reasons = []
+  for (let index = 0; index < expectedCount; index++) {
+    const report = list[index]
+    if (!report || typeof report !== 'object') {
+      reasons.push(`scout ${index + 1} returned no structured evidence report`)
+      continue
+    }
+    if (typeof runNonce === 'string' && runNonce !== '' && report.nonce !== runNonce) {
+      reasons.push(`scout ${index + 1} canary nonce is missing or mismatched`)
+    }
+    if (typeof report.evidenceHash !== 'string' || !/^sha256:[a-f0-9]{64}$/.test(report.evidenceHash)) {
+      reasons.push(`scout ${index + 1} evidence hash is missing or malformed`)
+    }
+    if (!Number.isInteger(report.evidenceBytes) || report.evidenceBytes < 1) {
+      reasons.push(`scout ${index + 1} evidence byte length is missing or invalid`)
+    }
+    const hasResearchExpectation =
+      expectedResearch.length > index
+    const mustResearch = expectedResearch[index] === true
+    if (
+      hasResearchExpectation &&
+      report.researchRequired !== mustResearch
+    ) {
+      reasons.push(
+        `scout ${index + 1} research requirement is mismatched`,
+      )
+      continue
+    }
+    if (hasResearchExpectation) {
+      reasons.push(...researchProgressReasons(report).map(
+        reason => `scout ${index + 1} ${reason}`,
+      ))
+    }
+    if (mustResearch) {
+      reasons.push(...researchReceiptReasons(report).map(
+        reason => `scout ${index + 1} ${reason}`,
+      ))
+    }
+  }
+  return reasons
+}
+// === ADAPTIVE-SCOPE-SLICE:END ===
+
+// ----- ADAPTIVE SCOPE-AND-ROADMAP ----------------------------------------
+// Every run starts with one useful author that writes a complete executable
+// ROADMAP.md. Multi-surface work adds retained complementary evidence before
+// concurrent independent assurance; unusually-large work alone pays a separate
+// synthesis round. Capability failure stops before any scout or build dispatch.
+const ROADMAP_OUTPUT_CONTRACT =
+  `Write the candidate to "${ARTIFACT_DIR}/ROADMAP.md" and copy those exact bytes atomically to the canonical root "${LEDGER_DIR}/ROADMAP.md". Report structured capability {run, read, write, evidence}, resolvedModel, effortStatus, promptLedgerPath, and missionPointer {path, hash, bytes, nonce}. ` +
+  `Include repositoryIntel, concrete toolDecisions, frameworkDecisions, and for every item: id, title, category, optional tag, tier, selected framework leaf, owned boundary, dependencies, launchGroup, integrationLane, doneMeans, implementationSteps, positive acceptanceCriteria, unhappyPaths, testsFirst, real verification commands/discovery, coverageRequirement explicitly requiring >=95% changed-line and touched-module coverage, and requiresDetailedPlan. ` +
+  `Set scopeProfile to bounded, multi-surface, or unusually-large. Use unusually-large only with a concrete escalationReason. Order by dependency; no time estimates. Append one SCOPE-CANDIDATE line to "${LEDGER_DIR}/GATELOG.md" with path/hash/bytes/nonce and candidate source; create no other root governance file. After atomically writing both roadmap copies, report the candidate roadmapPath, its SHA-256 roadmapHash, and UTF-8 roadmapBytes.`
+
+async function assureRoadmap(cycle, roadmap, scouts) {
+  const pointer = roadmapPointer({
+    roadmapPath: roadmap.roadmapPath,
+    roadmapHash: roadmap.roadmapHash,
+    roadmapBytes: roadmap.roadmapBytes,
+    runNonce: RUN_NONCE,
+  })
+  const evidencePointers = scouts.length
+    ? `\nRetained scout evidence (verify hashes and lengths before use):\n${scoutEvidencePointers(scouts, ARTIFACT_DIR)}`
+    : ''
+  const reviewThunk = () => agent(
+    compactBrief('an independent roadmap reviewer',
+      `${pointer}\nRead and hash-check the candidate before judging.${evidencePointers} SMASH only with specific affected item ids or structural gaps; PASS only when mission coverage, retained evidence, frameworks, boundaries, tests, and dependency lanes are executable. Append one ROADMAP-REVIEW line to "${LEDGER_DIR}/GATELOG.md" with path/hash/bytes/nonce and your PASS/SMASH verdict. Append only; do not rewrite the log or roadmap and create no other governance file.`,
+      null),
+    { label: `roadmap-review #${cycle}`, phase: 'Scope', schema: REVIEW_SCHEMA, agentType: PERSONA.reviewer },
+  )
+  const freshThunk = () => agent(
+    compactBrief('a blind roadmap fresh verifier',
+      `${pointer}\nRead only the original mission, real repository, hash-checked candidate, and raw evidence pointers below.${evidencePointers} APPROVE only if the candidate is consistent with that evidence and executing it would fully satisfy the mission; otherwise name the affected item ids. On APPROVE, append one PRE-BUILD-APPROVED line to "${LEDGER_DIR}/GATELOG.md" with transition=roadmap-to-implementation feature=RUN path=${roadmap.roadmapPath} hash=${roadmap.roadmapHash} bytes=${roadmap.roadmapBytes} nonce=${RUN_NONCE} gate=ROADMAP-APPROVAL persona=${PERSONA.freshVerifier} verdict=APPROVE. Append only; flush the write before returning. Return publication with the exact artifact and ledger bindings, exact ledgerRow bytes and their SHA-256, artifactExists=true only after re-reading the final non-.tmp roadmap, and ledgerRowDurable=true only after re-reading the appended row. On REJECT append the same binding with verdict=REJECT but return no approval publication. Do not copy or edit the roadmap and create no other governance file.`,
+      null),
+    { label: `roadmap-fresh-verify #${cycle}`, phase: 'Scope', schema: FRESH_SCHEMA, agentType: PERSONA.freshVerifier },
+  )
+  return fanout([reviewThunk, freshThunk], true, `roadmap-assurance-${cycle}`)
+}
+
+function roadmapAuthorThunk(capabilityInstruction) {
+  return () => agent(
+    brief('the useful-first roadmap author; inspect the real repository and produce the executable roadmap',
+      `This is the first useful worker, not a ceremony probe. Before any other work, create "${LEDGER_DIR}/PROMPTS.txt" atomically with the exact mission under an "=== PROMPT 1 ===" header, and append PRIOR_STEERS as later numbered prompt blocks when present. ${capabilityInstruction} Then inspect the repository and produce the complete roadmap. ${ROADMAP_OUTPUT_CONTRACT}`,
+      `${ARTIFACT_DIR}/ROADMAP.md`),
+    { label: 'roadmap author', phase: 'Scope', schema: ROADMAP_SCHEMA, agentType: PERSONA.scoper },
+  )
+}
+
+function roadmapScoutThunks(profile, startIndex = 0) {
+  const endIndex = scopeTopology(profile).scouts
+  return SCOPING_ANGLES.slice(startIndex, endIndex).map((angle, offset) => {
+    const index = startIndex + offset
+    return () => agent(
+      compactBrief(`a retained roadmap scout for ${angle.label}`,
+        `Inspect only this complementary angle: ${angle.label}. Write concise raw evidence and concrete roadmap corrections to "${scoutEvidencePointer(index, ARTIFACT_DIR)}". Report its SHA-256 hash and UTF-8 byte length. Set researchRequired=${angle.research}. ${angle.research ? `If current external facts are necessary, use at most 6 searches and 6 fetches, write the named usable output first, and write one JSON receipt row per call to "${scoutEvidencePointer(index, ARTIFACT_DIR)}.receipts.json". Every row must contain kind (search, fetch, or usable-inspection), request, source URL/path, and its material contribution. Re-read the final receipt artifact and report receiptArtifact {path, hash, bytes} plus exact claimed/receipted search, fetch, and usable-inspection counts and materializedOutputs. Zero output, a missing receipt artifact, or unreconciled rows is NO-USEFUL-OUTPUT; do not broaden or repeat the wave.` : 'Use repository evidence only. Report zero search/fetch/usable-inspection counts and materializedOutputs as the count of concrete repository findings written.'} Do not read or modify ROADMAP.md, do not write a separate governance artifact, and do not assume another scope worker's findings.`,
+        `${scoutEvidencePointer(index, ARTIFACT_DIR)}`),
+      { label: `roadmap scout ${angle.key}`, phase: 'Scope', schema: SCOUT_SCHEMA, agentType: PERSONA.scoper },
+    )
+  })
+}
+
+function capabilityFailure(roadmap) {
+  const capability = roadmap && roadmap.capability
+  if (!capability || capability.run !== true || capability.read !== true || capability.write !== true) {
+    return `bootstrap capability failed: ${capability && capability.evidence || 'structured RUN/READ/WRITE evidence missing'}`
+  }
+  if (roadmap.promptLedgerPath !== `${LEDGER_DIR}/PROMPTS.txt`) {
+    return `prompt ledger was not created at ${LEDGER_DIR}/PROMPTS.txt`
+  }
+  return ''
+}
+
+async function firstRoadmapPass(capabilityInstruction) {
+  return { roadmap: await roadmapAuthorThunk(capabilityInstruction)(), scouts: [] }
+}
+
+async function scopeAndRoadmap() {
+  phase('Scope')
+  const startedAt = Date.now()
+  let roadmap
+  let profile = EXPAND_MISSION ? 'multi-surface' : 'bounded'
+  let lastReasons = []
+  let scouts = []
+  let dispatchedAgents = 0
+  let dependencyRounds = 0
+  const metrics = () => ({
+    profile,
+    agents: dispatchedAgents,
+    rounds: dependencyRounds,
+    elapsedMs: Math.max(0, Date.now() - startedAt),
+  })
+
+  for (let cycle = 1; cycle <= MAX_SCOPE_CYCLES; cycle++) {
+    if (!roadmap) {
+      const capabilityInstruction = capabilityAttested
+        ? `The supervisor supplied a trusted RUN/READ/WRITE attestation. Set capability to run/read/write=true and evidence="trusted supervisor attestation"; do not repeat the scratch probe.`
+        : `Before repository inspection, prove shell execution and file read/write with a disposable scratch file. Set capability from the observed checks; do not claim success on a denied operation.`
+      const provisionalProfile = profile
+      const firstPass = await firstRoadmapPass(capabilityInstruction)
+      dispatchedAgents++
+      dependencyRounds++
+      roadmap = firstPass.roadmap
+      scouts = firstPass.scouts
+      if (canaryTripped(roadmap)) {
+        canaryTrips++
+        return { approved: false, reasons: ['roadmap author canary nonce is missing or mismatched'], metrics: metrics() }
+      }
+      const failure = capabilityFailure(roadmap)
+      if (failure) return { approved: false, capabilityFailed: true, reasons: [failure], metrics: metrics() }
+      profile = roadmap && roadmap.scopeProfile || provisionalProfile
+      if (profile !== provisionalProfile && profile !== 'unusually-large') scouts = []
+    }
+
+    const structuralReasons = validateRoadmapStructure(roadmap, missionPointerBinding())
+    if (roadmap && roadmap.hasTimeEstimates === true) structuralReasons.push('roadmap contains time estimates')
+    if (structuralReasons.length) return { approved: false, reasons: structuralReasons, metrics: metrics() }
+
+    const topology = scopeTopology(profile)
+    if (topology.scouts > scouts.length) {
+      const scoutThunks = roadmapScoutThunks(profile, scouts.length)
+      const additionalScouts = await fanout(scoutThunks, true, 'roadmap-scouts')
+      dispatchedAgents += scoutThunks.length
+      dependencyRounds++
+      scouts = [...scouts, ...additionalScouts]
+    }
+    if (topology.scouts > 0) {
+      const expectedResearch = SCOPING_ANGLES
+        .slice(0, topology.scouts)
+        .map(angle => angle.research)
+      const scoutReasons = validateScoutReports(
+        scouts,
+        topology.scouts,
+        RUN_NONCE,
+        expectedResearch,
+      )
+      if (scoutReasons.length) return { approved: false, reasons: scoutReasons, metrics: metrics() }
+    }
+    if (profile === 'unusually-large') {
+      roadmap = await agent(
+        compactBrief('the roadmap synthesizer',
+          `Update the one canonical roadmap at "${ARTIFACT_DIR}/ROADMAP.md" using only the retained evidence artifacts below. Verify each report's evidenceHash and evidenceBytes before using it. Do not invent evidence for a missing or mismatched scout.\n\nSCOUT EVIDENCE POINTERS:\n${scoutEvidencePointers(scouts, ARTIFACT_DIR)}\n\n${ROADMAP_OUTPUT_CONTRACT}`,
+          `${ARTIFACT_DIR}/ROADMAP.md`),
+        { label: `roadmap synthesis #${cycle}`, phase: 'Scope', schema: ROADMAP_SCHEMA, agentType: PERSONA.synthesizer },
+      )
+      dispatchedAgents++
+      dependencyRounds++
+      if (canaryTripped(roadmap)) {
+        canaryTrips++
+        return { approved: false, reasons: ['roadmap synthesizer canary nonce is missing or mismatched'], metrics: metrics() }
+      }
+    }
+
+    const [review, fresh] = await assureRoadmap(cycle, roadmap, scouts)
+    dispatchedAgents += 2
+    dependencyRounds++
+    if (canaryTripped(review) || canaryTripped(fresh)) {
+      canaryTrips += Number(canaryTripped(review)) + Number(canaryTripped(fresh))
+      lastReasons = [
+        ...(canaryTripped(review) ? ['roadmap reviewer canary nonce is missing or mismatched'] : []),
+        ...(canaryTripped(fresh) ? ['roadmap fresh verifier canary nonce is missing or mismatched'] : []),
+      ]
+    } else if (review.verdict === 'PASS' && fresh.verdict === 'APPROVE') {
+      const roadmapApproval = requireDurablePublication(
+        fresh.publication,
+        publicationExpected(
+          'roadmap-to-implementation',
+          roadmap.roadmapPath,
+          roadmap.roadmapHash,
+          roadmap.roadmapBytes,
+          'ROADMAP-APPROVAL',
+          PERSONA.freshVerifier,
+          'APPROVE',
+          'RUN',
+        ),
+        'roadmap-to-implementation',
+      )
+      return {
+        approved: true,
+        roadmap,
+        roadmapApproval,
+        features: deriveRoadmapFeatures(roadmap).map(feature => ({
+          ...feature,
+          roadmapApproval,
+        })),
+        topology,
+        metrics: metrics(),
+      }
+    } else {
+      lastReasons = [
+        ...((review && review.reasons) || ['roadmap reviewer returned no verdict']),
+        ...((fresh && fresh.reasons) || ['roadmap fresh verifier returned no verdict']),
+      ]
+    }
+    if (cycle === MAX_SCOPE_CYCLES) break
+    roadmap = await agent(
+      compactBrief('the roadmap repair author',
+        `Repair only the named affected items in "${ARTIFACT_DIR}/ROADMAP.md"; retain valid repository evidence.${scouts.length ? ` Verify and reuse the retained scout evidence below; do not invent or replace it.\n\nSCOUT EVIDENCE POINTERS:\n${scoutEvidencePointers(scouts, ARTIFACT_DIR)}` : ''}\n\nReasons:\n- ${lastReasons.join('\n- ')}\n${ROADMAP_OUTPUT_CONTRACT}`,
+        `${ARTIFACT_DIR}/ROADMAP.md`),
+      { label: `roadmap repair #${cycle}`, phase: 'Scope', schema: ROADMAP_SCHEMA, agentType: PERSONA.synthesizer },
+    )
+    dispatchedAgents++
+    dependencyRounds++
+    if (canaryTripped(roadmap)) {
+      canaryTrips++
+      return { approved: false, reasons: ['roadmap repair author canary nonce is missing or mismatched'], metrics: metrics() }
+    }
+  }
+  return { approved: false, reasons: lastReasons, metrics: metrics() }
+}
+
+
+// The harness has no fs binding (it runs in the workflow sandbox), so frontier
+// detection goes through a single read-only probe agent. A resumed run reuses
+// prior -vN artifacts instead of clobbering them: a feature that already froze
+// its plan skips planning; one that already passed verify skips straight to the
+// (cheap, re-confirming) sign-off panel. A missing dir or failed probe yields
+// the all-false default, so a fresh run is byte-for-byte identical to today.
+const RESUME_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: [
+    'planFinalPresent',
+    'verifyPassPresent',
+    'planPublication',
+    'verifyPublication',
+  ],
+  properties: {
+    planFinalPresent: { type: 'boolean', description: 'true only if <id>-plan-final.md exists and is non-empty' },
+    verifyPassPresent: { type: 'boolean', description: 'true only if a <id>-verify-vN.md exists whose verdict is VERIFIED' },
+    partialGatePresent: { type: 'boolean', description: 'true if an <id>-impl-vN.md exists with NO matching <id>-impl-review-vN / <id>-verify-vN - a mid-gate crash; the gate is NOT done and must be re-run as a fresh -v(N+1)' },
+    frozenPlan: { type: 'string', description: 'verbatim contents of <id>-plan-final.md if present, else empty' },
+    planPublication: PUBLICATION_SCHEMA,
+    lastVerifyEvidence: { type: 'string', description: 'the evidence line from the passing verify artifact if present, else empty' },
+    verifyPublication: PUBLICATION_SCHEMA,
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+async function detectFrontier(feature) {
+  const probe = await agent(
+    compactBrief('a resume probe; read the artifact dir, report what is already frozen, change nothing',
+      `Check "${ARTIFACT_DIR}" for this feature's checkpoints. Report planFinalPresent (does a non-empty "${feature.id}-plan-final.md" exist?), verifyPassPresent (does any "${feature.id}-verify-v*.md" exist whose JSON/verdict says VERIFIED?), partialGatePresent (does an "${feature.id}-impl-v*.md" exist with NO matching "-impl-review-v*"/"-verify-v*" - a half-finished gate from a mid-gate crash?), and copy the frozen plan + last passing evidence verbatim if present. Treat ANY lingering "*.tmp" or an empty/unparseable final file as ABSENT (a mid-write crash; never trust a partial). Read only; never write, never re-run a gate.`,
+      null),
+    { label: `${feature.id} resume-probe`, phase: 'Plan', schema: RESUME_SCHEMA, agentType: PERSONA.preflight },
+  )
+  // FIX-09: a NULL probe falls back to a harness-built default. Mark it
+  // LOCAL_SENTINEL so the canary exempts it - a default never went through a
+  // spawn and has no nonce by construction; an unmarked default would false-trip.
+  return probe || {
+    [LOCAL_SENTINEL]: true,
+    planFinalPresent: false,
+    verifyPassPresent: false,
+    partialGatePresent: false,
+    frozenPlan: '',
+    planPublication: null,
+    lastVerifyEvidence: '',
+    verifyPublication: null,
+  }
+}
+
+async function buildUntilVerified(
+  feature,
+  plan,
+  tier,
+  tierCfg,
+  planPublication,
+) {
+  const cfg = tierCfg || TIER_PIPELINE[DEFAULT_TIER]
+  const planPath = `${ARTIFACT_DIR}/${feature.id}-plan-final.md`
+  requireDurablePublication(
+    feature.roadmapApproval,
+    publicationExpected(
+      'roadmap-to-implementation',
+      feature.roadmapPath,
+      feature.roadmapHash,
+      feature.roadmapBytes,
+      'ROADMAP-APPROVAL',
+      PERSONA.freshVerifier,
+      'APPROVE',
+      'RUN',
+    ),
+    'roadmap-to-implementation',
+  )
+  const hasPlanGate =
+    (cfg.plan === true && feature.requiresDetailedPlan === true) ||
+    debugFreshVerifyRequired(feature, cfg)
+  if (hasPlanGate) {
+    if (!planPublication) {
+      throw new TypeError(
+        'BLOCKED plan-to-implementation: approved plan publication is missing',
+      )
+    }
+    requireDurablePublication(
+      planPublication,
+      publicationExpected(
+        'plan-to-implementation',
+        planPublication.artifactPath,
+        planPublication.artifactHash,
+        planPublication.artifactBytes,
+        planPublication.producerGate,
+        planPublication.producerPersona,
+        'APPROVED',
+        feature.id,
+      ),
+      'plan-to-implementation',
+    )
+  }
+  const approvedRoadmapPointer = roadmapPointer({
+    roadmapPath: feature.roadmapPath,
+    roadmapHash: feature.roadmapHash,
+    roadmapBytes: feature.roadmapBytes,
+    runNonce: RUN_NONCE,
+  })
+  const roadmapItemSpec = `${approvedRoadmapPointer}\nROADMAP ITEM: hash-check the candidate, then read ${feature.id}.`
+  let implementationSpec = feature.roadmapPlan === plan && feature.requiresDetailedPlan !== true
+    ? roadmapItemSpec
+    : `${approvedRoadmapPointer}\nFROZEN PLAN: read "${planPath}".`
+  const isCeiling = tier === 'T3' || !tier
+  // The redo trigger: at the T3 ceiling the existing arbiter cadence is honored
+  // verbatim (SMASH at MAX_IMPL_CYCLES, FAIL at MAX_VERIFY_CYCLES); a leaner tier
+  // escalates ONE tier up once its in-tier redo budget is spent (GATES.md
+  // ESCALATION). T3 never escalates - it arbitrates instead.
+  const smashTrigger = isCeiling ? MAX_IMPL_CYCLES : cfg.redoBudget
+  const verifyTrigger = isCeiling ? MAX_VERIFY_CYCLES : cfg.redoBudget
+  const ph = 'Build'
+  let attempts = 0
+  let smashCycles = 0
+  let verifyCycles = 0
+  let lastReasons = []
+
+  while (attempts < IMPL_ATTEMPT_BUDGET) {
+    attempts++
+    assertExecLevel(PERSONA.implementer, `${feature.id} implement #${attempts}`)
+    const impl = await agent(
+      compactBrief('an implementer, execute the approved plan exactly; top-tier code; TDD (failing test first)',
+        `${implementationSpec} Read the implementation contract before editing; report PLAN-CONFLICT rather than silently diverging.\n` +
+        (lastReasons.length ? `Prior attempt was rejected. Address only these named findings:\n- ${lastReasons.join('\n- ')}\n` : '') +
+        `Real systems only, real test runs, real services in a test env, no mocks of the system under test, no mocked DB in integration tests. Coverage >= 95% on changed lines. ` +
+        `Stay within your boundary: ${feature.boundary}. Report structured status, filesChanged, testsWritten, testEvidence, and conflictReason when status is PLAN-CONFLICT. If the item exceeds one owned executor boundary, return SPLIT-REQUEST with splitBoundaries [{boundary, dependsOn}] before editing or publication; do not spawn. A PLAN-CONFLICT or SPLIT-REQUEST must not claim COMPLETE evidence. For COMPLETE, ` +
+        publicationInstruction(
+          'implementation-to-review-verification',
+          `${ARTIFACT_DIR}/${feature.id}-impl-v${attempts}.md`,
+          'G4',
+          PERSONA.implementer,
+          'COMPLETE',
+          feature.id,
+        ) +
+        packPointer(feature),
+        `${ARTIFACT_DIR}/${feature.id}-impl-v${attempts}.md`),
+      { label: `${feature.id} implement #${attempts}`, phase: ph, schema: IMPLEMENT_SCHEMA, agentType: PERSONA.implementer },
+    )
+    recordGateSpawn(feature, 'G4', PERSONA.implementer, featureSpawnLog)
+    if (canaryTripped(impl)) {
+      canaryTrips++
+      lastReasons = ['canary trip: implementer nonce mismatch, re-running G4']
+      continue
+    }
+    if (impl.status === 'PLAN-CONFLICT') {
+      const conflictReason = typeof impl.conflictReason === 'string' && impl.conflictReason.trim() !== ''
+        ? impl.conflictReason.trim()
+        : 'implementer reported PLAN-CONFLICT without a reason'
+      const conflictFeature = { ...feature, requiresDetailedPlan: true }
+      const conflictPlan = await planUntilApproved(conflictFeature, { planLoop: true })
+      if (!conflictPlan.ok) {
+        return { ok: false, partial: true, reasons: [conflictReason, ...(conflictPlan.reasons || [])] }
+      }
+      requireDurablePublication(
+        conflictPlan.planPublication,
+        publicationExpected(
+          'plan-to-implementation',
+          conflictPlan.planPublication.artifactPath,
+          conflictPlan.planPublication.artifactHash,
+          conflictPlan.planPublication.artifactBytes,
+          conflictPlan.planPublication.producerGate,
+          conflictPlan.planPublication.producerPersona,
+          'APPROVED',
+          feature.id,
+        ),
+        'plan-to-implementation',
+      )
+      implementationSpec = `${approvedRoadmapPointer}\nPLAN-CONFLICT RESOLUTION: the revised G1 plan below supersedes the roadmap item where they conflict.\n${conflictPlan.plan}`
+      lastReasons = [`PLAN-CONFLICT resolved through G1: ${conflictReason}`]
+      continue
+    }
+
+    if (impl.status === 'SPLIT-REQUEST') {
+      const splitBoundaries = Array.isArray(impl.splitBoundaries)
+        ? impl.splitBoundaries.filter(item =>
+            item &&
+            typeof item.boundary === 'string' &&
+            item.boundary.trim() !== '' &&
+            Array.isArray(item.dependsOn),
+          )
+        : []
+      if (splitBoundaries.length < 2) {
+        return {
+          ok: false,
+          partial: true,
+          splitRequest: true,
+          reasons: ['SPLIT-REQUEST must name at least two disjoint implementation boundaries and their dependencies'],
+        }
+      }
+      return {
+        ok: false,
+        partial: true,
+        splitRequest: true,
+        reasons: splitBoundaries.map(item =>
+          `split boundary ${item.boundary}; dependsOn=${item.dependsOn.join(',') || 'none'}`,
+        ),
+      }
+    }
+
+    if (!impl.publication) {
+      lastReasons = [
+        'implementation publication receipt is missing',
+      ]
+      continue
+    }
+    requireDurablePublication(
+      impl.publication,
+      publicationExpected(
+        'implementation-to-review-verification',
+        `${ARTIFACT_DIR}/${feature.id}-impl-v${attempts}.md`,
+        impl.publication.artifactHash,
+        impl.publication.artifactBytes,
+        'G4',
+        PERSONA.implementer,
+        'COMPLETE',
+        feature.id,
+      ),
+      'implementation-to-review-verification',
+    )
+
+    // EDIT C (gate-DAG {G5‖G6}): G5 impl-review and G6 verify are INDEPENDENT
+    // (both consume the G4 diff + plan; review reads, verify runs the tests;
+    // neither reads the other's output), so they dispatch CONCURRENTLY via the
+    // existing fanout helper - concurrent in every mode, with TOKENSAVER bounded
+    // by its six-live wave cap. The implement≠verify keystone guard
+    // (assertDistinctImplementVerify) is called BEFORE the G6 thunk is built -
+    // UNCHANGED. NO short-circuit/cancel (§3(a) REJECT): both siblings run to
+    // completion and recordGateSpawn fires for BOTH even when G5 SMASHes; the
+    // loser is discarded at the join (G5-SMASH precedence).
+    const isDebug = feature.tag === 'debug'
+    const g5thunk = async () => agent(
+      compactBrief('an implementation reviewer, you did NOT write this code',
+        `${roadmapItemSpec}\n${implementationSpec}\nIMPLEMENTATION ARTIFACT: read "${ARTIFACT_DIR}/${feature.id}-impl-v${attempts}.md" and verify every claim against the real diff.\n` +
+        `${diffScope(feature)} Verify complete coverage against the exact mission ledger and implementation contract, with file:line evidence. A claim with no backing diff is an automatic SMASH. Flag broken code, weak tests, or scope creep. ` +
+        (isCeiling ? '' : `If this task is genuinely LARGER/RISKIER than its tier (${tier}: touches >1 subsystem, needs a real design decision, a hidden cross-cutting failure surfaced), set outOfScope=true so it climbs one tier; a fixable local defect is an ordinary SMASH, not out-of-scope. `) +
+        `Return SMASH with numbered file:line reasons, or PASS only if every line is clean.` +
+        packPointer(feature),
+        `${ARTIFACT_DIR}/${feature.id}-impl-review-v${attempts}.md`),
+      { label: `${feature.id} impl-review #${attempts}`, phase: ph, schema: REVIEW_SCHEMA, agentType: PERSONA.reviewer },
+    )
+    // The implement≠verify keystone: asserted BEFORE the G6 thunk is constructed.
+    assertExecLevel(PERSONA.verifier, `${feature.id} verify #${attempts}`)
+    assertDistinctImplementVerify(PERSONA.implementer, PERSONA.verifier, tier, `${feature.id} verify #${attempts}`)
+    const g6thunk = async () => agent(
+      compactBrief('a verifier, prove it works by RUNNING it, not by reading it',
+        `WHAT TO VERIFY: ${feature.name} (${feature.boundary}).\n` +
+        `${roadmapItemSpec}\n${implementationSpec} Map every claim to the exact mission ledger and this implementation contract.\n` +
+        `IMPLEMENTATION ARTIFACT: read "${ARTIFACT_DIR}/${feature.id}-impl-v${attempts}.md" but independently reproduce its claims.\n` +
+        `GROUNDED BEFORE/AFTER PROTOCOL (mandatory - DONE is recomputed from these, never from your prose verdict):\n` +
+        (isDebug
+          ? `1. RED BASELINE: run the issue's reproduction case against the CURRENT (pre-fix or stashed-fix) code and capture the VERBATIM failing output. A debug fix with no proven red baseline is INVALID - set reproWasRed=false and verdict FAILED if you cannot show the bug failing first.\n`
+          : `1. BASELINE: establish the target behavior's current state with a real run; set reproWasRed accordingly (true only if there is a genuine failing case you captured).\n`) +
+        `2. REGRESSION BASELINE: run the FULL pre-existing test file(s) of every TOUCHED module AND its direct dependents; record which were GREEN before the change. Report the exact command in testCommand.\n` +
+        `3. AFTER THE FIX: re-run both. The repro/target must now be GREEN (set reproNowGreen). Re-run the same pre-existing tests; ANY test that was green before and is red now is a regression - list its id in preExistingRegressions. A green→red flip is a hard FAILED, never acceptable.\n` +
+        `Also confirm coverage >= 95% on changed lines with the coverage tool, and try to break it with bad/empty input. Put the verbatim before/after command output in evidence.\n` +
+        `Report runnerKind, runnerInvocation (the exact runner command), collectedTestCount (the "collected N items" count), and assertingTestNodeId (the specific failing->passing test node).\n` +
+        `A model-authored python -c "...print..." MVCE re-run is NOT acceptable evidence; on a debug verify, no real test-runner invocation, zero collected tests, or no named asserting test is recomputed to FAILED.\n` +
+        `On a debug verify, prove the authored asserting test RED on a git-stashed clean tree (\`git stash\` -> run -> assert red -> \`git stash pop\`) and report redBaselineStashGated; reading and RUNNING the repo's own existing tests and authoring a scratch repro are always permitted even when the mission forbids EDITING the repo's test files.\n` +
+        `Report inputClassesCovered (distinct input forms the repro+fix exercise) and branchCoveragePercent (branch coverage on changed lines); on a debug verify, fewer than 2 input classes or branch coverage below the branch floor is fed back to G4 to raise.\n` +
+        (isCeiling ? '' : `If verifying reveals the task is LARGER/RISKIER than its tier (${tier}: a hidden cross-cutting failure, a real design decision), set outOfScope=true so it climbs one tier; a plain failing test is an ordinary FAILED. `) +
+        `Return VERIFIED only when reproNowGreen=true AND preExistingRegressions is empty${isDebug ? ' AND reproWasRed=true' : ''}; otherwise FAILED with the failing evidence. The harness RECOMPUTES the verdict from these fields - a VERIFIED that contradicts them is overridden to FAILED. If VERIFIED, ` +
+        publicationInstruction(
+          'verification-to-signoff',
+          `${ARTIFACT_DIR}/${feature.id}-verify-v${attempts}.md`,
+          'G6',
+          PERSONA.verifier,
+          'VERIFIED',
+          feature.id,
+        ) + '\n' +
+        packPointer(feature),
+        `${ARTIFACT_DIR}/${feature.id}-verify-v${attempts}.md`),
+      { label: `${feature.id} verify #${attempts}`, phase: ph, schema: VERIFY_SCHEMA, agentType: PERSONA.verifier },
+    )
+    const [review, verify] = await fanout([g5thunk, g6thunk], MODE_CFG.parallelFeatures)
+    recordGateSpawn(feature, 'G5', PERSONA.reviewer, featureSpawnLog)
+    recordGateSpawn(feature, 'G6', PERSONA.verifier, featureSpawnLog)
+
+    if (review && Array.isArray(review.suggestions)) {
+      for (const s of review.suggestions) allSuggestions.push(`${feature.id} (${ph}): ${s}`)
+    }
+    if (canaryTripped(review)) {
+      canaryTrips++
+      log(`CANARY: nonce mismatch at ${feature.id} impl-review #${attempts}; treating verdict as untrusted (SMASH)`)
+      lastReasons = ['canary trip: brief nonce mismatch, re-running the impl gate']
+      continue
+    }
+
+    // G5-SMASH precedence: a not-PASS impl-review loops the implementer and the
+    // concurrently-run G6 verify result is DISCARDED at the join (never consumed
+    // downstream - no advance to G7). Both siblings still ran to completion.
+    if (!review || review.verdict !== 'PASS') {
+      smashCycles++
+      lastReasons = (review && review.reasons) || ['reviewer returned no usable verdict']
+      // OUT-OF-SCOPE: a worker flagged the task is bigger than its tier; climb now.
+      if (!isCeiling && review && review.outOfScope === true) {
+        log(`${feature.id}: impl-review returned OUT-OF-SCOPE at ${tier}; escalating one tier up`)
+        return { ok: false, partial: true, escalate: true, reasons: [`OUT-OF-SCOPE at ${tier}: ${lastReasons.join('; ')}`] }
+      }
+      if (smashCycles >= smashTrigger) {
+        if (!isCeiling) {
+          log(`${feature.id}: impl-review SMASHED ${smashCycles}x (> ${tier} redo budget ${cfg.redoBudget}); escalating one tier up`)
+          return { ok: false, partial: true, escalate: true, reasons: lastReasons }
+        }
+        const ruling = await arbiter(`Implementation of ${feature.id} SMASHED ${smashCycles}x (total attempts ${attempts}/${IMPL_ATTEMPT_BUDGET}). Reasons:\n- ${lastReasons.join('\n- ')}\nDecide: accept as partial, or keep iterating?`, ph)
+        if (!ruling.proceed) return { ok: false, partial: true, reasons: lastReasons, arbiter: ruling.decision }
+        smashCycles = 0  // arbiter granted more, but the global IMPL_ATTEMPT_BUDGET still bounds the loop
+      }
+      continue
+    }
+
+    // G5 PASSed - JOIN now consumes the concurrently-run G6 verify result.
+
+    if (canaryTripped(verify)) {
+      canaryTrips++
+      log(`CANARY: nonce mismatch at ${feature.id} verify #${attempts}; treating verdict as FAILED`)
+      verifyCycles++
+      lastReasons = ['canary trip: brief nonce mismatch, re-verifying with a fresh brief']
+      if (verifyCycles >= verifyTrigger) {
+        if (!isCeiling) return { ok: false, partial: true, escalate: true, reasons: lastReasons }
+        const ruling = await arbiter(`Verification of ${feature.id} canary-tripped ${verifyCycles}x (total attempts ${attempts}/${IMPL_ATTEMPT_BUDGET}). Decide: accept as partial, or iterate once more?`, ph)
+        if (!ruling.proceed) return { ok: false, partial: true, reasons: lastReasons, arbiter: ruling.decision }
+        verifyCycles = 0
+      }
+      continue
+    }
+
+    // GROUNDED-VERIFY RECOMPUTE (the anti-coverage-theater gate). VERIFIED is
+    // NOT trusted from the verdict string. The fix must clear three real-test
+    // facts: a debug fix proved a RED baseline (reproWasRed), the repro/target
+    // is now GREEN (reproNowGreen), and there are ZERO pre-existing regressions
+    // (a green->red flip in a touched module or its dependents - the exact
+    // astropy-7606 failure the official grader caught as a PASS_TO_PASS break).
+    // Any breach OVERRIDES VERIFIED -> FAILED, which loops back to G4 like any
+    // other failing verify; a regressed feature thus can never reach ok:true and
+    // therefore can never be DONE (the feature-status path is the DONE gate).
+    if (verify && verify.verdict === 'VERIFIED') {
+      const groundedReasons = groundedVerifyReasons(verify, isDebug)
+      if (applyGroundedOverride(verify, groundedReasons)) {
+        log(`${feature.id} verify #${attempts}: GROUNDED-VERIFY override VERIFIED->FAILED - ${groundedReasons.join('; ')}`)
+      }
+    }
+
+    // SOFT rigor floors (FIX-03/FIX-15): a debug verify still claiming VERIFIED
+    // after the HARD override is checked against the advisory floors. A breach is
+    // fed back to G4 exactly like the COVERAGE_FLOOR below - arbitrable, verdict
+    // NOT mutated, NO `GROUNDED-VERIFY override` log (that string is reserved for
+    // the HARD rules). A HARD breach already flipped the verdict to FAILED above,
+    // so this block is skipped on a hard-failed verify (hard wins, soft never masks).
+    if (verify && verify.verdict === 'VERIFIED') {
+      const softReasons = softFloorReasons(verify, isDebug)
+      if (softReasons.length) {
+        verifyCycles++
+        lastReasons = softReasons
+        if (verifyCycles >= verifyTrigger) {
+          if (!isCeiling) return { ok: false, partial: true, escalate: true, reasons: lastReasons }
+          const ruling = await arbiter(`Verification of ${feature.id} reported VERIFIED but a soft rigor floor was breached, ${verifyCycles}x (total attempts ${attempts}/${IMPL_ATTEMPT_BUDGET}):\n- ${lastReasons.join('\n- ')}\nDecide: accept as partial, or iterate once more?`, ph)
+          if (!ruling.proceed) return { ok: false, partial: true, reasons: lastReasons, arbiter: ruling.decision }
+          verifyCycles = 0
+        }
+        continue
+      }
+    }
+
+    if (verify && verify.verdict === 'VERIFIED') {
+      // VERIFIED verdict that reports a number below COVERAGE_FLOOR is treated
+      // as a verification FAILURE (the floor is the mission's, not the model's).
+      const cov = verify.coveragePercent
+      const coverageMissing =
+        typeof cov !== 'number' || !Number.isFinite(cov)
+      if (coverageMissing || cov < COVERAGE_FLOOR) {
+        verifyCycles++
+        lastReasons = [coverageMissing
+          ? `coveragePercent is missing or non-finite; report measured changed-line coverage >= ${COVERAGE_FLOOR}% and re-verify`
+          : `coverage ${cov}% is below the ${COVERAGE_FLOOR}% floor; raise coverage on changed lines and re-verify`]
+        if (verifyCycles >= verifyTrigger) {
+          if (!isCeiling) return { ok: false, partial: true, escalate: true, reasons: lastReasons }
+          const coverageLabel = coverageMissing ? 'missing/non-finite' : `${cov}%`
+          const ruling = await arbiter(`Verification of ${feature.id} reported VERIFIED but coverage is ${coverageLabel} (required >= ${COVERAGE_FLOOR}%), ${verifyCycles}x (total attempts ${attempts}/${IMPL_ATTEMPT_BUDGET}). The floor and measured coverage field are not negotiable. Decide: accept as partial, or iterate once more?`, ph)
+          if (!ruling.proceed) return { ok: false, partial: true, reasons: lastReasons, arbiter: ruling.decision }
+          verifyCycles = 0
+        }
+        continue
+      }
+      if (!verify.publication) {
+        lastReasons = [
+          'verification publication receipt is missing',
+        ]
+        continue
+      }
+      const verifyPublication = requireDurablePublication(
+        verify.publication,
+        publicationExpected(
+          'verification-to-signoff',
+          `${ARTIFACT_DIR}/${feature.id}-verify-v${attempts}.md`,
+          verify.publication.artifactHash,
+          verify.publication.artifactBytes,
+          'G6',
+          PERSONA.verifier,
+          'VERIFIED',
+          feature.id,
+        ),
+        'verification-to-signoff',
+      )
+      return {
+        ok: true,
+        evidence: verify.evidence,
+        coverage: cov,
+        verifyPublication,
+      }
+    }
+    // OUT-OF-SCOPE at verify: the task is bigger than its tier; climb now.
+    if (!isCeiling && verify && verify.outOfScope === true) {
+      log(`${feature.id}: verify returned OUT-OF-SCOPE at ${tier}; escalating one tier up`)
+      return { ok: false, partial: true, escalate: true, reasons: [`OUT-OF-SCOPE at ${tier}: ${((verify && verify.reasons) || ['verify out of scope']).join('; ')}`] }
+    }
+    verifyCycles++
+    lastReasons = (verify && verify.reasons) || ['verification failed without stated reason']
+    if (verifyCycles >= verifyTrigger) {
+      if (!isCeiling) {
+        log(`${feature.id}: verify FAILED ${verifyCycles}x (> ${tier} redo budget ${cfg.redoBudget}); escalating one tier up`)
+        return { ok: false, partial: true, escalate: true, reasons: lastReasons }
+      }
+      const ruling = await arbiter(`Verification of ${feature.id} FAILED ${verifyCycles}x (total attempts ${attempts}/${IMPL_ATTEMPT_BUDGET}). Evidence:\n${verify ? verify.evidence : 'none'}\nDecide: accept as partial, or iterate once more?`, ph)
+      if (!ruling.proceed) return { ok: false, partial: true, reasons: lastReasons, arbiter: ruling.decision }
+      verifyCycles = 0
+    }
+  }
+
+  return { ok: false, partial: true, reasons: lastReasons.length ? lastReasons : ['implement attempt budget exhausted'] }
+}
+
+async function signOffPanel(feature, plan, buildResult, panelSize) {
+  requireDurablePublication(
+    buildResult && buildResult.verifyPublication,
+    publicationExpected(
+      'verification-to-signoff',
+      buildResult && buildResult.verifyPublication &&
+        buildResult.verifyPublication.artifactPath,
+      buildResult && buildResult.verifyPublication &&
+        buildResult.verifyPublication.artifactHash,
+      buildResult && buildResult.verifyPublication &&
+        buildResult.verifyPublication.artifactBytes,
+      'G6',
+      PERSONA.verifier,
+      'VERIFIED',
+      feature.id,
+    ),
+    'verification-to-signoff',
+  )
+  const size = Number.isInteger(panelSize) && panelSize > 0 ? panelSize : PANEL_SIZE
+  assertExecLevel(PERSONA.juror, `${feature.id} sign-off panel`)
+  const judges = await fanout(
+    Array.from({ length: size }, (_unused, i) => async () => {
+      const verdict = await agent(
+        compactBrief(`an independent sign-off reviewer (juror ${i + 1}), you have seen NONE of the work that produced this`,
+          `ROADMAP ITEM: read ${feature.id} in "${ARTIFACT_DIR}/ROADMAP.md".\n` +
+          `FROZEN PLAN: read "${ARTIFACT_DIR}/${feature.id}-plan-final.md" when it exists.\n` +
+          `IMPLEMENTATION AND VERIFICATION EVIDENCE: inspect the substantive ${feature.id} artifacts under "${ARTIFACT_DIR}/" and run any check needed; do not inherit another gate's verdict.\n` +
+          `${diffScope(feature)} Judge against the exact mission ledger first and the roadmap/plan second, with the project's coding-style and testing rules as the bar. Look for anything that hurts a real user or loses data in production. ` +
+          `Return PASS only if you would ship this and put your name on it; otherwise FAIL with numbered evidence-backed reasons. Approach a distinct correctness, security, or real-runtime angle.`,
+          `${ARTIFACT_DIR}/${feature.id}-signoff-j${i + 1}.md`),
+        { label: `${feature.id} signoff j${i + 1}`, phase: 'Sign-off', schema: PANEL_SCHEMA, agentType: PERSONA.juror },
+      )
+      recordGateSpawn(feature, 'G7', PERSONA.juror, featureSpawnLog)
+      return verdict
+    }),
+    MODE_CFG.parallelPanel,
+  )
+  const valid = judges.filter(Boolean)
+  for (const j of valid) {
+    if (canaryTripped(j)) {
+      canaryTrips++
+      log(`CANARY: nonce mismatch at ${feature.id} sign-off juror; forcing FAIL`)
+      j.verdict = 'FAIL'
+      j.reasons = [...(j.reasons || []), 'canary trip: brief nonce mismatch, juror verdict untrusted']
+    }
+  }
+  // PANEL-SIZE HARD GUARD: a unanimous PASS requires the FULL panel to convene.
+  // A missing/null juror result (a juror that did not return a valid verdict for
+  // ANY reason) shrinks the panel below its required size; that is an UNSIGNED-OFF
+  // juror, never a pass and never arbitrable into DONE. A short panel is hard
+  // non-unanimous, so finishFromBuild can never mint DONE over a panel that did
+  // not fully convene.
+  const panelShort = valid.length < size
+  if (panelShort) {
+    log(`${feature.id}: sign-off panel SHORT (${valid.length}/${size} jurors convened) - hard non-arbitrable, cannot reach DONE`)
+  }
+  const unanimous = valid.length === size && valid.every(j => j.verdict === 'PASS')
+  const fails = valid.filter(j => j.verdict === 'FAIL').flatMap(j => j.reasons || [])
+  return { unanimous, fails, jurorVerdicts: valid.map(j => j.verdict), panelShort, panelSize: size }
+}
+
+// ----- one feature, full pipeline G1..G7 --------------------------------
+// runFeature is the thin OUTER funnel (B1): EVERY feature outcome - fresh,
+// resumed, escalated, panel, arbiter-minted - returns through this one wrapper,
+// where sealDoneProvenance reconciles a DONE against the gates that really
+// spawned this session before the result may escape. runFeatureInner holds the
+// unchanged pipeline body (plus the three markResumed calls on the resume
+// branches). A FUTURE new DONE return inside runFeatureInner is sealed for free.
+async function runFeature(feature) {
+  const result = await runFeatureInner(feature)
+  const tierCfg = TIER_PIPELINE[result && result.tier] || TIER_PIPELINE[DEFAULT_TIER]
+  const sealed = sealDoneProvenance(
+    feature,
+    result,
+    tierCfg,
+    featureSpawnLog,
+  )
+  if (!sealed || sealed.status !== 'DONE') return sealed
+
+  const verification = sealed.verifyPublication
+  if (!verification) {
+    throw new TypeError(
+      `BLOCKED feature terminal publication: ${feature.id} ` +
+      `has no durable verification receipt`,
+    )
+  }
+  sealed.terminalPublication = requireDurablePublication(
+    verification,
+    publicationExpected(
+      'verification-to-signoff',
+      verification.artifactPath,
+      verification.artifactHash,
+      verification.artifactBytes,
+      'G6',
+      PERSONA.verifier,
+      'VERIFIED',
+      feature.id,
+    ),
+    'feature terminal publication',
+  )
+  return sealed
+}
+
+async function runFeatureInner(feature) {
+  // The TIER picks how many gates run (proportionality fix). An explicit
+  // recognized tier is honored; an omitted/unknown one resolves to the T3
+  // ceiling. A feature ESCALATES one tier up (re-running here) when its in-tier
+  // redo budget is spent or a worker returns OUT-OF-SCOPE; de-escalation never
+  // happens - a climbed feature keeps its highest tier for the rest of the run.
+  const tier = resolveTier(feature)
+  const baseTierCfg = TIER_PIPELINE[tier]
+
+  // FRAMEWORK HARD GATE (F-FRAMEWORK): resolve the feature's framework leaf ONCE at
+  // dispatch before any build gate. Absent/unknown -> INVALID-DISPATCH, repaired by
+  // the narrow generator (a category-derived known leaf, logged). The resolved leaf
+  // rides feature.framework into the result -> summary -> the SCRIBE FEATURE-META row
+  // (framework=<leaf>), the token the ledger frameworkTierFindings rule attests.
+  const framework = resolveFramework(feature)
+  // The `apply` leaf's GATE PATH is APPLY -> DIFF-REVIEW -> VERIFY-GREEN + GOAL-CHECK
+  // floor: it SKIPS G1 PLAN, G3 FRESH-VERIFY, and G7 SIGN-OFF regardless of tier.
+  // NARROW GATE-PATH INTERPRETATION (documented above): override the tier flags to
+  // plan/planLoop off + panelSize 0, keeping G5 DIFF-REVIEW (implReview) and G6
+  // VERIFY-GREEN (verify). FULL per-leaf GATE-PATH parsing is deferred.
+  const tierCfg = framework === APPLY_FRAMEWORK
+    ? { ...baseTierCfg, plan: false, planLoop: false, panelSize: 0, freshVerifyDebug: false }
+    : baseTierCfg
+
+  // Budget guard (iron rule 9): if the token target is nearly spent, defer
+  // this feature instead of opening a fresh ~40-agent pipeline. With the
+  // concurrency cap, later features in a wide wave hit this as budget drains.
+  if (!canSpawnNewWork()) {
+    return { feature, status: 'DEFERRED', reasons: ['token budget guard, deferred before planning'] }
+  }
+
+  // RESUME frontier probe: skip work that a prior session already froze, so we
+  // reuse prior -vN artifacts instead of clobbering them. The probe's own claim
+  // is canary-checked first: a tainted/hallucinated probe (mismatched nonce)
+  // could otherwise skip the whole build/verify pipeline straight to sign-off,
+  // so on a trip we treat the probe as untrusted and fall through to the normal
+  // pipeline (the re-verification duty GATES.md demands).
+  // COST GUARD: the probe only has anything to find on a SUPERVISOR RELAUNCH.
+  // On a fresh run nothing is frozen yet, so spawning a probe per feature is one
+  // wasted agent each - the dominant fixed tax on the small SWE-bench tasks that
+  // never resume. Skip it unless IS_RESUME; a fresh run gets the all-false
+  // default and goes straight to planning/building.
+  // FIX-09: the fresh-run frontier is a harness-built default (no spawn, no
+  // nonce). Mark it LOCAL_SENTINEL so canaryTripped exempts it - without the
+  // marker the inverted predicate would false-trip canaryTrips on every fresh run.
+  const frontier = IS_RESUME
+    ? await detectFrontier(feature)
+    : {
+        [LOCAL_SENTINEL]: true,
+        planFinalPresent: false,
+        verifyPassPresent: false,
+        partialGatePresent: false,
+        frozenPlan: '',
+        planPublication: null,
+        lastVerifyEvidence: '',
+        verifyPublication: null,
+      }
+  const frontierTrusted = !canaryTripped(frontier)
+  if (!frontierTrusted) {
+    canaryTrips++
+    log(`CANARY: nonce mismatch at ${feature.id} resume-probe; distrusting frontier detection, running the full pipeline`)
+  }
+  // Mid-gate-crash rule (F6): an impl artifact with no matching review/verify is
+  // a half-finished gate. It is NOT done; never take the verify/plan skip
+  // shortcut over it - re-run build/verify, which writes a fresh -v(N+1) beside
+  // the survivors, never clobbering them.
+  const midGateCrash = frontierTrusted && frontier.partialGatePresent === true && !frontier.verifyPassPresent
+  if (midGateCrash) {
+    markResumed(feature, featureSpawnLog)
+    log(`${feature.id}: resume - a half-finished gate (impl present, no verify) detected; re-running build/verify as a fresh -vN (never trusting a started-but-unconfirmed gate)`)
+    const resolved = frontier.frozenPlan
+      ? {
+          plan: frontier.frozenPlan,
+          planPublication: frontier.planPublication,
+        }
+      : await resolvePlan(feature, tier, tierCfg)
+    const plan = resolved.plan
+    // RESUME-BYPASS fix: a debug feature resumed past plan-freeze MUST still pass
+    // DEPTH-LOCK before its fix is re-built - never seal DONE with the gate skipped.
+    const lock = await lockDebugPlan(feature, plan)
+    if (!lock.ok) return { feature, status: 'BLOCKED_AT_PLAN', tier, reasons: lock.reasons, depthMiss: true, plan }
+    return finishFromBuild(
+      feature,
+      plan,
+      await buildUntilVerified(
+        feature,
+        plan,
+        tier,
+        tierCfg,
+        resolved.planPublication,
+      ),
+      tier,
+      tierCfg,
+      resolved.planPublication,
+    )
+  }
+  if (frontierTrusted && frontier.verifyPassPresent && frontier.frozenPlan) {
+    markResumed(feature, featureSpawnLog)
+    log(`${feature.id}: resume - verify already passed in a prior session, re-confirming via sign-off only`)
+    // RESUME-BYPASS fix: even a verify-passed debug resume must carry a DEPTH-LOCK -
+    // re-run the gate so a debug feature cannot reach DONE with DEPTH-LOCK skipped.
+    const lock = await lockDebugPlan(feature, frontier.frozenPlan)
+    if (!lock.ok) return { feature, status: 'BLOCKED_AT_PLAN', tier, reasons: lock.reasons, depthMiss: true, plan: frontier.frozenPlan }
+    const resumedBuild = {
+      ok: true,
+      evidence: frontier.lastVerifyEvidence,
+      coverage: undefined,
+      verifyPublication: frontier.verifyPublication,
+    }
+    // T0/T1 carry no sign-off panel; a resumed verified feature at those tiers is
+    // DONE without re-convening a panel that never ran (proportionality).
+    if (tierCfg.panelSize <= 0) {
+      return { feature, status: 'DONE', tier, coverage: undefined, evidence: resumedBuild.evidence, plan: frontier.frozenPlan, verifyPublication: resumedBuild.verifyPublication, jurorVerdicts: [], panelFails: [] }
+    }
+    const panel = await signOffPanel(feature, frontier.frozenPlan, resumedBuild, tierCfg.panelSize)
+    return {
+      feature, tier,
+      status: panel.unanimous ? 'DONE' : 'PARTIAL',
+      coverage: resumedBuild.coverage, evidence: resumedBuild.evidence, plan: frontier.frozenPlan,
+      verifyPublication: resumedBuild.verifyPublication,
+      jurorVerdicts: panel.jurorVerdicts, panelFails: panel.unanimous ? [] : panel.fails,
+    }
+  }
+  if (frontierTrusted && frontier.planFinalPresent && frontier.frozenPlan) {
+    markResumed(feature, featureSpawnLog)
+    log(`${feature.id}: resume - plan already frozen in a prior session, skipping to build`)
+    // RESUME-BYPASS fix: a plan-frozen debug resume re-enters DEPTH-LOCK before build.
+    const lock = await lockDebugPlan(feature, frontier.frozenPlan)
+    if (!lock.ok) return { feature, status: 'BLOCKED_AT_PLAN', tier, reasons: lock.reasons, depthMiss: true, plan: frontier.frozenPlan }
+    return finishFromBuild(
+      feature,
+      frontier.frozenPlan,
+      await buildUntilVerified(
+        feature,
+        frontier.frozenPlan,
+        tier,
+        tierCfg,
+        frontier.planPublication,
+      ),
+      tier,
+      tierCfg,
+      frontier.planPublication,
+    )
+  }
+
+  log(`${feature.id} (${feature.category}${feature.tag ? `/${feature.tag}` : ''}, ${tier}), ${feature.name}: ${tierCfg.plan ? 'planning' : (debugFreshVerifyRequired(feature, tierCfg) ? 'debug plan + fresh-verify (freshVerifyDebug)' : 'building (no plan phase at this tier)')}`)
+  const planResult = await resolvePlan(feature, tier, tierCfg)
+  if (!planResult.ok) {
+    return { feature, status: 'BLOCKED_AT_PLAN', tier, reasons: planResult.reasons, depthMiss: planResult.depthMiss === true, plan: planResult.plan }
+  }
+
+  log(`${feature.id}: building`)
+  const build = await buildUntilVerified(
+    feature,
+    planResult.plan,
+    tier,
+    tierCfg,
+    planResult.planPublication,
+  )
+  return finishFromBuild(
+    feature,
+    planResult.plan,
+    build,
+    tier,
+    tierCfg,
+    planResult.planPublication,
+  )
+}
+
+// Shared tail: take a build result through the (tier-sized) sign-off panel (and
+// one remediation cycle on a split) to a final feature status. A build that
+// flagged ESCALATE climbs ONE tier and re-runs the whole feature there.
+async function finishFromBuild(
+  feature,
+  plan,
+  build,
+  tier,
+  tierCfg,
+  planPublication,
+) {
+  const t = tier || DEFAULT_TIER
+  const cfg = tierCfg || TIER_PIPELINE[DEFAULT_TIER]
+
+  // ESCALATION (GATES.md): a leaner tier whose redo budget was spent (or whose
+  // worker returned OUT-OF-SCOPE) climbs ONE tier and re-runs the feature there
+  // with the same cryptographically bound mission pointer. T3 is the ceiling and never escalates.
+  if (build.escalate && t !== 'T3') {
+    const climbed = nextTier(t)
+    log(`${feature.id}: ESCALATE ${t} -> ${climbed} (${(build.reasons || []).join('; ') || 'tier redo budget spent'}); re-running at the higher tier`)
+    return runFeature({ ...feature, tier: climbed })
+  }
+
+  if (!build.ok) {
+    return { feature, status: 'PARTIAL', tier: t, reasons: build.reasons, arbiter: build.arbiter, plan }
+  }
+
+  requireDurablePublication(
+    build.verifyPublication,
+    publicationExpected(
+      'verification-to-signoff',
+      build.verifyPublication &&
+        build.verifyPublication.artifactPath,
+      build.verifyPublication &&
+        build.verifyPublication.artifactHash,
+      build.verifyPublication &&
+        build.verifyPublication.artifactBytes,
+      'G6',
+      PERSONA.verifier,
+      'VERIFIED',
+      feature.id,
+    ),
+    'verification-to-signoff',
+  )
+
+  // T0/T1: no sign-off panel (GATES.md tier table). The IMPL-REVIEW + VERIFY
+  // gates already policed the work; the run-level GOAL-CHECK is the final
+  // default-FAIL backstop. A verified build at these tiers is DONE.
+  if (cfg.panelSize <= 0) {
+    return { feature, status: 'DONE', tier: t, coverage: build.coverage, evidence: build.evidence, plan, verifyPublication: build.verifyPublication, jurorVerdicts: [], panelFails: [] }
+  }
+
+  log(`${feature.id}: sign-off panel (${cfg.panelSize} juror${cfg.panelSize === 1 ? '' : 's'})`)
+  let panel = await signOffPanel(feature, plan, build, cfg.panelSize)
+  if (!panel.unanimous) {
+    log(`${feature.id}: panel split (${panel.jurorVerdicts.join('/')}), one remediation cycle`)
+    const remed = await buildUntilVerified(
+      { ...feature, name: `${feature.name} (panel remediation: ${panel.fails.join('; ')})` },
+      plan,
+      t,
+      cfg,
+      planPublication,
+    )
+    if (remed.ok) {
+      build.evidence = remed.evidence
+      build.coverage = remed.coverage
+      build.verifyPublication = remed.verifyPublication
+      panel = await signOffPanel(feature, plan, build, cfg.panelSize)
+    }
+    if (!panel.unanimous) {
+      // Pillar B M1/N2: a persistent split is normally an arbiter call, BUT a
+      // FAIL that names a P0/P1 blocker is NOT arbitrable into DONE. The arbiter
+      // may decide HOW to log it, never that a blocker is acceptable to ship.
+      // A SHORT panel (a juror result missing/null) is likewise NON-ARBITRABLE:
+      // an unsigned-off juror is never shippable, so a sub-panel-size panel can
+      // only be logged PARTIAL - the arbiter cannot mint DONE over it.
+      const namesBlocker = panelNamesBlocker(panel.fails)
+      const panelShort = panel.panelShort === true
+      const hardBlock = namesBlocker || panelShort
+      const ruling = await arbiter(`Sign-off panel for ${feature.id} still split after remediation (${panel.jurorVerdicts.join('/')}). FAIL reasons:\n- ${panel.fails.join('\n- ')}\n${namesBlocker ? 'NOTE: a FAIL names a P0/P1 blocker; an open blocker is NOT shippable, so this can only be logged PARTIAL, never DONE. ' : ''}${panelShort ? `NOTE: only ${panel.jurorVerdicts.length}/${panel.panelSize} jurors convened (a juror result is missing); an incompletely-convened panel is NOT a valid unanimous sign-off, so this can only be logged PARTIAL, never DONE. ` : ''}Decide: ${hardBlock ? 'log partial (the only valid option over an open blocker / incomplete panel).' : 'ship as-is, or log partial?'}`, 'Sign-off')
+      return {
+        feature, tier: t,
+        status: (ruling.proceed && !hardBlock) ? 'DONE' : 'PARTIAL',
+        coverage: build.coverage, evidence: build.evidence, plan,
+        verifyPublication: build.verifyPublication,
+        jurorVerdicts: panel.jurorVerdicts, panelFails: panel.fails, arbiter: ruling.decision,
+        blockerNamed: namesBlocker, panelShort,
+      }
+    }
+  }
+
+  return {
+    feature, tier: t,
+    status: 'DONE',
+    coverage: build.coverage,
+    evidence: build.evidence,
+    plan,
+    verifyPublication: build.verifyPublication,
+    jurorVerdicts: panel.jurorVerdicts,
+    panelFails: [],
+  }
+}
+
+// ----- USEFUL-FIRST BOOTSTRAP + ADAPTIVE ROADMAP ------------------------
+// A trusted supervisor attestation lets the first roadmap worker skip redundant
+// capability work. Without one, that same useful worker proves RUN/READ/WRITE
+// before it scopes; there is no dedicated preflight or intake round trip.
+// === CAPABILITY-ATTESTATION-SLICE:START ===
+const CAPABILITY_ATTESTATION_VERSION = 4
+const MAX_CAPABILITY_PROOF_BYTES = 4096
+const CAPABILITY_BINDING_FIELDS = [
+  'provider',
+  'cliVersion',
+  'permissionProfile',
+  'agentSelector',
+  'agentDefinitionsHash',
+  'castingHash',
+  'effortStatus',
+  'effortSource',
+]
+
+function verifyCapabilityAttestation(raw, expected, hashText) {
+  if (typeof raw !== 'string' || raw.trim() === '') return { trusted: false, reason: 'attestation missing' }
+  let attestation
+  try { attestation = JSON.parse(raw) } catch { return { trusted: false, reason: 'attestation is not valid JSON' } }
+  if (!attestation || attestation.schemaVersion !== CAPABILITY_ATTESTATION_VERSION) {
+    return { trusted: false, reason: `schemaVersion must be ${CAPABILITY_ATTESTATION_VERSION}` }
+  }
+  if (attestation.run !== true || attestation.read !== true || attestation.write !== true) {
+    return { trusted: false, reason: 'RUN/READ/WRITE capability is incomplete' }
+  }
+  if (attestation.proofKind !== 'disposable-scratch') {
+    return { trusted: false, reason: 'RUN/READ/WRITE proofKind is not disposable-scratch' }
+  }
+  if (typeof attestation.proofHash !== 'string' || !/^sha256:[a-f0-9]{64}$/.test(attestation.proofHash)) {
+    return { trusted: false, reason: 'RUN/READ/WRITE proofHash is missing or malformed' }
+  }
+  // The proof hash must recompute from inspectable scratch bytes carried in
+  // the attestation itself (the gate is fs-free); a bare well-formed hash
+  // string proves nothing.
+  if (
+    typeof attestation.proofBytes !== 'string' ||
+    attestation.proofBytes === '' ||
+    attestation.proofBytes.length > MAX_CAPABILITY_PROOF_BYTES
+  ) {
+    return { trusted: false, reason: 'RUN/READ/WRITE proof bytes are missing or oversized' }
+  }
+  if (typeof hashText !== 'function') {
+    return { trusted: false, reason: 'RUN/READ/WRITE proof cannot be recomputed' }
+  }
+  if (`sha256:${hashText(attestation.proofBytes)}` !== attestation.proofHash) {
+    return { trusted: false, reason: 'RUN/READ/WRITE proofHash does not match the scratch proof bytes' }
+  }
+  for (const field of CAPABILITY_BINDING_FIELDS) {
+    if (typeof attestation[field] !== 'string' || attestation[field] === '' || attestation[field] === 'unknown') {
+      return { trusted: false, reason: `${field} binding is missing or unverified` }
+    }
+    if (!expected || attestation[field] !== expected[field]) {
+      return { trusted: false, reason: `${field} binding does not match the live launch` }
+    }
+  }
+  return { trusted: true, reason: 'trusted supervisor attestation' }
+}
+// === CAPABILITY-ATTESTATION-SLICE:END ===
+
+const CAPABILITY_BINDING = Object.freeze({
+  provider: WORKFLOW_ENV.AUTOPROMPT_PROVIDER || 'unknown',
+  cliVersion: WORKFLOW_ENV.AUTOPROMPT_CLI_VERSION || 'unknown',
+  permissionProfile: WORKFLOW_ENV.AUTOPROMPT_PERMISSION_PROFILE || 'unknown',
+  agentSelector: WORKFLOW_ENV.AUTOPROMPT_AGENTS || 'off',
+  agentDefinitionsHash: WORKFLOW_ENV.AUTOPROMPT_AGENT_DEFINITIONS_HASH || 'unknown',
+  castingHash: WORKFLOW_ENV.AUTOPROMPT_CASTING_HASH || 'none',
+  effortStatus: MODEL_CASTING.effort.status,
+  effortSource: MODEL_CASTING.effort.source,
+})
+const capabilityVerdict = verifyCapabilityAttestation(
+  WORKFLOW_ENV.AUTOPROMPT_CAPABILITY_ATTESTATION,
+  CAPABILITY_BINDING,
+  sha256Hex,
+)
+const capabilityAttested = capabilityVerdict.trusted
+log(capabilityAttested
+  ? 'Bootstrap capability attestation verified; no preflight agent call.'
+  : `No trusted capability attestation (${capabilityVerdict.reason}); the useful-first roadmap author will prove RUN/READ/WRITE.`)
+
+function preExecutionSealReason() {
+  const getBuiltin =
+    typeof process === 'object' &&
+    process &&
+    typeof process.getBuiltinModule === 'function'
+      ? process.getBuiltinModule.bind(process)
+      : null
+  const fileSystem = getBuiltin &&
+    (getBuiltin('node:fs') || getBuiltin('fs'))
+  if (!fileSystem) return ''
+  for (const marker of [
+    'SCOPE-BUDGET-BREACH',
+    'SCOPE-CONVERGE-REQUEST',
+  ]) {
+    const read = readUtf8File(fileSystem, `${LEDGER_DIR}/${marker}`)
+    if (typeof read.text === 'string') {
+      const missionBinding = read.text.match(
+        /(?:^|\s)mission=(sha256:[a-f0-9]{64})(?:\s|$)/,
+      )
+      const expectedBinding = `sha256:${sha256Hex(MISSION)}`
+      if (!missionBinding || missionBinding[1] !== expectedBinding) {
+        continue
+      }
+      return `${marker}: ${read.text.trim()}`
+    }
+  }
+  return ''
+}
+
+const preExecutionSeal = preExecutionSealReason()
+if (preExecutionSeal) {
+  log(`PRE-EXECUTION SEALED: ${preExecutionSeal}`)
+  return {
+    error: 'pre-execution budget sealed before roadmap dispatch',
+    scopeReasons: [preExecutionSeal],
+    mission: MISSION,
+  }
+}
+
+const REANCHOR_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['verdict'],
+  properties: {
+    verdict: { type: 'string', enum: ['ALIGNED', 'DRIFT'] },
+    reasons: { type: 'array', items: { type: 'string' }, description: 'if DRIFT, the specific mismatch between the on-disk frontier and the ORIGINAL MISSION' },
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+if (IS_RESUME && canSpawnNewWork()) {
+  phase('Re-anchor')
+  const reAnchor = await agent(
+    compactBrief('the post-resume re-anchor',
+      `Read "${ARTIFACT_DIR}/ROADMAP.md" and the current gate log, compare them with the original mission, and report either ALIGNED or DRIFT with specific reasons. Change nothing.`,
+      null),
+    { label: 're-anchor', phase: 'Re-anchor', schema: REANCHOR_SCHEMA, agentType: PERSONA.reAnchor },
+  )
+  if (canaryTripped(reAnchor)) {
+    canaryTrips++
+    return {
+      error: 'post-resume re-anchor failed its run binding',
+      scopeReasons: ['re-anchor canary nonce is missing or mismatched'],
+      mission: MISSION,
+    }
+  }
+  if (reAnchor.verdict !== 'ALIGNED') {
+    return {
+      error: 'post-resume re-anchor found mission drift',
+      scopeReasons: Array.isArray(reAnchor.reasons) && reAnchor.reasons.length
+        ? reAnchor.reasons
+        : ['re-anchor returned no specific drift reasons'],
+      mission: MISSION,
+    }
+  }
+}
+
+const scope = await scopeAndRoadmap()
+if (!scope.approved) {
+  return {
+    error: scope.capabilityFailed
+      ? 'bootstrap capability check failed; build was not started'
+      : 'mission has no approved executable roadmap; scope gate did not converge',
+    scopeReasons: scope.reasons || [],
+    scope: scope.metrics,
+    mission: MISSION,
+  }
+}
+const features = scope.features
+const scopeDep = validateDependencies(features)
+if (!scopeDep.ok) {
+  return { error: `roadmap-derived dependency graph invalid: ${scopeDep.reason}`, mission: MISSION }
+}
+const contractRejects = debugContractRejects(features)
+if (contractRejects.length) {
+  return { error: `roadmap debug-contract invalid: ${contractRejects.map(item => item.id).join(', ')}`, mission: MISSION }
+}
+const scopeLanes = phasesOf(features).map(lane => lane.map(feature => feature.id))
+log(`Roadmap APPROVED via ${scope.topology.profile}: ${scope.metrics.agents} actual scope agents / ${scope.metrics.rounds} actual rounds / ${scope.metrics.elapsedMs}ms; ${features.length} executable feature(s).`)
+
+// ----- run features (per the execution mode; disjoint boundaries) -----
+phase('Plan')
+if (!canSpawnNewWork()) {
+  log('Token budget already low after roadmap approval, deferring the build wave.')
+}
+const built = []
+const builtById = new Map()
+
+function dependencyBlockReasons(feature) {
+  const reasons = []
+  for (const dependencyId of feature.dependsOn || []) {
+    const dependency = builtById.get(dependencyId)
+    if (!dependency) {
+      reasons.push(`${dependencyId} has no completed result`)
+      continue
+    }
+    if (dependency.status !== 'DONE') {
+      reasons.push(
+        `${dependencyId} reached ${dependency.status || 'UNKNOWN'}, not DONE`,
+      )
+      continue
+    }
+    if (!dependency.terminalPublication) {
+      reasons.push(`${dependencyId} has no durable terminal publication`)
+      continue
+    }
+    requireDurablePublication(
+      dependency.terminalPublication,
+      publicationExpected(
+        'verification-to-signoff',
+        dependency.terminalPublication.artifactPath,
+        dependency.terminalPublication.artifactHash,
+        dependency.terminalPublication.artifactBytes,
+        'G6',
+        PERSONA.verifier,
+        'VERIFIED',
+        dependencyId,
+      ),
+      'feature-to-dependent',
+    )
+  }
+  return reasons
+}
+
+function recordFeatureResult(result) {
+  if (!result || !result.feature) return
+  built.push(result)
+  builtById.set(result.feature.id, result)
+}
+
+function blockDependent(feature, reasons) {
+  const result = {
+    feature,
+    status: 'BLOCKED_AT_DEPENDENCY',
+    reasons,
+  }
+  recordFeatureResult(result)
+  log(
+    `BLOCKED dependency-to-feature ${feature.id}: ${reasons.join('; ')}`,
+  )
+}
+
+const buckets = phasesOf(features)
+for (const bucket of buckets) {
+  const ready = []
+  for (const feature of bucket) {
+    const reasons = dependencyBlockReasons(feature)
+    if (reasons.length) blockDependent(feature, reasons)
+    else ready.push(feature)
+  }
+  if (!ready.length) continue
+
+  if (!canSpawnNewWork()) {
+    for (const feature of ready) {
+      recordFeatureResult({
+        feature,
+        status: 'DEFERRED',
+        reasons: ['token budget guard, deferred before planning'],
+      })
+    }
+    continue
+  }
+
+  if (MODE_CFG.parallelFeatures) {
+    log(`${MODE.toUpperCase()}: fanning out phase bucket of ${ready.length} feature(s)${TOPOLOGY.liveCap == null ? ' at once' : ` (up to ${TOPOLOGY.liveCap} live per wave)`}.${scopeLanes.length ? ` (ROADMAP.md declared ${scopeLanes.length} launch lane(s); the phase bucket is the widest disjoint wave)` : ''}`)
+    const results = await fanout(
+      ready.map(feature => () => runFeature(feature)),
+      true,
+      `phase-bucket(${ready.length})`,
+    )
+    for (const result of results.filter(Boolean)) recordFeatureResult(result)
+    continue
+  }
+
+  for (const feature of ready) {
+    const result = await runFeature(feature)
+    if (result) recordFeatureResult(result)
+  }
+}
+const byId = {}
+for (const r of built) byId[r.feature.id] = r
+const deferredFeatures = built.filter(r => r.status === 'DEFERRED').length
+if (deferredFeatures) log(`${deferredFeatures} feature(s) deferred by the budget guard.`)
+
+// The run-level SWEEP depth is scaled by the mission's highest feature tier
+// (PLAYBOOKS): T0/T1 skip the sweeper wave entirely (GOAL-CHECK is the
+// backstop), T2 runs a single mini-sweep round, T3 sweeps to convergence. A
+// feature that escalated at runtime carries its climbed tier in the result, so
+// the mission tier reflects the highest tier ACTUALLY reached.
+const reachedTiers = built.map(r => r.tier).filter(Boolean)
+const MISSION_TIER = reachedTiers.length
+  ? reachedTiers.reduce((top, t) => TIER_ORDER.indexOf(t) > TIER_ORDER.indexOf(top) ? t : top, 'T0')
+  : maxTier(features)
+const SWEEP_CFG = SWEEP_BY_TIER[MISSION_TIER] || SWEEP_BY_TIER[DEFAULT_TIER]
+const SWEEP_ROUND_CAP = SWEEP_CFG.rounds
+const SWEEP_CLEAN_REQUIRED = SWEEP_CFG.cleanRequired
+log(`Mission tier ${MISSION_TIER}: sweep depth ${SWEEP_ROUND_CAP === 0 ? 'NONE (GOAL-CHECK is the backstop)' : `${SWEEP_ROUND_CAP} round cap, ${SWEEP_CLEAN_REQUIRED} clean sweep(s) to converge`}.`)
+
+// ----- SWEEP to convergence --------------------------------------------
+phase('Sweep')
+const seen = new Set()
+const key = f => `${(f.where || '').trim().toLowerCase()}::${(f.title || '').trim().toLowerCase()}`
+const allFindings = []
+let cleanStreak = 0
+let sweepRound = 0
+let convergedReason = ''
+
+// The sweepers are the run's last line of defense, so they get everything:
+// the mission (first, prioritized), every approved plan, and the artifact
+// checkpoints - and they re-derive mission coverage themselves instead of
+// trusting the gate verdicts. The plans are passed as POINTERS (the frozen
+// -plan-final.md paths the sweeper reads on demand), not inlined verbatim: a
+// sweeper has Read and is told to open them, so inlining every full plan into
+// every sweep round was pure duplicated payload on the widest fan-out.
+function approvedPlansBlock() {
+  const withPlans = Object.values(byId).filter(r => r.plan)
+  if (!withPlans.length) return '(no approved plans on record)'
+  return withPlans
+    .map(r => `- ${r.feature.id} (${r.feature.name}) [${r.status}]: read "${ARTIFACT_DIR}/${r.feature.id}-plan-final.md"`)
+    .join('\n')
+}
+
+while (sweepRound < SWEEP_ROUND_CAP && cleanStreak < SWEEP_CLEAN_REQUIRED) {
+  sweepRound++
+  if (!canSpawnNewWork()) { convergedReason = 'token budget guard, stopped opening new work'; break }
+
+  assertExecLevel(PERSONA.sweeper, `sweep round ${sweepRound}`)
+  const sweep = await agent(
+    compactBrief('a production-readiness sweeper (problem-finder grade), you have seen none of the work that produced this',
+      `THE APPROVED IMPLEMENTATION PLANS (what was supposed to be built; the ORIGINAL MISSION above outranks them):\n${approvedPlansBlock()}\n\n` +
+      `RUN STATE: read the canonical ROADMAP.md plus substantive implementation and verification evidence under "${ARTIFACT_DIR}/". Trust no prior verdict over the mission.\n\n` +
+      `Do, in order:\n` +
+      `1. MISSION COVERAGE FIRST. Re-derive every ask from the ORIGINAL MISSION text alone, not from the plans, not from the gate verdicts. Check each ask against the actually-delivered work (read the code, run \`git diff\`, run the thing). Any mission ask not provably delivered is a P0 finding, even if every gate passed it.\n` +
+      `2. THEN the neighborhood: run \`git diff\` and read the touched code plus its surroundings. Find what the mission did NOT explicitly ask for but a senior engineer would catch: adjacent bugs, missing edge cases, untested paths, security holes, data-integrity risks, operability gaps. This is the "while fixing login I found 20 other bugs" pass.\n` +
+      (seen.size ? `ALREADY-KNOWN findings (do NOT repeat these; only report findings NOT in this list):\n- ${[...seen].join('\n- ')}\n` : '') +
+      `Return a severity-ranked findings list (P0..P3) with file:line and impact. If you find nothing new and genuinely material, return an empty list, do not invent nits to look thorough.`,
+      `${ARTIFACT_DIR}/sweep-round-${sweepRound}.md`),
+    { label: `sweep round ${sweepRound}`, phase: 'Sweep', schema: SWEEP_SCHEMA, agentType: PERSONA.sweeper },
+  )
+
+  if (canaryTripped(sweep)) {
+    canaryTrips++
+    cleanStreak = 0
+    log(`CANARY: nonce mismatch at sweep round ${sweepRound}; discarding the round and not advancing the clean streak`)
+    continue
+  }
+
+  const found = (sweep && sweep.findings) || []
+  const fresh = found.filter(f => !seen.has(key(f)))
+  for (const f of fresh) { seen.add(key(f)); allFindings.push(f) }
+
+  const newReentry = fresh.filter(f => f.severity === 'P0' || f.severity === 'P1')
+  if (!newReentry.length) {
+    cleanStreak++
+    log(`Sweep round ${sweepRound}: no new P0/P1 (clean streak ${cleanStreak}/${SWEEP_CLEAN_REQUIRED})`)
+    continue
+  }
+
+  cleanStreak = 0
+  if (!canSpawnNewWork()) { convergedReason = 'token budget guard, P0/P1 left for next run'; break }
+  log(`Sweep round ${sweepRound}: ${newReentry.length} new P0/P1, re-entering the gates`)
+  if (newReentry.length > MAX_FEATURES) {
+    log(`Sweep round ${sweepRound}: ${newReentry.length - MAX_FEATURES} P0/P1 finding(s) exceed the per-round re-entry limit of ${MAX_FEATURES} and remain open as residual for the next run`)
+  }
+  // A swept P0/P1 re-enters as a T1 debug feature (a root-cause fix is bounded
+  // work); it escalates on its own if a worker finds it cross-cutting.
+  const reentryFeatures = newReentry
+    .slice(0, MAX_FEATURES)
+    .map((finding, index) => ({
+      id: `S${sweepRound}.${index + 1}`,
+      name: finding.title,
+      category: 'backend',
+      tag: 'debug',
+      tier: 'T1',
+      boundary: finding.where,
+      acceptanceCriteria: [
+        `the ${finding.title} finding is fixed and its reported impact no longer occurs`,
+      ],
+      requiresDetailedPlan: true,
+      roadmapPlan:
+        `Sweep remediation: ${finding.title} at ${finding.where}. ` +
+        `Impact: ${finding.impact}`,
+      roadmapPath: scope.roadmap.roadmapPath,
+      roadmapHash: scope.roadmap.roadmapHash,
+      roadmapBytes: scope.roadmap.roadmapBytes,
+      roadmapApproval: scope.roadmapApproval,
+    }))
+  const reentryResults = (await fanout(reentryFeatures.map(f => () => runFeature(f)), MODE_CFG.parallelFeatures, `sweep-reentry(${reentryFeatures.length})`)).filter(Boolean)
+  for (const r of reentryResults) byId[r.feature.id] = r
+}
+if (!convergedReason) {
+  convergedReason = SWEEP_ROUND_CAP === 0
+    ? `tier ${MISSION_TIER}: no sweep wave (GOAL-CHECK is the backstop)`
+    : (cleanStreak >= SWEEP_CLEAN_REQUIRED
+      ? `converged: ${SWEEP_CLEAN_REQUIRED} consecutive clean sweep(s)`
+      : `sweep round cap (${SWEEP_ROUND_CAP}) reached`)
+}
+
+// ----- result -----------------------------------------------------------
+const allResults = Object.values(byId)
+const blocked = allResults.filter(r => r.status !== 'DONE')
+const deferred = allFindings.filter(f => f.severity === 'P2' || f.severity === 'P3')
+const openP01 = allResults.filter(r => r.feature.id.startsWith('S') && r.status !== 'DONE')
+// Pillar B N1/2.3: isDone is BLOCKER-AWARE. Any sweep P0/P1 whose re-entry
+// feature did not reach DONE is an open blocker that hard-blocks DONE,
+// independent of feature status. A clean streak alone is necessary, not
+// sufficient. (allFindings carry the raw severities the sweep surfaced; an
+// open re-entry means a found blocker was not fixed-and-re-verified.)
+// The clean-streak bar is the tier-scaled SWEEP_CLEAN_REQUIRED: at T0/T1 it is
+// 0 (no sweep wave runs), so the GOAL-CHECK below is the sole DONE backstop.
+const openSweepBlockers = openP01.length > 0
+const isDone = blocked.length === 0 && cleanStreak >= SWEEP_CLEAN_REQUIRED && !openSweepBlockers
+
+// GOAL-CHECK (the "are we really done?" backstop the mission demands): a fresh
+// agent re-derives every ask from the MISSION text alone and default-FAILs.
+// Every ask starts NOT-DONE and only flips on evidence the agent opens itself.
+// It runs exactly once, outside the sweep loop, and never re-enters the gates,
+// so it cannot recurse. A NOT-DONE verdict blocks the DONE claim.
+const GOAL_CHECK_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: [
+    'verdict',
+    'unmetAsks',
+    'openBlockers',
+    'usable',
+    'coverageFloorOk',
+    'severityDowngrades',
+  ],
+  properties: {
+    verdict: { type: 'string', enum: ['DONE', 'NOT-DONE'] },
+    unmetAsks: { type: 'array', items: { type: 'string' }, description: 'every mission ask not provably delivered; empty only if truly all met' },
+    openBlockers: {
+      type: 'array',
+      description: 'every still-open P0/P1 anywhere (feature gate, sweep, your own check); any entry forces NOT-DONE',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['severity', 'title', 'where'],
+        properties: {
+          severity: { type: 'string', enum: ['P0', 'P1'] },
+          title: { type: 'string' },
+          where: { type: 'string', description: 'file:line' },
+        },
+      },
+    },
+    usable: {
+      type: 'object', additionalProperties: false,
+      description: 'is the deliverable actually usable, generalized by deliverable type',
+      required: ['entryPoint', 'roadmap', 'onboarding'],
+      properties: {
+        entryPoint: { type: 'boolean', description: 'a reachable entry point exists (local run path / CLI command / library API), no false claim' },
+        roadmap: { type: 'boolean', description: 'a ROADMAP/PRD artifact is on disk (for an ambitious mission, the approved master ROADMAP.md)' },
+        onboarding: { type: 'boolean', description: 'basic onboarding/first-run path is present (README/quickstart/--help)' },
+      },
+    },
+    coverageFloorOk: { type: 'boolean', description: `true only if changed-line coverage is >= ${COVERAGE_FLOOR}%` },
+    severityDowngrades: {
+      type: 'array',
+      description: 'any P0/P1 silently reclassified to P2/P3 at the DONE boundary without a justified, evidenced reason; any entry blocks DONE',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['from', 'to', 'where'],
+        properties: {
+          from: { type: 'string' },
+          to: { type: 'string' },
+          where: { type: 'string' },
+        },
+      },
+    },
+    nonce: { type: 'string' },
+  },
+}
+let goalCheck = null
+let goalCheckPassed = false
+if (isDone && canSpawnNewWork()) {
+  assertGateRouting('GOALCHECK', PERSONA.goalChecker, 'goal-check')
+  goalCheck = await agent(
+    compactBrief('the GOAL-CHECK gate; INDEPENDENT and ADVERSARIAL, default-FAIL; fresh context, you have seen none of the work and did NOT author it; answer ARE WE REALLY DONE',
+      `Re-derive EVERY ask from the ORIGINAL MISSION text alone. Default-FAIL: every ask starts NOT-DONE and flips to DONE only on evidence you open yourself (read the code, run git diff, run the thing under "${ARTIFACT_DIR}" and the project). ` +
+      `Report, structurally: (1) unmetAsks: every mission ask not provably delivered; (2) openBlockers: every still-open P0/P1 anywhere - a "PASS with P0 notes" is itself a finding, list the P0; (3) usable: does the deliverable have a reachable entry point, a ROADMAP/PRD artifact on disk, and a basic onboarding/first-run path (generalize by deliverable type - CLI command/--help, library API/docs, etc.); (4) coverageFloorOk: is changed-line coverage >= ${COVERAGE_FLOOR}%; (5) severityDowngrades: any P0/P1 silently reclassified to P2/P3 without a justified evidenced reason. ` +
+      `Return verdict DONE ONLY if every mission ask is provably delivered AND openBlockers is empty AND all three usable sub-criteria hold AND coverageFloorOk is true AND there are no unjustified severity downgrades; otherwise NOT-DONE. A single unmet ask, a single open P0/P1, a missing usable sub-criterion, a sub-floor coverage number, or a silent downgrade each means NOT-DONE.`,
+      `${ARTIFACT_DIR}/goal-check.md`),
+    { label: 'goal-check', phase: 'Sweep', schema: GOAL_CHECK_SCHEMA, agentType: PERSONA.goalChecker },
+  )
+  if (canaryTripped(goalCheck)) {
+    canaryTrips++
+    log('CANARY: nonce mismatch at goal-check; treating verdict as NOT-DONE')
+  }
+  // Pillar B 2.2: DONE is RECOMPUTED in code from the structured fields, never
+  // trusted from the model's verdict string. Every evidence collection must be
+  // present in its declared shape; omission is NOT equivalent to clean.
+  const gc = goalCheck || {}
+  const asksMet = Array.isArray(gc.unmetAsks) && gc.unmetAsks.length === 0
+  const blockerFree = Array.isArray(gc.openBlockers) && gc.openBlockers.length === 0
+  const u = gc.usable || {}
+  const usableOk = u.entryPoint === true && u.roadmap === true && u.onboarding === true
+  const coverageOk = gc.coverageFloorOk === true
+  const downgradesClean = Array.isArray(gc.severityDowngrades) && gc.severityDowngrades.length === 0
+  goalCheckPassed = !!goalCheck
+    && goalCheck.verdict === 'DONE'
+    && asksMet && blockerFree && usableOk && coverageOk && downgradesClean
+    && !canaryTripped(goalCheck)
+}
+const isDoneFinal = isDone && goalCheckPassed
+
+// DONE-sentinel (binding F2): the supervisor's process-external, mission-scoped
+// "is this DONE?" signal. Written by the JANITOR/SCRIBE subagent (never the
+// parent) ONLY when isDoneFinal (which requires OPEN-BLOCKERS:0). A NOT-DONE run
+// writes NO sentinel, so "no sentinel" == "not yet done OR crashed" == relaunch.
+const DONE_SENTINEL = `${LEDGER_DIR}/DONE-${RUN_NONCE}`
+
+// Which DONE precondition failed (Pillar B 2.6: the verdict names the reason).
+function goalCheckFailReason() {
+  const gc = goalCheck || {}
+  if (!goalCheck) return 'goal-check did not run'
+  if (canaryTripped(goalCheck)) return 'goal-check canary trip (nonce mismatch)'
+  if (!Array.isArray(gc.unmetAsks)) return 'unmetAsks is missing or malformed'
+  if (gc.unmetAsks.length) return `unmet ask(s): ${gc.unmetAsks.join('; ')}`
+  if (!Array.isArray(gc.openBlockers)) return 'openBlockers is missing or malformed'
+  if (gc.openBlockers.length) return `open blocker(s): ${gc.openBlockers.map(b => `${b.severity} ${b.title} @ ${b.where}`).join('; ')}`
+  if (!gc.usable || typeof gc.usable !== 'object') return 'usable is missing or malformed'
+  const u = gc.usable
+  if (!(u.entryPoint === true && u.roadmap === true && u.onboarding === true)) return `not user-usable (entry=${u.entryPoint} roadmap=${u.roadmap} onboarding=${u.onboarding})`
+  if (gc.coverageFloorOk === false) return `coverage below the ${COVERAGE_FLOOR}% floor`
+  if (gc.coverageFloorOk !== true) return 'coverageFloorOk is missing or malformed'
+  if (!Array.isArray(gc.severityDowngrades)) return 'severityDowngrades is missing or malformed'
+  if (gc.severityDowngrades.length) return `unjustified severity downgrade(s): ${gc.severityDowngrades.map(d => `${d.from}->${d.to} @ ${d.where}`).join('; ')}`
+  if (goalCheck.verdict !== 'DONE') return 'goal-check verdict is NOT-DONE'
+  return 'a DONE precondition failed'
+}
+
+const summary = {
+  mission: MISSION,
+  mode: MODE,
+  missionTier: MISSION_TIER,
+  topology: resolveTopology(MODE),
+  scope: scope.metrics,
+  maxConcurrent: MAX_CONCURRENT,
+  agents: AGENTS,
+  artifacts: { dir: ARTIFACT_DIR, deletedAtEnd: isDoneFinal },
+  featureCount: features.length,
+  features: allResults.map(r => ({
+    id: r.feature.id, name: r.feature.name, category: r.feature.category, tag: r.feature.tag,
+    tier: r.tier || resolveTier(r.feature), status: r.status,
+    framework: r.feature.framework || undefined,
+    coverage: r.coverage, jurors: r.jurorVerdicts,
+    // F-DEPTH live writer: the DEPTH-LOCK result the SCRIBE turns into the real
+    // `fixlayer=`/`tag=debug` G3.5 row + FEATURE-META tag= token (BY CONSTRUCTION).
+    depthLock: r.feature.depthLock || undefined,
+    openReasons: r.status === 'DONE' ? [] : ((r.panelFails && r.panelFails.length ? r.panelFails : r.reasons) || []),
+  })),
+  sweep: { rounds: sweepRound, roundCap: SWEEP_ROUND_CAP, totalFindings: allFindings.length, deferred, convergence: convergedReason, openReentry: openP01.length },
+  deferredFeatures,
+  canaryTrips,
+  goalCheck: goalCheck ? {
+    verdict: goalCheck.verdict,
+    unmetAsks: goalCheck.unmetAsks || [],
+    openBlockers: goalCheck.openBlockers || [],
+    usable: goalCheck.usable || null,
+    coverageFloorOk: goalCheck.coverageFloorOk,
+    severityDowngrades: goalCheck.severityDowngrades || [],
+  } : undefined,
+  coverageFloor: COVERAGE_FLOOR,
+  suggestions: allSuggestions.length ? [...new Set(allSuggestions)] : undefined,
+  userQuestions: userQuestions.length ? [...new Set(userQuestions)] : undefined,
+  assumed: assumed.length ? [...new Set(assumed)] : undefined,
+  done: isDoneFinal,
+  doneSentinel: isDoneFinal ? DONE_SENTINEL : undefined,
+  verdict: isDoneFinal
+    ? `All features unanimous PASS; sweep converged clean; GOAL-CHECK (independent, adversarial) confirmed zero open blockers, user-usable, coverage >= ${COVERAGE_FLOOR}%, no severity downgrade.`
+    : (isDone && !goalCheckPassed
+      ? `GOAL-CHECK says NOT-DONE - ${goalCheckFailReason()}; artifacts kept, re-run to continue.`
+      : `${blocked.length} feature(s) not DONE${openSweepBlockers ? ` (${openP01.length} open sweep blocker(s))` : ''}${deferredFeatures ? ` (${deferredFeatures} deferred by budget guard)` : ''} / sweep not converged, logged partial; re-run to continue.`),
+}
+
+// ----- SCRIBE: append the compact run checkpoint -------------------------
+phase('Scribe')
+await agent(
+  compactBrief('the scribe; append compact run checkpoints, never evaluate or edit code',
+    `Keep the canonical root prompt ledger at "${LEDGER_DIR}/PROMPTS.txt" unchanged. Copy the approved "${ARTIFACT_DIR}/ROADMAP.md" to "${LEDGER_DIR}/ROADMAP.md". Append one line per feature/gate transition to "${LEDGER_DIR}/GATELOG.md", including persona, model selector, requested/applied effort status, verdict, elapsed scope topology, artifact path, framework, tier, and dependency frontier. Write atomically where replacing and append-only where appending. ` +
+    `These three root files are the normal governance state: PROMPTS.txt, ROADMAP.md, GATELOG.md. Do NOT resolve or create a nested prompt directory for a new run. Do NOT create BRIEF.md, PLAN.md, AGENTS.md, COVERAGE.md, BACKLOG.md, ANCHOR.md, bucketlist.md, intake.md, or scope-map.md for this run. ` +
+    `For every debug feature, the G3.5 line must include tag=debug fixlayer=<depthLock.frozenLayer>; append the trailing tag=debug token to its FEATURE-META fields in the same GATELOG line. ` +
+    `Legacy files may exist from an older resumed run; do not delete or rewrite them. Do not touch track.md until the run is sealed and verified. RUN SUMMARY (the exact mission remains in PROMPTS.txt and is intentionally omitted here):\n${JSON.stringify({ ...summary, mission: undefined }, null, 2)}`),
+  { label: 'scribe', phase: 'Scribe', agentType: PERSONA.scribe },
+)
+
+// ----- LEDGER-CHECK: the disk + substance HARD-STOP (P-01 / P-02 / P-22) -----
+// The load-bearing anti-fabrication teeth that previously existed but never ran.
+// The SCRIBE has just written the canonical GATELOG/ROADMAP state; NOW an
+// INDEPENDENT default-FAIL leaf RUNS the standalone on-disk validator
+// (autoprompt-ledger-check.js runLedgerCheck) against that state + the real -vN
+// artifacts + this session's transcripts, and reconciles roadmap closure.
+// gate.js is fs-less, so the validator runs in the leaf's shell; its REAL process
+// EXIT CODE (1 = any P0: a gate claimed with no distinct spawn, an artifact under
+// the 200-char substance floor, a SKIPPED pre-spawn handshake, a tier/framework
+// mismatch, a self-review signature) and any still-open roadmap item BLOCK the
+// DONE seal in code here. Legacy bucketlist closure remains readable on resume.
+// A would-be DONE run whose written ledger does not
+// reconcile to real substance on disk is downgraded to NOT-DONE - no sentinel, the
+// supervisor re-runs. This is the seam audit-D flagged: the strongest teeth in the
+// repo, finally on the live path.
+const LEDGER_CHECK_SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['exitCode', 'p0Findings', 'openBucketlistItems'],
+  properties: {
+    exitCode: { type: 'integer', description: 'the EXACT process exit code of `node autoprompt-ledger-check.js --ledger-dir ... --artifact-dir ...` (0 = every claimed gate reconciles to a distinct spawn + a >=200-char on-disk artifact and no P0 lint fired; 1 = at least one P0). Report the real captured code, never a guess.' },
+    p0Findings: { type: 'array', items: { type: 'string' }, description: 'every "P0 [rule] title" line the validator printed; empty ONLY when the validator exited 0' },
+    openBucketlistItems: { type: 'array', items: { type: 'string' }, description: 'legacy compatibility only; new runs derive closure from ROADMAP.md and return []' },
+    ranCommand: { type: 'string', description: 'the exact validator command you executed (for audit)' },
+    nonce: { type: 'string', description: 'echo RUN-NONCE verbatim from your brief header' },
+  },
+}
+let ledgerCheckPassed = false
+let ledgerCheckFailReason = ''
+if (isDoneFinal) {
+  assertGateRouting('LEDGERCHECK', PERSONA.goalChecker, 'ledger-check')
+  // Arm the P-02 skipped-handshake lint whenever a transcript dir is available:
+  // gate.js wires --transcript-dir directly into the validator command so the teeth
+  // do not depend on the leaf self-locating a folder. Absent (headless) => log loud,
+  // omit the flag, run the reconcile + substance checks anyway (never a hard stop).
+  const transcriptFlag = TRANSCRIPT_DIR ? ` --transcript-dir "${TRANSCRIPT_DIR}"` : ''
+  const transcriptNote = TRANSCRIPT_DIR
+    ? 'The harness resolved this session\'s transcript dir and wired --transcript-dir into the command above, so the P-02 skipped-handshake lint is ARMED - run it verbatim.'
+    : 'No transcript dir was available to the harness, so --transcript-dir is omitted and the P-02 skipped-handshake lint is DISARMED this run; if you can locate this session\'s conductor transcript directory (e.g. under ~/.omp/agent/sessions/), ALSO pass --transcript-dir "<that dir>" to arm it. The reconcile + substance checks still run either way.'
+  if (!TRANSCRIPT_DIR) log('LEDGER-CHECK WARNING: no transcript dir available (set AUTOPROMPT_TRANSCRIPT_DIR) - the P-02 skipped-handshake lint is DISARMED this run; reconcile + substance checks still run, and the load-time frontmatter prose remains the primary handshake gate.')
+  const ledgerCheck = await agent(
+    compactBrief('the LEDGER-CHECK gate; INDEPENDENT and default-FAIL; you did NOT write this ledger; RUN the on-disk provenance validator and report its EXACT captured exit code, never a guessed pass',
+      `The SCRIBE has written the canonical root run ledger. RUN the standalone validator against real disk state and reconcile roadmap closure. Report REAL captured results only.\n` +
+      `1. RUN THE VALIDATOR and capture its exit code VERBATIM (new runs reconcile root GATELOG persona/model/effort rows against immutable launch/casting metadata and substantive artifacts; legacy nested resumes remain readable when explicitly invoked on their prompt directory):\n` +
+      `   node "${LEDGER_CHECK_PATH}" --ledger-dir "${LEDGER_DIR}" --artifact-dir "${ARTIFACT_DIR}" --run-nonce "${RUN_NONCE}" --terminal${transcriptFlag}; echo "EXITCODE=$?"\n` +
+      `   ${transcriptNote} Set exitCode to the EXITCODE you captured and p0Findings to every "P0 [...]" line the validator printed.\n` +
+      `2. ROADMAP CLOSURE: compare every ROADMAP.md item with the GATELOG frontier and substantive evidence. Set openBucketlistItems=[] for a closed new-format run; on a legacy resume, preserve the legacy bucketlist check.\n` +
+      `Echo the RUN-NONCE. Change NOTHING: do not edit code, do not delete anything, do not write the sentinel - only run the checks and report.`,
+      `${ARTIFACT_DIR}/ledger-check.md`),
+    { label: 'ledger-check', phase: 'Scribe', schema: LEDGER_CHECK_SCHEMA, agentType: PERSONA.goalChecker },
+  )
+  if (canaryTripped(ledgerCheck)) {
+    canaryTrips++
+    log('CANARY: nonce mismatch at ledger-check; treating the disk validator as NOT clean (DONE blocked)')
+  }
+  // Default-FAIL, RECOMPUTED in code from the captured fields (never a verdict
+  // string): DONE is sealed only when the validator EXITED 0, printed NO P0, and
+  // closed every roadmap item (or legacy bucketlist item on resume) - a non-zero
+  // exit / any P0 / any open item blocks.
+  const lc = ledgerCheck || {}
+  const exitClean = lc.exitCode === 0
+  const p0Clean = !(Array.isArray(lc.p0Findings) && lc.p0Findings.length > 0)
+  const bucketlistClean = !(Array.isArray(lc.openBucketlistItems) && lc.openBucketlistItems.length > 0)
+  ledgerCheckPassed = !!ledgerCheck && exitClean && p0Clean && bucketlistClean && !canaryTripped(ledgerCheck)
+  if (!ledgerCheckPassed) {
+    if (!ledgerCheck) ledgerCheckFailReason = 'ledger-check did not run'
+    else if (!exitClean) ledgerCheckFailReason = `disk validator exited ${lc.exitCode} (P0 provenance finding)`
+    else if (!p0Clean) ledgerCheckFailReason = `P0 provenance finding(s): ${lc.p0Findings.join('; ')}`
+    else if (!bucketlistClean) ledgerCheckFailReason = `open legacy bucketlist item(s): ${lc.openBucketlistItems.join('; ')}`
+    else ledgerCheckFailReason = 'ledger-check canary trip (nonce mismatch)'
+    log(`LEDGER-CHECK blocked DONE: ${ledgerCheckFailReason}`)
+  }
+}
+
+// P-22 (non-blocking dispatch, in-harness teeth): replay the dispatch ledger - a wave of
+// independent ready work that ran SERIALLY while the mode supported parallel fan-out blocks
+// the DONE seal, exactly like an open roadmap item. Serial now means TWO things: a serial
+// dispatch DECISION (the wave's isParallel flag) and an observed serial COLLAPSE (the
+// wave's measured peakLive never reached its achievableWidth - a parallel-flagged wave
+// that physically ran spawn-wait-spawn behind blocking spawns). On a genuinely concurrent
+// runtime this is always empty, so it only ever fires on a serialization regression -
+// spawn-all-then-collect, by construction AND by measurement.
+const serialDispatchViolations = serialDispatchFindings(dispatchLedger)
+if (serialDispatchViolations.length) {
+  log(`P-22 SERIAL-DISPATCH blocked DONE: ${serialDispatchViolations.length} independent wave(s) ran serially - ${serialDispatchViolations.map(v => v.title).join(' | ')}`)
+}
+summary.serialDispatchFindings = serialDispatchViolations
+// The recorded dispatch waves (intended AND observed shape) are run evidence:
+// operators, the ledger, and E2E harnesses read peakLive vs achievableWidth to
+// prove fan-out happened rather than trusting a concurrency claim.
+summary.dispatchWaves = dispatchLedger.map(wave => ({ ...wave }))
+
+// The DONE seal is now the goal-check AND the on-disk ledger validator AND a proof that
+// no independent work was dispatched serially (spawn-all-then-collect).
+const isDoneSealed = isDoneFinal && ledgerCheckPassed && serialDispatchViolations.length === 0
+summary.done = isDoneSealed
+summary.doneSentinel = isDoneSealed ? DONE_SENTINEL : undefined
+summary.artifacts.deletedAtEnd = isDoneSealed
+if (isDoneFinal && !isDoneSealed) {
+  summary.verdict = !ledgerCheckPassed
+    ? `LEDGER-CHECK blocked DONE - the on-disk provenance validator did not pass (${ledgerCheckFailReason}); artifacts kept, re-run to continue.`
+    : `SERIAL-DISPATCH blocked DONE - ${serialDispatchViolations.length} independent dispatch wave(s) ran serially (P-22 non-blocking dispatch violated); artifacts kept, re-run to continue.`
+}
+
+// ----- JANITOR: artifacts live for the whole session, deleted only at DONE --
+// The JANITOR/SCRIBE subagent (never the parent) also writes the DONE-sentinel
+// the external supervisor polls - only on a genuinely DONE + disk-sealed run,
+// atomically.
+if (isDoneSealed) {
+  assertGateRouting('JANITOR', PERSONA.janitor, 'janitor')
+  await agent(
+    compactBrief('the janitor, end-of-run cleanup; write the DONE-sentinel, then delete the scratch artifacts, touch nothing else',
+      `The run is DONE and the canonical root ledger is written.\n` +
+      `1. Write the DONE-sentinel ATOMICALLY (binding F2/F6): write the JSON {"done": true, "nonce": "${RUN_NONCE}", "verdict": "${(summary.verdict || 'DONE').replace(/"/g, "'").slice(0, 200)}", "ts": "<output of \`date -Iseconds\` or \`date\`>"} to "${DONE_SENTINEL}.tmp" then \`mv\` (rename) it to "${DONE_SENTINEL}" - write-temp-then-rename so a reader never sees a half-written file. NEVER write the sentinel if the run were not DONE; it is the supervisor's halt signal.\n` +
+      `2. THEN delete the artifact directory "${ARTIFACT_DIR}" entirely, and "${LEDGER_DIR}/.artifacts" too if it is now empty. ` +
+      `NEVER touch PROMPTS.txt, ROADMAP.md, GATELOG.md, track.md, the DONE-sentinel you just wrote, or any project code. ` +
+      `BEFORE deleting, verify "${LEDGER_DIR}" contains non-empty PROMPTS.txt, ROADMAP.md, and GATELOG.md; if any is missing or empty, do NOT delete anything and report the gap instead. ` +
+      `Report under 40 words: the sentinel path, what you deleted, what you kept.`),
+    { label: 'janitor', phase: 'Scribe', agentType: PERSONA.janitor },
+  )
+} else {
+  log(`Run not fully DONE - artifacts kept at ${ARTIFACT_DIR} as the resume checkpoint (the janitor only runs on a DONE run).`)
+}
+
+return summary

--- a/agents/omp/workflow/autoprompt-ledger-check.js
+++ b/agents/omp/workflow/autoprompt-ledger-check.js
@@ -1,0 +1,3869 @@
+#!/usr/bin/env node
+// FX-INTEGRITY FIX-05 + FIX-06 - the STANDALONE, cross-session provenance
+// validator. The in-harness seal (autoprompt-gate.js sealDoneProvenance) is the
+// THIS-SESSION spawn-linkage authority; this file is the CROSS-SESSION on-disk
+// authority. For new runs it reconciles each compact GATELOG.md gate row's
+// inline persona/model/effort provenance against a matching artifact. Legacy
+// resumes may instead use the older GATELOG.md + AGENTS.md split. It also flags
+// the F5-18 one-context self-review signature (one transcript that both edits a
+// production file and runs that feature's verify/goal-check test).
+//
+// Runs at 0% user input, read-only on the ledger + transcripts, non-destructive:
+// it writes only its own findings to stdout and exits 0 (clean) or 1 (a P0
+// finding). git fully restores the tree.
+//
+// SCOPE: ONLY the FIX-05 reconcile + the FIX-06 F5-18 rule are implemented. The
+// six FX-HIERARCHY linter rules (FIX-10/11/12/13/14/17) are OUT OF SCOPE; the
+// RULE_REGISTRY is left extensible so they append with zero rework.
+//
+// Usage: node autoprompt-ledger-check.js --ledger-dir <dir> --artifact-dir <dir> --transcript-dir <dir>
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const crypto = require('crypto')
+
+// SPD-4 / P-26: the prose decision tree in agents/claude/frameworks/README.md is now the
+// SINGLE routing source of truth (the competing framework-selector.js was deleted).
+// The pure leaf<->tier consistency helper - a lint concern, not a routing concern -
+// lives here so the frameworkTierFindings rule keeps its teeth with no external dep.
+// LEAF_TIER_BANDS: each seeded leaf's allowed tier band, transcribed VERBATIM from
+// README §1. A recorded tier OUTSIDE its leaf's band is the FRAMEWORK-TIER MISMATCH.
+const LEAF_TIER_BANDS = {
+  'apply': ['T0', 'T1'],
+  'backend-fix': ['T1', 'T2'],
+  'backend-implement': ['T2'],
+  'backend-build': ['T2', 'T3'],
+  'frontend-fix': ['T1', 'T2'],
+  'frontend-implement': ['T2'],
+  'frontend-build': ['T2', 'T3'],
+  'frontend-review': ['T1', 'T2', 'T3'],
+  'polish': ['T1', 'T2'],
+  'refactor': ['T1', 'T2'],
+  'docs': ['T0', 'T1', 'T2'],
+  'plan-scope': ['T2', 'T3'],
+  'plan-research': ['T2'],
+  'plan-design': ['T2'],
+}
+// leafTierConsistent(leaf, tier) -> { known, ok }. PURE, total. `known` is true ONLY
+// when BOTH the leaf is a seeded band entry AND the tier is a recognized token (T0..T3),
+// so the rule fails-closed on an unknown/generated leaf or an unparseable tier. When
+// known, `ok` is true IFF the leaf's band admits the tier. Garbage -> { known:false, ok:false }.
+const RECOGNIZED_TIERS = new Set(['T0', 'T1', 'T2', 'T3'])
+function leafTierConsistent(leaf, tier) {
+  const band = typeof leaf === 'string' ? LEAF_TIER_BANDS[leaf] : undefined
+  if (!Array.isArray(band) || typeof tier !== 'string' || !RECOGNIZED_TIERS.has(tier)) {
+    return { known: false, ok: false }
+  }
+  return { known: true, ok: band.includes(tier) }
+}
+
+// The canonical gate->expected-persona map. Kept in lockstep with the same
+// constant in autoprompt-gate.js (gate.js is an ES module and cannot be
+// require()d here, so the two copies are duplicated by necessity). A claimed
+// gate backed by a spawn under a DIFFERENT persona is a substitution.
+const GATE_EXPECTED_PERSONA = {
+  G1: 'ap-planner', G2: 'ap-reviewer', G3: 'ap-fresh-verifier',
+  'G3.5': 'ap-depth-prober',
+  G4: 'ap-implementer', G5: 'ap-reviewer', G6: 'ap-verifier',
+  G7: 'ap-juror', G8: 'ap-scribe',
+}
+
+// A GATELOG verdict counts as a PASS-family claim (and therefore demands a spawn
+// + an artifact) only when it carries one of these tokens. SMASH/FAILED/REJECT
+// rows record a failed attempt and are never required to be backed.
+const PASS_VERDICT_RE = /\b(PASS|VERIFIED|APPROVE|UNANIMOUS|COMPLETE|DONE)\b/i
+
+// A real test-runner invocation (same family as gate.js REAL_RUNNER_RE / FIX-01).
+const REAL_RUNNER_RE = /\b(pytest|py\.test|python -m pytest|unittest|nose2?|tox|go test|jest|mocha|cargo test)\b/
+
+// PLAN-substance-provenance - a PASS verdict is legitimate only when its artifact
+// carries real, re-derivable substance (CONV-38 anti-fabrication). A capture gate
+// (G3/G6) PASS rests on a captured run (a real runner token OR the structured verify-
+// schema green field); a bare fence/row count NEVER substantiates the capture leg (v3).
+const MIN_SUBSTANCE_CHARS = 200      // non-whitespace body chars below this == stub/hollow
+const MIN_CAPTURE_ITEMS = 1          // a clean/zero-gap claim needs >=1 SUBSTANTIVE captured item
+const MIN_FENCE_CONTENT_CHARS = 12   // a fenced block below this (no runner/exit/pass) is decorative
+const GATE_SUBSTANCE_KIND = {
+  G1: 'prose', G2: 'prose', G3: 'capture', G4: 'prose',
+  'G3.5': 'prose',
+  G5: 'prose', G6: 'capture', G7: 'prose', G8: 'prose',
+}
+const BROAD_RUNNER_RE = /\b(pytest|py\.test|python -m pytest|unittest|nose2?|tox|go test|jest|mocha|vitest|bun test|deno test|cargo test|rspec|bundle exec rspec|phpunit|dotnet test|gradle(\.\w+)? test|mvn(\.\w+)? test|ctest)\b|\bnode\b[^\n`]*\.test\.[cm]?js\b|\bc8\b|\bnyc\b/i
+const VERIFY_GREEN_RE = /\breproNowGreen\s*[=:]\s*true\b|\btestCommand\s*[=:]/i
+const VERIFY_EVIDENCE_RE = /\bcoveragePercent\b|\brunnerInvocation\b|\bexit\s*[=:]\s*0\b|\bexit code\s*0\b/i
+const VERIFY_NOT_GREEN_RE = /\breproNowGreen\s*[=:]\s*false\b/i
+const REGRESSIONS_NONEMPTY_RE = /\bpreExistingRegressions\s*[=:]\s*\[\s*[^\]\s]/i
+const CLEAN_CLAIM_RE = /\bhardGapCount\s+0\b|\b(0|zero)\s+(hard\s+)?gaps?\b|\bno\s+(hard\s+)?gaps?\b|\ball[-\s]?pass(ed|ing)?\b/i
+const COUNT_CLAIM_RE = /\bhardGapCount\s+(\d+)\b|\b(\d+)\s+(?:hard\s+)?gaps?\b|\b(\d+)\s+of\s+(\d+)\b/i
+
+// SPEC-3 (PLAN-spec3) commit-doctrine constants. FEATURE_ID_RE tolerates the real id
+// forms (F1, F01, FX-KEYSTONE, F-LIB-COPY). GOALCHECK_DONE_RE marks a GOAL-CHECK line;
+// a DONE seal additionally needs /\bDONE\b/ and NOT /\bNOT-?DONE\b/i. GIT_ADD_ALL_RE
+// matches bulk staging (-A/--all/.) but not an explicit pathspec. COMMIT_ROW_RE is the
+// rule-8 checkpoint row, with __RUN__ (single-feature seal) as the first alternative.
+const FEATURE_ID_RE = /\bF(?:X-[A-Z0-9-]+|-[A-Z0-9-]+|\d+)\b/
+const GOALCHECK_DONE_RE = /GOAL-?CHECK\b/i
+const GIT_ADD_ALL_RE = /\bgit\s+add\s+(-A\b|--all\b|\.(\s|$))/
+const GIT_COMMIT_RE = /\bgit\s+commit\b/
+const COMMIT_ROW_RE = /^COMMIT\s+(__RUN__|F(?:X-[A-Z0-9-]+|-[A-Z0-9-]+|\d+))\s+([0-9a-f]{7,40})\s+branch=(\S+)\s+push=(\S+)/
+
+// PLAN-no-idle-pushwork - lean-as-idle detection. A turn is a lean-as-idle excuse when
+// it carries a lean token AND an idle/wait token AND NO legitimate dependency/
+// convergence justification.
+const LEAN_TOKEN_RE = /\b(stay(?:ing)?\s+lean|keep(?:ing)?\s+(?:it\s+)?lean|lean(?:ness)?)\b/i
+const IDLE_TOKEN_RE = /\b(wait(?:ing)?|idl(?:e|ing)|nothing\s+to\s+(?:do|dispatch)|standing\s+by|hold(?:ing)?\s+off)\b/i
+const LEGIT_WAIT_RE = /\b(BLOCKED|depends?\s+on|needs?\s+\S|ALL\s+CONVERGED|dependenc(?:y|ies)|dependent|gate[- ]order)\b/i
+
+// PLAN-lean-L0-coordinator - the L0 conductor must stay LEAN: ingest <=150-word
+// verdicts, never full gate detail. An over-budget tool_result (or one carrying a diff
+// / test-runner dump), or a fleet-state table rebuilt across turns, is parent-side
+// synthesis that belongs to the COORDINATOR.
+const VERDICT_BUDGET_CHARS = 1200            // ~150-200 words; the <=150-word report budget
+const DIFF_RE = /^(diff --git |@@ |\+\+\+ |--- )/m
+const FLEET_ROW_RE = /\bF\d+\b[^\n]*\b(in[- ]?flight|pending|done|blocked|PASS|SMASH|G[1-8])\b/i
+const FLEET_ROW_MIN = 3                       // <3 rows = an incidental mention, not a rebuilt table
+const FLEET_TABLE_TURN_MIN = 2                // rebuilt across >=2 turns = accumulation, not a one-off
+
+// PLAN-liveness-reconcile (FIX-016-2 / P18) - per-turn liveness reconcile constants.
+// RUNNING_NARRATION_RE matches the narrate-as-running-SUBAGENT shape ONLY (not a
+// generic "running the test suite"). AGENT_ID_RE extracts a poll's target id to bind it
+// to the claimed id. FEATURE_LABEL_RE (v4 narrowed) matches ONLY FX-/SPEC- frontier
+// keys. DEAD_SIGNAL_RE marks a poll RESULT that proves an agent is dead.
+const RUNNING_NARRATION_RE =
+  /\b(still running\.?\s*holding|running\s*\(\s*\d|in flight|agents? (are|is) coming back|standing by for|waiting (for|on)\b[^.]{0,48}\b(subagent|agent|report|scout|spec|reader|worker|supervisor)|awaiting\b[^.]{0,40}\b(subagent|agent|report)|holding (for|on)\b[^.]{0,40}\b(report|agent|worker))/i
+const BASH_POLL_RE = /\b(pgrep|ps -ef|ps aux|ps -e|ps -a|\bjobs\b)\b/
+const POLL_TOOL_NAMES = new Set(['TaskOutput', 'BashOutput'])
+const POLL_READ_RE =
+  /(^|[\/\\])(AGENTS\.md|RESUME\.md|resume\.md|resume\.json|ANCHOR\.md|[A-Za-z0-9-]*frontier[A-Za-z0-9-]*\.md)$/i
+const AGENT_ID_RE = /\b(F\d{1,3}|(?:ap|cl)-[a-z0-9]+(?:-[a-z0-9]+)*|sub-[a-z0-9]+(?:-[a-z0-9]+)*)\b/gi
+const FEATURE_LABEL_RE = /\b(FX-[A-Z][A-Z0-9]+|SPEC-\d{1,3})\b/g
+const DEAD_SIGNAL_RE = /\b(no such process|not running|stalled|connection ?refused|econnrefused|exited|killed|terminated|appears stalled)\b/i
+const LIVENESS_FRESH_WINDOW_MS = 15 * 60 * 1000
+const FRONTIER_LIVE_RE = /\b(in[- ]?flight|alive|live|running|G[1-7]\b|not[- ]?(?:sealed|complete)|incomplete)\b/i
+const FRONTIER_DEAD_RE = /\b(sealed|complete|completed|done|closed|merged|landed|shipped|G8|VERIFIED|sign-?off)\b/i
+const TRANSCRIPT_DONE_RE = /\b(LOOP-DONE|DONE-SENTINEL|wrote .*done|terminated|process exited)\b/i
+
+// FIX-016 (false-negative liveness, the MIRROR of livenessReconcileFindings). A turn concluding a spawned
+// agent is dead/absent - distinct from the false-POSITIVE "Running…" narration. Keyed on dead/absent/gone +
+// re-spawn vocabulary so a slow-but-alive agent declared dead from disk-absence is caught.
+const DEAD_CONCLUSION_RE = /\b(appears? (?:dead|absent|gone)|looks? (?:dead|absent)|(?:is|seems?) (?:dead|absent|gone|missing)|no (?:artifact|plan|output|file)s? (?:yet|written|present|on disk)|nothing on disk|produced no (?:artifact|plan|output)|must have (?:died|crashed)|treating (?:it |this )?as (?:dead|absent)|declaring (?:it |this )?dead|re-?spawn(?:ing)?|spawning a (?:replacement|duplicate|second)|duplicate (?:agent|spawn))/i
+// A task-status poll result that proves the agent is GENUINELY GONE (dead OR completed-without-artifact).
+// Reuses DEAD_SIGNAL_RE's death markers PLUS a completed/exited-0 done marker - the only sound basis for a
+// dead conclusion. A "running"/"in progress"/live-PID result is NOT here (alive-in-progress).
+const TASK_STATUS_DEAD_RE = /\b(no such process|not running|killed|terminated|exited(?:\s+(?:0|[1-9]\d*))?|completed|done|finished|process exited)\b/i
+
+// PLAN-time-optimization - serialGateFindings (P1) constants. A BILLIONAIRE feature-manager must dispatch a
+// STATICALLY-INDEPENDENT gate pair concurrently (one batched turn), never serially (two turns). The pairs are
+// independent by gate contract: {G2 plan-review, G3 fresh-verify} and {G5 impl-review, G6 verify}. The gate
+// label is read PER-TURN from each spawn's description - NOT a flat count (the unsound lint the prior G3s
+// rejected). Detection is priority-ordered so "fresh-verify" classifies as G3, never G6.
+const INDEPENDENT_GATE_PAIRS = [['G2', 'G3'], ['G5', 'G6']]
+
+// serialFeatureFindings (PLAN-autoprompt-enforcement) constants. The mission's literal headline
+// is "always fewer than 6 subagents" - a WIDTH throttle at the FEATURE tier. Below the floor never
+// fires (proportionality). Feature independence is DECLARED (NOT static like gate pairs) -> the rule
+// reads the mandatory DECOMPOSE rows for the cohort; a legacy/malformed ledger with no rows
+// fail-closes (no cohort, no finding) as a defensive guard only.
+const SERIAL_FEATURE_FLOOR = 6
+// FID_RE_SRC: the ONE canonical feature-id grammar (GATES.md feature ids). Four forms:
+//   F-digit  F1 .. F999          (\d{1,3})
+//   FX-NAME  FX-FOO              (X-[A-Z][A-Z0-9]*)
+//   F-NAME   F-QUAL / F-DEPTH    (-[A-Z][A-Z0-9]*)   <- the form v1 dropped at the parser
+//   SPEC-n   SPEC-3              (SPEC-\d{1,3})
+// The NAME bodies are [A-Z][A-Z0-9]* - letters/digits, NO embedded hyphen. This is
+// load-bearing for the FILENAME matcher: a hyphen-permissive body would greedily eat the
+// "-NN" turn-index suffix of `sub-ap-manager-F-QUAL-01.jsonl` and capture `F-QUAL-01`.
+// The no-hyphen body stops cleanly at the '-' before the turn index -> `F-QUAL`. In a
+// ledger row the trailing `\s+phase=`/`\s+wave=` delimits, so the same body is correct there.
+// EVERY parser that lifts an FID derives from THIS string. Drift is impossible by construction
+// and asserted by a drift-guard test against the pre-existing FEATURE_META_RE / FEATURE_TARGET_RE.
+const FID_RE_SRC = 'F(?:X-[A-Z][A-Z0-9]*|-[A-Z][A-Z0-9]*|\\d{1,3})|SPEC-\\d{1,3}'
+// FEATURE_DECL_RE: parse a DECOMPOSE ledger row ([at …] prefix stripped before matching):
+//   DECOMPOSE <FID> phase=<token> deps=<none|FID[,FID...]> owns=<path[,path...]>
+// Derives from FID_RE_SRC (Change 1) - F-digit/SPEC match byte-identically to the prior form;
+// the FX arm relaxes to a 1-char name; the ONLY genuinely new admission is the F-NAME arm.
+const FEATURE_DECL_RE = new RegExp(`^DECOMPOSE\\s+(${FID_RE_SRC})\\s+phase=(\\S+)\\s+deps=(\\S+)\\s+owns=(\\S+)`)
+// DISPATCH_RE: parse a mandatory DISPATCH ledger row ([at …] prefix stripped first):
+//   DISPATCH <FID> wave=<W>
+// The GUARANTEED firing signal - width is grouped by wave from these rows ALONE, never from prose
+// descriptions (which a mission-first run leaves FID-less). Derives from the SAME FID_RE_SRC so the
+// DECOMPOSE cohort and the DISPATCH width can never drift on the id grammar.
+const DISPATCH_RE = new RegExp(`^DISPATCH\\s+(${FID_RE_SRC})\\s+wave=(\\S+)`)
+
+// SPD-1 (tierProportionalityFindings) - the machine-readable per-feature row
+// derived from ROADMAP.md on new runs, or INTAKE on a legacy resume, beside any
+// DECOMPOSE/COMMIT rows: `FEATURE-META <FID> tier=<T0|T1|T2|T3> framework=<leaf> issues=<N> [tag=<playbook>]`.
+// The single-file derivation reuses the DECOMPOSE owns= set (NOT a field here). Byte-exact to GATES.md.
+// The OPTIONAL trailing `tag=` captures the authoritative playbook classification
+// (debug/research/...) - depthLockFindings keys "is this a debug feature" on THIS
+// recorded metadata, NOT on a self-applied inline token an author can omit. The feature-id group accepts the F-NAME
+// shape (F-DEPTH/F-PYL) as well as F123/FX-NAME/SPEC-N (mirrors FEATURE_TARGET_RE) so a real run parses.
+const FEATURE_META_RE = /^FEATURE-META\s+(F(?:X-[A-Z0-9-]+|-[A-Z0-9-]+|\d+)|SPEC-\d{1,3})\s+tier=(T[0-3])\s+framework=(\S+)\s+issues=(\d+)(?:\s+tag=([A-Za-z][A-Za-z-]*))?/
+// The over-tiering ceremony rows attributed to a feature (DIAGNOSIS §3 reproducible tax). A
+// SCOPE-AND-ROADMAP or SCOPE row, or a whole-mission END-VERDICT, attributed to a single-file
+// single-issue feature is over-tiering. plan-scope as a feature's recorded framework is the same signal.
+const SCOPE_ROW_RE = /^SCOPE(?:-AND-ROADMAP)?\s+(F\d{1,3}|FX-[A-Z][A-Z0-9]+|SPEC-\d{1,3})\b/
+const END_VERDICT_ROW_RE = /^END-VERDICT\s+(F\d{1,3}|FX-[A-Z][A-Z0-9]+|SPEC-\d{1,3})\b/
+// A single-file feature ran a 3-juror G7 panel when >= this many G7 SIGN-OFF rows are attributed to it.
+const THREE_JUROR_PANEL = 3
+
+// SUPERVISOR_WAVE_FLOOR (PLAN-supervisor-collapse): a SECOND ap-feature-coordinator in ONE L0 wave
+// is already the supervisor-per-feature anti-pattern - there is only ever ONE feature-build scope
+// per run, so >=2 feature-supervisors batched in a single conductor turn is the defect.
+const SUPERVISOR_WAVE_FLOOR = 2
+
+// PLAN-proportional-gates - the mission's core fix made structural. A run must NOT
+// wrap mechanical/frozen-spec application or batchable homogeneous units in per-unit
+// full pipelines. PROPORTIONAL_SIBLING_FLOOR is the minimum count of sibling features
+// that each ran a full G1..G8 pipeline over ONE shared file before ARM B fires.
+// DESIGN_GATES are the G1-G3 design cycle; FULL_PIPELINE_GATES is the complete ladder.
+// The frozen plan is recognized by the canonical <feature>-plan-final.md name OR a
+// <feature>-fresh-verify*.md artifact whose body carries APPROVE (FROZEN_FRESHVERIFY_RE /
+// FRESHVERIFY_APPROVE_RE). FEATURE_TARGET_RE extracts the explicit per-feature target token.
+const PROPORTIONAL_SIBLING_FLOOR = 3
+const DESIGN_GATES = ['G1', 'G2', 'G3']
+const FULL_PIPELINE_GATES = ['G1', 'G2', 'G3', 'G4', 'G5', 'G6', 'G7', 'G8']
+const FROZEN_FRESHVERIFY_RE = /-fresh-?verify.*\.md$/i
+const FRESHVERIFY_APPROVE_RE = /\bAPPROVE\b/
+const FEATURE_TARGET_RE = /\b(F(?:X-[A-Z0-9-]+|-[A-Z0-9-]+|\d+))\b[^\n]*?\b(?:target|file)=(\S+)/
+
+// F-DEPTH (depthLockFindings, P0) - the DEPTH-LOCK mechanical teeth. DEPTHLOCK_D3_RE
+// pulls the independently-derived deepest-cause function from a depth-lock artifact's
+// `D3:` line (file.py::function, tolerating Class.method). DEPTHLOCK_FIXLAYER_RE pulls
+// the frozen fix-layer token from a GATELOG G3.5/G4 row. DEPTHLOCK_D4_RED_RE proves the
+// D4 adversarial repro was captured RED. DEPTHLOCK_PYFN_RE is the file.py::function shape
+// the layer-equality compares on (normalized to ignore decorative trailing text).
+const DEPTHLOCK_D3_RE = /^\s*D3[:\s][^\n]*?([A-Za-z0-9_./-]+\.py::[A-Za-z0-9_.]+)/m
+const DEPTHLOCK_FIXLAYER_RE = /\bfixlayer=([A-Za-z0-9_./:.-]+)/
+const DEPTHLOCK_D4_RED_RE = /\bD4\b[\s\S]*?\bRED\b/i
+
+// PLAN-fanout-fix - thinSprawlFindings constants. THIN_SPRAWL_REPEAT identical
+// (persona, description) spawns in one transcript is a templated 1-per-query sprawl.
+// L3_MAY_FAN_OUT are the only L3 executor personas that legitimately dispatch their
+// own L4 leaves; any OTHER L3-named transcript that spawned is a recursion smell.
+const THIN_SPRAWL_REPEAT = 5
+const L3_MAY_FAN_OUT = new Set(['ap-implementer', 'ap-intake'])
+const L3_NON_SPAWNING = new Set([
+  'ap-planner', 'ap-reviewer', 'ap-verifier', 'ap-scoper', 'ap-synthesizer',
+  'ap-researcher', 'ap-sweeper', 'ap-execharness-resolver', 'ap-framework-generator',
+])
+
+// parseLedgerLines: tolerant line parser for a GATELOG.md or AGENTS.md file.
+// kind === 'gatelog' -> rows of the form
+//   [at HH:MM DD.MM.YYYY] <FEATURE> <GATE> <NAME> (<persona>): <VERDICT> - artifact <file>
+// kind === 'agents'   -> rows of the form
+//   [at HH:MM DD.MM.YYYY] <persona> (<GATE>, <Lx>): <description> ... Artifact <file>.
+// Unparseable lines are collected in `malformed` (fail-closed: never synthesized
+// into a backing). Returns { records, malformed }.
+function parseLedgerLines(text, kind) {
+  const records = []
+  const malformed = []
+  const lines = (typeof text === 'string' ? text : '').split('\n')
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (line === '' || line.startsWith('#')) continue
+    if (!line.startsWith('[at ')) continue
+    const body = line.replace(/^\[at[^\]]*\]\s*/, '')
+    if (kind === 'gatelog') {
+      const rec = parseGatelogRow(body)
+      if (rec) records.push(rec)
+      else malformed.push(line)
+    } else if (kind === 'agents') {
+      const rec = parseAgentsRow(body)
+      if (rec) records.push(rec)
+      else malformed.push(line)
+    }
+  }
+  return { records, malformed }
+}
+
+// A GATELOG row: <FEATURE> ... <GATE> ... (<persona>...): <VERDICT...> - artifact(s) <files>
+// FEATURE is the leading token (F1, F2, ...). GATE is the first G\d token.
+// persona is the first ap-* token inside parentheses. verdict is the text after
+// the first colon up to the em-dash/artifact pointer. Artifacts are every
+// <id>-*.md filename mentioned. A row missing a feature or gate is malformed.
+function parseGatelogRow(body) {
+  const featureMatch = body.match(/^(F(?:X-[A-Z0-9-]+|-[A-Z0-9-]+|\d+))\b/)
+  if (!featureMatch) return null
+  const gateMatch = body.match(/\b(G[1-8](?:\.\d+)?)\b/)
+  if (!gateMatch) return null
+  const personaMatch = body.match(/\(((?:ap|cl)-[a-z-]+)\)/)
+  const persona = personaMatch ? personaMatch[1] : ''
+  const colonIdx = body.indexOf(':')
+  const afterColon = colonIdx >= 0 ? body.slice(colonIdx + 1) : body
+  const verdict = afterColon.split(/[--]/)[0].trim()
+  const artifacts = (body.match(/[A-Za-z0-9_]+-[A-Za-z0-9_.-]+\.md/g) || [])
+  // F-DEPTH: capture the optional debug tag + the frozen fix-layer token, mirroring
+  // deriveFeatureTargets' explicit-token discipline (fail-closed: an absent token is '').
+  const tagMatch = body.match(/\btag=([A-Za-z0-9_-]+)/)
+  const fixlayerMatch = body.match(DEPTHLOCK_FIXLAYER_RE)
+  const modelMatch = body.match(/\bmodel=([^\s:]+)/)
+  const effortMatch = body.match(/\beffort=([^\s:]+(?::[^\s:]+)?)/)
+  return {
+    feature: featureMatch[1], gate: gateMatch[1], persona, verdict, artifacts,
+    tag: tagMatch ? tagMatch[1] : '',
+    fixlayer: fixlayerMatch ? fixlayerMatch[1] : '',
+    model: modelMatch ? modelMatch[1] : '',
+    effort: effortMatch ? effortMatch[1] : '',
+  }
+}
+
+// An AGENTS row: <persona> (<GATE>..., <Lx>): <desc> ... Artifact <file>.
+function parseAgentsRow(body) {
+  const personaMatch = body.match(/^((?:ap|cl)-[a-z-]+)/)
+  if (!personaMatch) return null
+  const gateMatch = body.match(/\b(G[1-8](?:\.\d+)?)\b/)
+  return {
+    persona: personaMatch[1],
+    gate: gateMatch ? gateMatch[1] : '',
+    artifacts: (body.match(/[A-Za-z0-9_]+-[A-Za-z0-9_.-]+\.md/g) || []),
+  }
+}
+
+// parseGoalCheckRows (SPEC-3): the terminal-seal scanner. Scans RAW lines (independent
+// of parseGatelogRow so heterogeneous prefixes parse). A line is a DONE seal when it
+// matches GOALCHECK_DONE_RE AND /\bDONE\b/ AND NOT /\bNOT-?DONE\b/i. Feature id via
+// FEATURE_ID_RE; a run-level DONE seal with no id -> { feature: '__RUN__' }. Deduped.
+// [] on non-string (fail-closed).
+function parseGoalCheckRows(text) {
+  if (typeof text !== 'string') return []
+  const seen = new Set()
+  const out = []
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/^\[at[^\]]*\]\s*/, '').trim()
+    if (!GOALCHECK_DONE_RE.test(line)) continue
+    if (!/\bDONE\b/.test(line) || /\bNOT-?DONE\b/i.test(line)) continue
+    const m = line.match(FEATURE_ID_RE)
+    const feature = m ? m[0] : '__RUN__'
+    if (seen.has(feature)) continue
+    seen.add(feature)
+    out.push({ feature })
+  }
+  return out
+}
+
+function parseGoalCheckFrontiers(text) {
+  const frontiers = []
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/^\[at[^\]]*\]\s*/, '').trim()
+    if (!GOALCHECK_DONE_RE.test(line)) continue
+    const featureMatch = line.match(FEATURE_ID_RE)
+    if (!featureMatch) continue
+    const isDone = /\bDONE\b/.test(line) && !/\bNOT-?DONE\b/i.test(line)
+    frontiers.push({ feature: featureMatch[0], isDone })
+  }
+  return frontiers
+}
+
+// parseCommitRows (SPEC-3): scans the SAME raw GATELOG text; strips the [at …] prefix,
+// applies COMMIT_ROW_RE; on match pushes { feature, sha, branch, push }. [] on
+// non-string (fail-closed).
+function parseCommitRows(text) {
+  if (typeof text !== 'string') return []
+  const out = []
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/^\[at[^\]]*\]\s*/, '').trim()
+    const m = COMMIT_ROW_RE.exec(line)
+    if (m) out.push({ feature: m[1], sha: m[2], branch: m[3], push: m[4] })
+  }
+  return out
+}
+
+// commitCheckpointFindings (SPEC-3 - commit doctrine, GATES.md G8): P1 (surfaced, does
+// NOT flip ok). ARM A - a sealed feature (GOAL-CHECK DONE) with no COMMIT row, or with a
+// deferred push, is a recoverability gap. ARM B - any transcript with a bulk `git add`
+// is a feature-scoping breach. Fail-closed on non-array ctx fields.
+function commitCheckpointFindings(ctx) {
+  const findings = []
+  const goalChecks = Array.isArray(ctx.goalChecks) ? ctx.goalChecks : []
+  const commits = Array.isArray(ctx.commits) ? ctx.commits : []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  const commitByFeature = new Map()
+  for (const c of commits) if (c && c.feature) commitByFeature.set(c.feature, c)
+  for (const seal of goalChecks) {
+    if (!seal || !seal.feature) continue
+    const commit = commitByFeature.get(seal.feature)
+    if (!commit) {
+      findings.push({
+        severity: 'P1',
+        rule: 'commitCheckpointFindings',
+        title: `sealed ${seal.feature} (GOAL-CHECK DONE) has no COMMIT row - each feature must commit AND push at its end and record the checkpoint (commit doctrine, GATES.md G8); RESUME cannot fall back to this boundary.`,
+      })
+      continue
+    }
+    const push = String(commit.push || '')
+    if (/^deferred:/.test(push)) {
+      findings.push({
+        severity: 'P1',
+        rule: 'commitCheckpointFindings',
+        title: `sealed ${seal.feature} committed but push deferred (${push.replace(/^deferred:/, '')}) - the remote checkpoint is missing; resolve the branch/remote and push (rules 4-6).`,
+      })
+    }
+  }
+  for (const t of transcripts) {
+    if (!t || typeof t !== 'object') continue
+    if (t.hasGitAddAll === true) {
+      findings.push({
+        severity: 'P1',
+        rule: 'commitCheckpointFindings',
+        title: `\`git add -A\`/\`.\` in ${t.path || '(unknown transcript)'} - staging must be feature-scoped by explicit pathspec (rule 2); a bulk add sweeps unrelated changes into the checkpoint.`,
+      })
+    }
+  }
+  return findings
+}
+
+// reconcileProvenance (FIX-05 core): for every GATELOG PASS-family row, require
+// (a) AGENTS.md carries the gate's expected persona for that feature AND (b) at
+// least one of the row's artifact files exists on disk. A breach is a P0
+// `fabricated <gate> attestation` finding. PERMISSIVE-ON-ABSENCE: a gate absent
+// from GATELOG is never synthesized or required. artifactExists is injected so
+// tests run without touching disk; the CLI passes a real fs-backed checker.
+const PERSONA_CASTING_TIER = {
+  'ap-planner': 'R3', 'ap-reviewer': 'R2', 'ap-fresh-verifier': 'R2',
+  'ap-depth-prober': 'R2', 'ap-implementer': 'R3', 'ap-verifier': 'R2',
+  'ap-juror': 'R2', 'ap-scribe': 'R4',
+}
+const MODEL_SELECTOR_BY_TIER = { R2: 'sonnet', R3: 'sonnet', R4: 'haiku' }
+const EFFORT_BY_TIER = { R2: 'xhigh', R3: 'high', R4: 'medium' }
+const MAXIMUM_EFFORT_PERSONAS = new Set([
+  'ap-reviewer', 'ap-fresh-verifier', 'ap-verifier', 'ap-juror',
+  'ap-depth-prober', 'ap-planner',
+])
+
+function expectedEffortForRow(row, launchBinding) {
+  const effort = launchBinding && launchBinding.effort
+  if (!effort || typeof effort.status !== 'string') return ''
+  if (effort.status !== 'selectable') return effort.status
+  const tier = PERSONA_CASTING_TIER[row.persona]
+  const requestedEffort = MAXIMUM_EFFORT_PERSONAS.has(row.persona)
+    ? effort.maximum
+    : EFFORT_BY_TIER[tier]
+  const selected = resolveAcceptedEffort(requestedEffort, effort)
+  return typeof selected === 'string' && selected !== ''
+    ? `selectable:${selected}`
+    : ''
+}
+
+function resolveAcceptedEffort(requestedEffort, capability) {
+  const acceptedValues = capability.acceptedValues
+  if (!Array.isArray(acceptedValues) || acceptedValues.length === 0) {
+    return requestedEffort
+  }
+  if (acceptedValues.includes(requestedEffort)) return requestedEffort
+
+  return acceptedValues.reduce((closest, candidate) => {
+    const closestDistance = Math.abs(
+      effortRank(closest) - effortRank(requestedEffort),
+    )
+    const candidateDistance = Math.abs(
+      effortRank(candidate) - effortRank(requestedEffort),
+    )
+    return candidateDistance < closestDistance
+      ? candidate
+      : closest
+  }, capability.maximum)
+}
+
+function effortRank(effort) {
+  return ['low', 'medium', 'high', 'xhigh'].indexOf(effort)
+}
+
+function expectedModelForRow(row, launchBinding) {
+  if (launchBinding && launchBinding.enabled === false) return 'inherit'
+  return MODEL_SELECTOR_BY_TIER[PERSONA_CASTING_TIER[row.persona]] || ''
+}
+
+function launchProvenanceFindings(row, launchBinding) {
+  if (!launchBinding || typeof launchBinding !== 'object') return []
+  const findings = []
+  const expectedModel = expectedModelForRow(row, launchBinding)
+  const aliases = launchBinding.aliases
+  const hasBoundModel = launchBinding.enabled === false ||
+    (aliases && typeof aliases === 'object' && typeof aliases[expectedModel] === 'string' && aliases[expectedModel] !== '')
+  if (expectedModel === '' || !hasBoundModel || row.model !== expectedModel) {
+    findings.push({
+      severity: 'P0', rule: 'reconcileProvenance',
+      title: `model provenance for ${row.gate} (${row.feature}) does not match immutable launch binding: recorded ${row.model}, expected ${expectedModel || '(unbound)'}`,
+    })
+  }
+  const expectedEffort = expectedEffortForRow(row, launchBinding)
+  if (expectedEffort !== '' && row.effort !== expectedEffort) {
+    findings.push({
+      severity: 'P0', rule: 'reconcileProvenance',
+      title: `effort provenance for ${row.gate} (${row.feature}) does not match immutable launch binding: recorded ${row.effort}, expected ${expectedEffort}`,
+    })
+  }
+  return findings
+}
+
+function reconcileProvenance(ctx) {
+  const findings = []
+  const gatelog = Array.isArray(ctx.gatelog) ? ctx.gatelog : []
+  const agents = Array.isArray(ctx.agents) ? ctx.agents : []
+  const compactLedger = ctx.compactLedger === true
+  const artifactExists = typeof ctx.artifactExists === 'function' ? ctx.artifactExists : () => false
+  for (const row of gatelog) {
+    if (!PASS_VERDICT_RE.test(row.verdict || '')) continue
+    const expectedPersona = GATE_EXPECTED_PERSONA[row.gate]
+    if (!expectedPersona) continue
+
+    const legacySpawn = agents.some(a => a.persona === expectedPersona && (a.gate === row.gate || a.gate === ''))
+    const inlinePersonaMatches = row.persona === expectedPersona
+    const hasSpawn = compactLedger ? inlinePersonaMatches : legacySpawn
+    if (row.persona && row.persona !== expectedPersona) {
+      findings.push({
+        severity: 'P0',
+        rule: 'reconcileProvenance',
+        title: `contradictory persona provenance for ${row.gate} (${row.feature}): GATELOG names ${row.persona}, expected ${expectedPersona}`,
+      })
+    } else if (!hasSpawn) {
+      findings.push({
+        severity: 'P0',
+        rule: 'reconcileProvenance',
+        title: `fabricated ${row.gate} attestation (${row.feature}): claimed PASS with no distinct ${expectedPersona} spawn in ${compactLedger ? 'GATELOG' : 'AGENTS.md'}`,
+      })
+    }
+    if (compactLedger && (!row.model || !row.effort)) {
+      findings.push({
+        severity: 'P0',
+        rule: 'reconcileProvenance',
+        title: `incomplete ${row.gate} attestation (${row.feature}): compact GATELOG row has no model/effort provenance`,
+      })
+    } else if (compactLedger) {
+      findings.push(...launchProvenanceFindings(row, ctx.launchBinding))
+    }
+    if (!(row.artifacts || []).some(artifactExists)) {
+      findings.push({
+        severity: 'P0',
+        rule: 'reconcileProvenance',
+        title: `fabricated ${row.gate} attestation (${row.feature}): claimed PASS with no matching artifact file on disk`,
+      })
+    }
+  }
+  return findings
+}
+
+// countSubstantiveCaptures (PLAN-substance-provenance): enumerated REAL evidence in a
+// markdown body - SUBSTANTIVE fenced blocks (a lone decorative empty fence does NOT
+// count), table DATA rows (not the |---| separator), and broad-runner invocations. PURE.
+function countSubstantiveCaptures(text) {
+  const segments = String(text).split('```')
+  let fences = 0
+  for (let i = 1; i < segments.length; i += 2) {
+    const inner = segments[i] || ''
+    const innerNonWs = inner.replace(/\s/g, '').length
+    if (innerNonWs >= MIN_FENCE_CONTENT_CHARS || BROAD_RUNNER_RE.test(inner) || /\bexit\b|\bpass|\bfail|\bok\b/i.test(inner)) {
+      fences++
+    }
+  }
+  const tableRows = (text.match(/^\s*\|.+\|\s*$/gm) || [])
+    .filter(r => !/^\s*\|[\s:|-]+\|\s*$/.test(r)).length
+  const runners = (text.match(new RegExp(BROAD_RUNNER_RE.source, 'gi')) || []).length
+  return fences + tableRows + runners
+}
+
+// artifactSubstantiationReasons (PLAN-substance-provenance v3): the per-body reasons a
+// verdict is UNSUBSTANTIATED. (b) non-empty/non-stub floor; (c) on-point per gate TYPE
+// - a capture gate PASS rests ONLY on a runner token or the structured schema green
+// field (a bare fence/row count NEVER substantiates - v3 fix); (d) count-reconcile.
+function artifactSubstantiationReasons(row, body) {
+  const reasons = []
+  const text = typeof body === 'string' ? body : ''
+  const nonWs = text.replace(/\s/g, '').length
+  if (nonWs < MIN_SUBSTANCE_CHARS) {
+    reasons.push(`empty/stub artifact (${nonWs} non-ws chars < ${MIN_SUBSTANCE_CHARS}) - a present file is not substance`)
+    return reasons
+  }
+  const captureCount = countSubstantiveCaptures(text)
+  const claimsPass = PASS_VERDICT_RE.test(row.verdict || '')
+  const kind = GATE_SUBSTANCE_KIND[row.gate] || 'prose'
+  if (kind === 'capture') {
+    if (claimsPass) {
+      const hasGreenSchema = VERIFY_GREEN_RE.test(text)
+      const hasCapturedRun = BROAD_RUNNER_RE.test(text) || VERIFY_EVIDENCE_RE.test(text)
+      if (!hasGreenSchema && !hasCapturedRun) {
+        reasons.push(`${row.gate} verdict claims pass but body carries NO captured-run evidence - no verify-schema green field (reproNowGreen=true / testCommand / coveragePercent), no recognized runner invocation. A bare fence or table row is NOT a captured run.`)
+      }
+      if (VERIFY_NOT_GREEN_RE.test(text)) {
+        reasons.push(`${row.gate} claims pass but body states reproNowGreen=false - the artifact's own schema contradicts the verdict`)
+      }
+      if (REGRESSIONS_NONEMPTY_RE.test(text)) {
+        reasons.push(`${row.gate} claims pass but body lists a non-empty preExistingRegressions - a green->red flip is NOT a pass (GATES.md G6)`)
+      }
+    }
+  } else {
+    const onPoint = (row.feature && text.includes(row.feature)) || new RegExp(`\\b${row.gate}\\b`).test(text)
+    if (!onPoint) {
+      reasons.push(`${row.gate} artifact does not reference feature ${row.feature || '(none)'} or gate ${row.gate} - off-point / not the claimed evidence`)
+    }
+  }
+  const claimsClean = CLEAN_CLAIM_RE.test(row.verdict || '') || CLEAN_CLAIM_RE.test(text)
+  if (claimsClean && captureCount < MIN_CAPTURE_ITEMS) {
+    reasons.push(`claims clean/zero-gap but body enumerates ZERO substantive captured items (CONV-38 hollow verdict) - a "hardGapCount 0" over no captures is fabricated`)
+  }
+  const m = COUNT_CLAIM_RE.exec(row.verdict || '') || COUNT_CLAIM_RE.exec(text)
+  if (m) {
+    const claimed = Number(m[1] || m[2] || m[3])
+    if (claimed > 0 && captureCount === 0) {
+      reasons.push(`claims ${claimed} checked item(s) but body enumerates none - claimed count contradicts the artifact body`)
+    }
+  }
+  return reasons
+}
+
+// artifactSubstanceFindings (PLAN-substance-provenance): a GATELOG PASS-family verdict
+// is legitimate only when at least ONE named artifact is present AND substantiates the
+// verdict (re-derived from the body, not asserted in prose). reconcileProvenance proved
+// PRESENCE; this proves SUBSTANCE. .some over the artifact set - reordering cannot
+// launder a hollow file behind a decoy. Permissive-on-absence: pure absence is
+// reconcileProvenance's P0, not ours.
+function artifactSubstanceFindings(ctx) {
+  const findings = []
+  const gatelog = Array.isArray(ctx.gatelog) ? ctx.gatelog : []
+  const artifactExists = typeof ctx.artifactExists === 'function' ? ctx.artifactExists : () => false
+  const readArtifact = typeof ctx.readArtifact === 'function' ? ctx.readArtifact : () => null
+  for (const row of gatelog) {
+    if (!PASS_VERDICT_RE.test(row.verdict || '')) continue
+    const present = (row.artifacts || []).filter(artifactExists)
+    if (present.length === 0) continue
+    const bodies = present.map(readArtifact).filter(b => typeof b === 'string')
+    if (bodies.length === 0) {
+      findings.push({
+        severity: 'P0', rule: 'artifactSubstanceFindings',
+        title: `unsubstantiated ${row.gate} verdict (${row.feature}): ${present.length} artifact(s) present on disk but UNREADABLE - a verdict cannot rest on a file that cannot be opened`,
+      })
+      continue
+    }
+    const reasonsPerBody = bodies.map(b => artifactSubstantiationReasons(row, b))
+    if (reasonsPerBody.some(r => r.length === 0)) continue
+    const best = reasonsPerBody.reduce((a, b) => (b.length < a.length ? b : a))
+    findings.push({
+      severity: 'P0', rule: 'artifactSubstanceFindings',
+      title: `unsubstantiated ${row.gate} verdict (${row.feature}): NONE of ${bodies.length} present artifact(s) substantiates the verdict - ${best.join('; ')}`,
+    })
+  }
+  return findings
+}
+
+function parseRoadmapItems(text) {
+  if (typeof text !== 'string' || text.trim() === '') return []
+  try {
+    const parsed = JSON.parse(text)
+    if (parsed && Array.isArray(parsed.items)) {
+      return parsed.items
+        .filter(item => item && typeof item.id === 'string' && item.id.trim() !== '')
+        .map(item => ({ id: item.id.trim(), title: typeof item.title === 'string' ? item.title.trim() : '' }))
+    }
+  } catch {
+    // Markdown roadmaps are a supported compatibility input.
+  }
+  const items = []
+  const seen = new Set()
+  for (const line of text.split('\n')) {
+    const match = line.match(/^#{1,6}\s+(F(?:X-[A-Z0-9-]+|-[A-Z0-9-]+|\d+)|SPEC-\d+)\s*(?::|-|-)\s*(.+)$/)
+    if (!match || seen.has(match[1])) continue
+    seen.add(match[1])
+    items.push({ id: match[1], title: match[2].trim() })
+  }
+  return items
+}
+
+function rowHasSubstantiveEvidence(row, ctx) {
+  if (typeof ctx.artifactExists !== 'function' || typeof ctx.readArtifact !== 'function') {
+    return false
+  }
+  const { artifactExists, readArtifact } = ctx
+  for (const artifact of row.artifacts) {
+    if (!artifactExists(artifact)) continue
+    const body = readArtifact(artifact)
+    if (typeof body !== 'string') continue
+    const verifyRow = { ...row, gate: 'G6', verdict: 'VERIFIED' }
+    if (artifactSubstantiationReasons(verifyRow, body).length === 0) return true
+  }
+  return false
+}
+
+function roadmapClosureFindings(ctx) {
+  if (ctx.terminal !== true || ctx.compactLedger !== true) return []
+  const items = Array.isArray(ctx.roadmapItems) ? ctx.roadmapItems : []
+  if (items.length === 0) {
+    return [{ severity: 'P0', rule: 'roadmapClosureFindings', title: 'terminal new-format run has no parseable ROADMAP.md items - closure cannot be reconstructed' }]
+  }
+  const gatelog = Array.isArray(ctx.gatelog) ? ctx.gatelog : []
+  if (typeof ctx.gatelogText !== 'string' || ctx.gatelogText.trim() === '') {
+    return [{ severity: 'P0', rule: 'roadmapClosureFindings', title: 'terminal new-format run has GATELOG.md empty - no roadmap frontier can be proven' }]
+  }
+  const goalFrontiers = parseGoalCheckFrontiers(ctx.gatelogText)
+  const findings = []
+  for (const item of items) {
+    const rows = gatelog.filter(row => row && row.feature === item.id)
+    const hasDone = goalFrontiers.some(frontier => frontier.feature === item.id && frontier.isDone)
+    if (!hasDone) {
+      findings.push({ severity: 'P0', rule: 'roadmapClosureFindings', title: `${item.id} (${item.title || 'roadmap item'}) has no terminal frontier in GATELOG.md` })
+      continue
+    }
+    const terminalEvidence = rows.filter(row => row.gate === 'G6')
+    if (!terminalEvidence.some(row => rowHasSubstantiveEvidence(row, ctx))) {
+      findings.push({ severity: 'P0', rule: 'roadmapClosureFindings', title: `${item.id} (${item.title || 'roadmap item'}) has no substantive terminal evidence backing its DONE frontier` })
+    }
+  }
+  return findings
+}
+
+// mixedLedgerFormatFindings: a new-format run (PROMPTS.txt + ROADMAP.md + GATELOG.md)
+// whose directory ALSO carries parseable legacy AGENTS.md spawn rows has two provenance
+// sources claiming the same run. That contradiction fails closed - the checker cannot
+// know which source is authoritative, and a stale file must never silently reroute
+// provenance through the legacy table. An AGENTS.md that exists but parses to ZERO
+// spawn rows (heading-only residue) is harmless: no finding, closure proceeds.
+function mixedLedgerFormatFindings(ctx) {
+  const findings = []
+  if (ctx == null || ctx.compactLedger !== true) return findings
+  const agents = Array.isArray(ctx.agents) ? ctx.agents : []
+  if (agents.length > 0) {
+    findings.push({
+      severity: 'P0',
+      rule: 'mixedLedgerFormatFindings',
+      title: `CONTRADICTORY MIXED-FORMAT LEDGER: new-format PROMPTS.txt/ROADMAP.md/GATELOG.md coexist with ${agents.length} AGENTS.md spawn row(s) - two provenance sources claim the same run. Remove the stale legacy file, or resume explicitly against the legacy prompt directory.`,
+    })
+  }
+  return findings
+}
+
+// scanTranscript (pure): classify ONE transcript's tool_use events.
+// production Edit/Write = an Edit/Write/MultiEdit tool_use whose file_path is NOT
+// under tests/ and NOT an artifact/ledger path. verify/goal-check pytest = a Bash
+// tool_use whose command matches REAL_RUNNER_RE. Returns the booleans the F5-18
+// rule + the five FX-HIERARCHY rules key on, all derived from the SAME tool_use
+// walk. Tolerant of format drift: tool_use found by name + a path heuristic; an
+// unparseable transcript yields all-false / empty.
+//
+// FX-HIERARCHY derived fields:
+//   hasBashEditWrite   - ANY Bash OR Edit/Write/MultiEdit, regardless of path
+//                        (FIX-10 ap-manager exec guard).
+//   hasNonAgentToolUse - ANY tool_use whose name is NOT Agent and NOT Task
+//                        (FIX-11 L0 conductor Agent-only guard).
+//   wroteDoneSentinel  - a Write/Edit/MultiEdit to a DONE-<nonce> or .../DONE path
+//                        (FIX-14 only ap-janitor may write the sentinel).
+//   wroteGoalCheck     - a Write/Edit/MultiEdit to a goal-check*.md path
+//                        (FIX-14 only ap-goal-checker authors the verdict).
+//   spawnedTypes       - every subagent_type on an Agent/Task tool_use
+//                        (FIX-13 an L1 node's children must all be ap-manager).
+const DONE_SENTINEL_RE = /(^|[\/\\])DONE-|[\/\\]DONE$/
+const GOAL_CHECK_FILE_RE = /goal-check[^\/\\]*\.md$/
+// PLAN-e2e-verify: the goal-check artifact's machine lines. E2E_AXIS_RE captures the
+// tri-axis line `E2E: scope=<pass|gap> prompt=<pass|gap> flaws=<n> ran=<rest-of-line>`;
+// `ran` is terminal (greedy to EOL) so a run description with spaces survives. OPEN_
+// BLOCKERS_RE reads the `OPEN-BLOCKERS:<n>` count. GOAL_CHECK_ARTIFACT_RE selects the
+// goal-check-vN.md artifact bodies threaded into ctx.goalCheckArtifacts.
+const E2E_AXIS_RE = /^E2E:\s*scope=(pass|gap)\s+prompt=(pass|gap)\s+flaws=(\d+)\s+ran=(.*)$/im
+const OPEN_BLOCKERS_RE = /^OPEN-BLOCKERS:\s*(\d+)\s*$/im
+const GOAL_CHECK_ARTIFACT_RE = /goal-check[^\/\\]*\.md$/i
+// FIX-016 (PLAN-anchor): the SCRIBE-maintained parent-anchor resume file.
+const ANCHOR_FILE_RE = /(^|[\/\\])ANCHOR\.md$/
+function scanTranscript(jsonlText) {
+  let hasProductionEditOrWrite = false
+  let hasVerifyOrGoalCheckPytest = false
+  let hasBashEditWrite = false
+  let hasWriteEditBashWebTool = false
+  let hasNonAgentToolUse = false
+  let wroteDoneSentinel = false
+  let wroteGoalCheck = false
+  let hasUserInterrupt = false
+  let wroteAnchor = false
+  let hasGitAddAll = false
+  let hasGitCommit = false
+  // PLAN-startup-handshake: the name of the FIRST tool_use seen anywhere in this
+  // transcript, in scan order ('' if the transcript emitted none). startupHandshake
+  // Findings reads it on the 00-conductor ROOT to tell "asked the handshake FIRST"
+  // (AskUserQuestion) from "did some other tool first" (the startup-drift signature).
+  let firstToolUseName = ''
+  const spawnedTypes = []
+  const spawnedDescriptions = []
+  const assistantTextParts = []
+  let maxToolResultChars = 0
+  let hasOversizedReport = false
+  let fleetTableTurns = 0
+  // SPEC-2 wave-barrier: per-event (per-turn) spawn batching. maxBatchedSpawns is
+  // the widest single-turn Agent/Task batch; hadFoldOrDispatchAfterWave is true when
+  // a later assistant turn carried a text fold OR a further spawn. totalSpawnCount is
+  // diagnostics only.
+  let maxBatchedSpawns = 0
+  let maxBatchIndex = -1
+  let totalSpawnCount = 0
+  // PLAN-supervisor-collapse: the widest single-turn count of ap-feature-coordinator children
+  // (the supervisor-per-feature signature). Fail-closed: no such spawn anywhere -> 0.
+  let maxFeatureSupervisorWave = 0
+  const eventTurns = []
+  const parsedEvents = []
+  const livenessTurns = []
+  // PLAN-time-optimization (serialGateFindings): per-turn gate labels read from each turn's
+  // SPAWN descriptions, so the rule can tell a batched independent pair (one turn) from a
+  // serialized one (two turns). PLAN-false-negative-liveness: dead-conclusion turns +
+  // transcript-level respawn targets.
+  const gateSpawnTurns = []
+  const deadConclusionTurns = []
+  const respawnTargets = new Set()
+  // SPD-2 evidence-pack: the Set of PRODUCTION file paths this transcript opened with the Read tool
+  // (filtered by isProductionPath - test/artifact reads excluded). Used by evidencePackFindings to
+  // count how many gates of one feature re-Read the SAME prod file with no <feature>-context.md pack.
+  const readsProductionFiles = new Set()
+  const lines = (typeof jsonlText === 'string' ? jsonlText : '').split('\n')
+  let eventIndex = -1
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed === '') continue
+    let event
+    try { event = JSON.parse(trimmed) } catch (e) { continue }
+    parsedEvents.push(event)
+    eventIndex++
+    let spawnsThisEvent = 0
+    let featureSupervisorsThisEvent = 0
+    let hasTextBlock = hasAssistantText(event)
+    const turnText = assistantText(event)
+    if (turnText) assistantTextParts.push(turnText)
+    const gateLabelsThisTurn = new Set()
+    // PLAN-lean-L0-coordinator: ingested tool_result size + fleet-table-rebuild signals.
+    for (const result of toolResults(event)) {
+      const len = result.length
+      if (len > maxToolResultChars) maxToolResultChars = len
+      if (len > VERDICT_BUDGET_CHARS || REAL_RUNNER_RE.test(result) || DIFF_RE.test(result)) hasOversizedReport = true
+    }
+    if (turnText) {
+      const fleetRows = (turnText.match(new RegExp(FLEET_ROW_RE.source, 'gim')) || []).length
+      const hasFleetHeader = /\|\s*feature\s*\|[^\n]*\|\s*status\s*\|/i.test(turnText)
+      if (fleetRows >= FLEET_ROW_MIN || hasFleetHeader) fleetTableTurns++
+    }
+    for (const use of toolUses(event)) {
+      const name = String(use.name)
+      const input = use.input || {}
+      if (name !== '' && firstToolUseName === '') firstToolUseName = name   // PLAN-startup-handshake: first tool in scan order
+      if (name !== '' && name !== 'Agent' && name !== 'Task') hasNonAgentToolUse = true
+      // hasWriteEditBashWebTool marks GENERAL mutation/web I/O (Write/Edit/MultiEdit/
+      // Bash/WebSearch/WebFetch), used by non-L1 checks. It is NOT the L1 gate: an L1
+      // coordinator is Agent-ONLY (base:68), so the L1 doctrine keys on hasNonAgentToolUse
+      // (Read/Glob/Grep included) - see l1ChildrenFindings.
+      if (name === 'WebSearch' || name === 'WebFetch') hasWriteEditBashWebTool = true
+      if (name === 'AskUserQuestion') hasUserInterrupt = true
+      if (name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
+        hasBashEditWrite = true
+        hasWriteEditBashWebTool = true
+        const filePath = String(input.file_path || input.path || '')
+        if (filePath && isProductionPath(filePath)) hasProductionEditOrWrite = true
+        if (filePath && DONE_SENTINEL_RE.test(filePath)) wroteDoneSentinel = true
+        if (filePath && GOAL_CHECK_FILE_RE.test(filePath)) wroteGoalCheck = true
+        if (filePath && ANCHOR_FILE_RE.test(filePath)) wroteAnchor = true
+      } else if (name === 'Bash') {
+        hasBashEditWrite = true
+        hasWriteEditBashWebTool = true
+        const command = String(input.command || '')
+        if (REAL_RUNNER_RE.test(command)) hasVerifyOrGoalCheckPytest = true
+        if (GIT_ADD_ALL_RE.test(command)) hasGitAddAll = true
+        if (GIT_COMMIT_RE.test(command)) hasGitCommit = true
+      } else if (name === 'Read') {
+        const filePath = String(input.file_path || input.path || '')
+        if (filePath && isProductionPath(filePath)) readsProductionFiles.add(filePath)
+      } else if (name === 'Agent' || name === 'Task') {
+        const childType = input.subagent_type || input.agentType
+        if (typeof childType === 'string' && childType !== '') spawnedTypes.push(childType)
+        if (childType === 'ap-feature-supervisor' || childType === 'ap-feature-coordinator') featureSupervisorsThisEvent++
+        spawnsThisEvent++
+        totalSpawnCount++
+        const desc = typeof input.description === 'string' && input.description.trim() !== ''
+          ? input.description.trim()
+          : (typeof input.prompt === 'string' && input.prompt.trim() !== '' ? input.prompt.trim().slice(0, 40) : '')
+        if (desc !== '') spawnedDescriptions.push(desc)
+        // PLAN-time-optimization: classify this spawn's gate from its description + child persona.
+        const gate = gateLabelFromSpawn(desc, typeof childType === 'string' ? childType : '')
+        if (gate) gateLabelsThisTurn.add(gate)
+      }
+    }
+    if (gateLabelsThisTurn.size > 0) gateSpawnTurns.push({ index: eventIndex, gateLabels: gateLabelsThisTurn })
+    if (spawnsThisEvent > maxBatchedSpawns) { maxBatchedSpawns = spawnsThisEvent; maxBatchIndex = eventIndex }
+    if (featureSupervisorsThisEvent > maxFeatureSupervisorWave) maxFeatureSupervisorWave = featureSupervisorsThisEvent
+    eventTurns.push({ index: eventIndex, spawnCount: spawnsThisEvent, hasTextBlock })
+  }
+  const hadFoldOrDispatchAfterWave = maxBatchIndex >= 0 &&
+    eventTurns.some(t => t.index > maxBatchIndex && (t.hasTextBlock === true || t.spawnCount > 0))
+  const assistantTextAll = assistantTextParts.join('\n')
+  const hasLeanAsIdleNarration = LEAN_TOKEN_RE.test(assistantTextAll) && IDLE_TOKEN_RE.test(assistantTextAll) && !LEGIT_WAIT_RE.test(assistantTextAll)
+  const dispatchedAnyTrack = spawnedTypes.length >= 1
+  // PLAN-liveness-reconcile: per-turn walk. A turn that narrates the fleet as running
+  // records its claimed ids/labels + the same-turn poll (its result bound from the NEXT
+  // event; a DEAD_SIGNAL result strips that id/label from the backing poll set).
+  for (let i = 0; i < parsedEvents.length; i++) {
+    const event = parsedEvents[i]
+    const text = assistantText(event)
+    if (!RUNNING_NARRATION_RE.test(text)) continue
+    const claimedAgentIds = new Set([...text.matchAll(AGENT_ID_RE)].map(m => m[1].toLowerCase()))
+    const claimedLabels = new Set([...text.matchAll(FEATURE_LABEL_RE)].map(m => m[1].toUpperCase()))
+    if (claimedAgentIds.size === 0 && claimedLabels.size === 0) claimedAgentIds.add('__unnamed__')
+    const resultText = pollResultsText(parsedEvents, i)
+    let polledThisTurn = false
+    const polledAgentIds = new Set()
+    const polledLabels = new Set()
+    for (const use of toolUses(event)) {
+      const name = String(use.name)
+      const input = use.input || {}
+      const isPoll = POLL_TOOL_NAMES.has(name) ||
+        (name === 'Bash' && BASH_POLL_RE.test(String(input.command || ''))) ||
+        ((name === 'Read' || name === 'Edit') && POLL_READ_RE.test(String(input.file_path || input.path || '')))
+      if (!isPoll) continue
+      polledThisTurn = true
+      const probe = `${input.command || ''} ${input.file_path || input.path || ''} ${input.description || ''}`
+      for (const m of probe.matchAll(AGENT_ID_RE)) polledAgentIds.add(m[1].toLowerCase())
+      for (const m of probe.matchAll(FEATURE_LABEL_RE)) polledLabels.add(m[1].toUpperCase())
+    }
+    // result-bind: a poll whose result is a DEAD signal does NOT back the claim - the
+    // polled ids/labels (whose liveness the dead result refutes) are dropped.
+    if (DEAD_SIGNAL_RE.test(resultText)) {
+      polledAgentIds.clear()
+      polledLabels.clear()
+      polledThisTurn = false
+    }
+    livenessTurns.push({ index: i, claimedAgentIds, claimedLabels, polledThisTurn, polledAgentIds, polledLabels })
+  }
+  // PLAN-false-negative-liveness (EDIT 2): a PARALLEL per-turn walk capturing DEAD-CONCLUSION turns. A turn
+  // that narrates a spawned agent dead/absent + the same-turn task-status polls (bound PER-USE so a poll of A
+  // never clears a conclusion about B) + any disk-only read + any spawn (the duplicate-onto-owned arm's input).
+  for (let i = 0; i < parsedEvents.length; i++) {
+    const event = parsedEvents[i]
+    const text = assistantText(event)
+    if (!DEAD_CONCLUSION_RE.test(text)) continue
+    const deadConcludedIds = new Set([...text.matchAll(AGENT_ID_RE)].map(m => m[1].toLowerCase()))
+    const deadConcludedLabels = new Set([...text.matchAll(FEATURE_LABEL_RE)].map(m => m[1].toUpperCase()))
+    const taskStatusDeadIds = new Set()
+    const taskStatusDeadLabels = new Set()
+    const taskStatusRunningIds = new Set()
+    const taskStatusRunningLabels = new Set()
+    const spawnedIdsThisTurn = new Set()
+    const spawnedLabelsThisTurn = new Set()
+    let diskReadThisTurn = false
+    for (const use of toolUses(event)) {
+      const name = String(use.name)
+      const input = use.input || {}
+      const isTaskStatusPoll = POLL_TOOL_NAMES.has(name) ||
+        (name === 'Bash' && BASH_POLL_RE.test(String(input.command || '')))
+      const isDiskRead = (name === 'Read' || name === 'Edit') &&
+        POLL_READ_RE.test(String(input.file_path || input.path || ''))
+      if (isTaskStatusPoll) {
+        const probe = `${input.command || ''} ${input.description || ''}`
+        const polledIds = [...probe.matchAll(AGENT_ID_RE)].map(m => m[1].toLowerCase())
+        const polledLbls = [...probe.matchAll(FEATURE_LABEL_RE)].map(m => m[1].toUpperCase())
+        const result = toolResultForUse(parsedEvents, i, use.id)
+        const confirmsDead = TASK_STATUS_DEAD_RE.test(result) || DEAD_SIGNAL_RE.test(result)
+        for (const id of polledIds) (confirmsDead ? taskStatusDeadIds : taskStatusRunningIds).add(id)
+        for (const lbl of polledLbls) (confirmsDead ? taskStatusDeadLabels : taskStatusRunningLabels).add(lbl)
+      } else if (isDiskRead) {
+        diskReadThisTurn = true
+      } else if (name === 'Agent' || name === 'Task') {
+        const desc = typeof input.description === 'string' ? input.description
+          : (typeof input.prompt === 'string' ? input.prompt : '')
+        for (const m of desc.matchAll(AGENT_ID_RE)) { spawnedIdsThisTurn.add(m[1].toLowerCase()); respawnTargets.add(m[1].toLowerCase()) }
+        for (const m of desc.matchAll(FEATURE_LABEL_RE)) { spawnedLabelsThisTurn.add(m[1].toUpperCase()); respawnTargets.add(m[1].toUpperCase()) }
+      }
+    }
+    deadConclusionTurns.push({
+      index: i, deadConcludedIds, deadConcludedLabels, diskReadThisTurn,
+      taskStatusDeadIds, taskStatusDeadLabels, taskStatusRunningIds, taskStatusRunningLabels,
+      spawnedIdsThisTurn, spawnedLabelsThisTurn,
+    })
+  }
+  return {
+    hasProductionEditOrWrite, hasVerifyOrGoalCheckPytest,
+    hasBashEditWrite, hasWriteEditBashWebTool, hasNonAgentToolUse, wroteDoneSentinel, wroteGoalCheck, spawnedTypes,
+    hasUserInterrupt, wroteAnchor,
+    maxBatchedSpawns, hadFoldOrDispatchAfterWave, totalSpawnCount,
+    maxFeatureSupervisorWave,
+    hasGitAddAll, hasGitCommit,
+    spawnedDescriptions,
+    hasLeanAsIdleNarration, dispatchedAnyTrack,
+    maxToolResultChars, hasOversizedReport, fleetTableTurns,
+    livenessTurns,
+    gateSpawnTurns,
+    deadConclusionTurns, respawnTargets,
+    readsProductionFiles: [...readsProductionFiles],
+    firstUserTurnText: firstUserText(parsedEvents),
+    userTurnTexts: allUserTexts(parsedEvents),
+    firstToolUseName,
+  }
+}
+
+// gateLabelFromSpawn (PLAN-time-optimization): classify ONE spawn's gate from its description + child
+// persona. Priority-ordered so "fresh-verify" -> G3 (never G6) and "impl-review" -> G5 (never G2). Returns
+// '' when no gate is identifiable (fail-closed: serialGateFindings never fires on an unclassifiable spawn).
+function gateLabelFromSpawn(description, childType) {
+  const d = `${description || ''} ${childType || ''}`.toLowerCase()
+  if (/\bg3\b|fresh-?verif|ap-fresh-verifier/.test(d)) return 'G3'
+  if (/\bg2\b|plan-?review|ap-reviewer.*plan|review.*plan/.test(d)) return 'G2'
+  if (/\bg6\b|\bverif(?:y|ier|ication)\b|ap-verifier/.test(d)) return 'G6'
+  if (/\bg5\b|impl-?review|implementation review|ap-reviewer/.test(d)) return 'G5'
+  return ''
+}
+
+// toolResultForUse (PLAN-false-negative-liveness EDIT 2b): the tool_result text bound to ONE tool_use by
+// tool_use_id (the next event carries the results; multiple same-turn polls each return their own block).
+// '' when unpaired/absent - the caller then treats the id as NOT-confirmed-dead (alive), the mission's
+// fail-direction (never declare dead on an unconfirmable check). Per-USE binding is what makes the
+// dead-confirmation per-ID, not per-turn.
+function toolResultForUse(events, fromIndex, useId) {
+  const next = events[fromIndex + 1]
+  if (!next || useId == null) return ''
+  const msg = next.message || next
+  const blocks = Array.isArray(msg.content) ? msg.content : (Array.isArray(next.content) ? next.content : [])
+  for (const b of blocks) {
+    if (!b || b.type !== 'tool_result' || b.tool_use_id !== useId) continue
+    const c = b.content
+    if (typeof c === 'string') return c
+    if (Array.isArray(c)) return c.map(x => (x && typeof x.text === 'string') ? x.text : (typeof x === 'string' ? x : '')).join('\n')
+    if (c && typeof c.text === 'string') return c.text
+  }
+  return ''
+}
+
+// pollResultsText: gather the tool_result content text from the event AFTER fromIndex
+// (a poll's result returns in the following user/tool_result event). '' if none.
+function pollResultsText(events, fromIndex) {
+  const next = events[fromIndex + 1]
+  if (!next) return ''
+  return toolResults(next).join('\n')
+}
+
+// assistantText: pull the assistant-authored TEXT out of one event (string content,
+// or content[] blocks of type 'text'). Tolerant: a non-assistant or tool-only event
+// yields ''. Shared by the lean-idle and liveness rules.
+function assistantText(event) {
+  if (!event || typeof event !== 'object') return ''
+  const msg = event.message || event
+  const role = msg.role || event.type
+  if (role !== 'assistant') return ''
+  const content = msg.content
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content.filter(b => b && b.type === 'text' && typeof b.text === 'string')
+    .map(b => b.text).join('\n')
+}
+
+// firstUserText (INH-5): the first user-role TEXT turn - the spawn BRIEF - string
+// content, or content[] text blocks joined. SKIPS tool_result-only user turns (gate
+// results, not the brief) and whitespace-only content. '' when none. Pure, total;
+// tolerant of {message:{role,content}} and {role|type,content}. The inverse of
+// assistantText (role==='user'); used by missionFidelityFindings to diff the received
+// brief against PROMPTS.txt.
+function firstUserText(events) {
+  for (const event of (Array.isArray(events) ? events : [])) {
+    if (!event || typeof event !== 'object') continue
+    const msg = event.message || event
+    const role = msg.role || event.type
+    if (role !== 'user') continue
+    const content = msg.content
+    if (typeof content === 'string') { if (content.trim() !== '') return content }
+    else if (Array.isArray(content)) {
+      const textParts = content
+        .filter(b => b && b.type === 'text' && typeof b.text === 'string')
+        .map(b => b.text)
+      if (textParts.length) return textParts.join('\n')
+    }
+  }
+  return ''
+}
+
+// === MISSION-FIDELITY (INH-5) =================================================
+// Lockstep duplicates of gate.js's brief() framing (gate.js is ESM-shaped, not
+// require-able here - the same necessity as GATE_EXPECTED_PERSONA). The test asserts
+// each is a verbatim substring of autoprompt-gate.js, so a future label edit there
+// fails the lockstep tripwire loudly.
+const MISSION_BLOCK_LABEL = 'ORIGINAL MISSION (the user prompt, verbatim, the constitution for this work; it OUTRANKS every plan, artifact, and reviewer note below; verify against THIS text, never against what another agent told you):'
+const MISSION_POINTER_LABEL = 'MISSION POINTER: read the exact prompt ledger before acting; stop if its hash or byte length differs.'
+const PRIOR_STEERS_BLOCK_LABEL = 'PROMPTS-SO-FAR (the user\'s later steers in this session; they ride ALONGSIDE the ORIGINAL MISSION and refine HOW to do it, but the ORIGINAL MISSION above OUTRANKS them - a steer can never override what the mission asks):'
+
+// Tells DIFFERS(paraphrase) from ABSENT - both P0. Run ONLY over the received brief,
+// never the source. A mission-labelled header (the gate label OR a bare "MISSION:")
+// present without the verbatim bytes is a paraphrase; no header at all is an omission.
+const MISSION_HEADER_RE = /ORIGINAL MISSION|MISSION POINTER|^MISSION:/im
+const MISSION_POINTER_LINE_RE = /^path=(\S+) hash=sha256:([a-f0-9]{64}) bytes=(\d+) nonce=(\S+)$/m
+// The ONLY legal bytes before the mission anchor: the "You are <role>.\n\n" persona line.
+const PERSONA_PREAMBLE_RE = /^You are [^\n]*\.\n\n$/
+// INH-4 / Arbiter A1: the UNSPOOFABLE one-per-run conductor ROOT, keyed on the
+// 00-conductor ROOT FILENAME (never the spoofable cl-conductor persona). Exactly the
+// live idiom at scanTranscriptDir (`/(^|[\/\\])00-conductor/`). A cl-conductor-PERSONA
+// subagent spawn (sub-cl-conductor-NN.jsonl) does NOT match and is mission-diffed.
+const CONDUCTOR_ROOT_RE = /(^|[\/\\])00-conductor/
+
+// parsePromptsTxt: split the verbatim PROMPTS.txt ledger into ordered prompt blocks on
+// "=== PROMPT N ===". block0 = mission, block1.. = later steers. Strips a trailing
+// newline run; PRESERVES internal blank lines (a multi-paragraph mission). Pure, total;
+// no markers -> [] (no usable source -> the brief-diff arm goes inert).
+function parsePromptsTxt(text) {
+  const lines = String(text == null ? '' : text).split('\n')
+  const blocks = []
+  let current = null
+  const MARKER = /^=== PROMPT \d+ ===\s*$/
+  for (const line of lines) {
+    if (MARKER.test(line)) { current = []; blocks.push(current); continue }
+    if (current) current.push(line)
+  }
+  return blocks.map(b => b.join('\n').replace(/\n+$/, ''))
+}
+
+// missionFidelityFindings (INH-5 - TEXT-DIFF canary; the mission's "not some LLM
+// rewritten slop version" made structural). P0. INERT when PROMPTS.txt is absent
+// (ctx.promptsText == null): no source -> nothing to diff -> [] (missionSourceOfTruth
+// Findings owns the "absent on a DONE run" case so this arm is never the false-positive
+// vector v1 died on). Arbiter A1: the 00-conductor ROOT (matched on its FILENAME, the
+// unspoofable one-per-run signal) is EXEMPT - its first user turn is the RAW user
+// prompt, the human boundary, with no MISSION_BLOCK_LABEL by construction. A
+// cl-conductor-PERSONA subagent spawn is NOT the root (its filename is
+// sub-cl-conductor-NN.jsonl), does NOT match CONDUCTOR_ROOT_RE, and IS mission-diffed.
+// When PROMPTS.txt IS present, for each non-root transcript's received brief
+// (firstUserTurnText): the verbatim mission must lead (only "You are <role>.\n\n"
+// before it) and every later steer must appear verbatim.
+function missionPointerReasons(ctx, brief) {
+  const reasons = []
+  const match = brief.match(MISSION_POINTER_LINE_RE)
+  if (!match) return ['MALFORMED: expected path, sha256 hash, byte length, and nonce']
+  if (ctx.promptsText == null) return ['SOURCE MISSING: PROMPTS.txt could not be read']
+
+  const [, pointerPath, pointerHash, pointerBytes, pointerNonce] = match
+  const expectedPath = typeof ctx.promptsPath === 'string' ? ctx.promptsPath : ''
+  const expectedNonce = typeof ctx.runNonce === 'string' ? ctx.runNonce : ''
+  const actualHash = crypto.createHash('sha256').update(ctx.promptsText, 'utf8').digest('hex')
+  const actualBytes = Buffer.byteLength(ctx.promptsText, 'utf8')
+
+  if (expectedPath !== '' && path.resolve(pointerPath) !== path.resolve(expectedPath)) reasons.push('PATH MISMATCH')
+  if (pointerHash !== actualHash) reasons.push('HASH MISMATCH')
+  if (Number(pointerBytes) !== actualBytes) reasons.push('BYTE-LENGTH MISMATCH')
+  if (expectedNonce !== '' && pointerNonce !== expectedNonce) reasons.push('NONCE MISMATCH')
+  return reasons
+}
+
+function missionFidelityFindings(ctx) {
+  const findings = []
+  if (ctx == null) return findings
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  const prompts = ctx.promptsText == null ? [] : parsePromptsTxt(ctx.promptsText)
+  const mission = prompts[0]
+  const steers = prompts.slice(1)
+  const anchor = mission === undefined ? '' : MISSION_BLOCK_LABEL + '\n' + mission + '\n'
+
+  for (const t of transcripts) {
+    if (!t || typeof t !== 'object') continue
+    if (CONDUCTOR_ROOT_RE.test(t.path || '')) continue
+    const brief = typeof t.firstUserTurnText === 'string' ? t.firstUserTurnText : ''
+    if (brief === '') continue
+    const where = t.path || '(unknown transcript)'
+
+    if (brief.includes(MISSION_POINTER_LABEL)) {
+      const pointerIdx = brief.indexOf(MISSION_POINTER_LABEL)
+      const prefix = brief.slice(0, pointerIdx)
+      const reasons = missionPointerReasons(ctx, brief)
+      if (prefix !== '' && !PERSONA_PREAMBLE_RE.test(prefix)) reasons.unshift('PRESENT-BUT-NOT-FIRST')
+      for (const reason of reasons) {
+        findings.push({
+          severity: 'P0', rule: 'missionFidelityFindings',
+          title: `MISSION POINTER ${reason} in ${where}: compact briefs must reference the exact PROMPTS.txt bytes with the canonical path, SHA-256 hash, byte length, and run nonce.`,
+        })
+      }
+      continue
+    }
+
+    if (mission === undefined) continue
+    const idx = brief.indexOf(anchor)
+    if (idx === -1) {
+      const hasHeader = MISSION_HEADER_RE.test(brief)
+      findings.push({
+        severity: 'P0', rule: 'missionFidelityFindings',
+        title: hasHeader
+          ? `MISSION DIFFERS (paraphrase) in ${where}: a mission-labelled header is present but its text is NOT byte-identical to PROMPTS.txt prompt 1 - an LLM-rewritten/bulletized mission ("slop") reached the spawn. Splice the mission from PROMPTS.txt bytes, never re-type it.`
+          : `MISSION ABSENT in ${where}: this spawned subagent's brief carries neither the verbatim ORIGINAL MISSION nor a verified mission pointer envelope.`,
+      })
+      continue
+    }
+    const prefix = brief.slice(0, idx)
+    if (prefix !== '' && !PERSONA_PREAMBLE_RE.test(prefix)) {
+      findings.push({
+        severity: 'P0', rule: 'missionFidelityFindings',
+        title: `MISSION PRESENT-BUT-NOT-FIRST in ${where}: the verbatim mission block appears at offset ${idx}, after non-persona content - the ORIGINAL MISSION must come FIRST, preceded only by "You are <role>.". Re-splice with the mission on top.`,
+      })
+      continue
+    }
+    for (let i = 0; i < steers.length; i++) {
+      if (steers[i] !== '' && !brief.includes(steers[i])) {
+        findings.push({
+          severity: 'P0', rule: 'missionFidelityFindings',
+          title: `STEER DROPPED/PARAPHRASED (prompt ${i + 2}) in ${where}: the verbatim later-steer bytes from PROMPTS.txt are not present in the brief - use the verified pointer envelope for compact workers or carry the full PROMPTS-SO-FAR bytes.`,
+        })
+      }
+    }
+  }
+  return findings
+}
+
+// missionSourceOfTruthFindings (INH-1 teeth): a run that REACHED DONE (a DONE-* sentinel
+// with done:true) with real gate activity but NO PROMPTS.txt on disk never created the
+// verbatim source of truth, so missionFidelityFindings could diff nothing and an
+// operational spawn could have dropped the mission unflagged. P0 - a run cannot seal
+// DONE without the source of truth. PERMISSIVE-ON-ABSENCE done right: keyed on REACHING
+// DONE (ctx.missionDone), NOT on bare gatelog presence - a literal "gatelog present + no
+// PROMPTS.txt" P0 would flip ~15 existing ok-true fixtures (GOOD_GATELOG, no PROMPTS.txt,
+// not done) and re-create the v1-class false-positive storm. DONE is the exact mission
+// boundary ("…drop the mission and still reach DONE") and the ONLY signal separating a
+// real run from those fixtures (none of which write a DONE sentinel).
+function missionSourceOfTruthFindings(ctx) {
+  const findings = []
+  if (ctx == null) return findings
+  if (ctx.promptsText != null) return findings                  // source of truth present -> brief-diff arm owns the rest
+  const gatelog = Array.isArray(ctx.gatelog) ? ctx.gatelog : []
+  if (ctx.missionDone === true && gatelog.length > 0) {
+    findings.push({
+      severity: 'P0', rule: 'missionSourceOfTruthFindings',
+      title: `MISSION SOURCE OF TRUTH ABSENT: the run reached DONE (a DONE-* done:true sentinel) with real gate activity but no PROMPTS.txt on disk - the verbatim user-prompt ledger (INH-1) was never written, so no operational/steering spawn's brief could be diffed against the mission. A run cannot seal DONE without the source of truth; INTAKE/SCRIBE must write PROMPTS.txt (=== PROMPT N === blocks) before any spawn.`,
+    })
+  }
+  return findings
+}
+
+// === SELFWRITTEN-CAPTURE-SLICE:START - test-only export seam; sliced by
+// selfwritten-capture-coverage.cjs. Self-contained: pure array/string helpers over
+// injected transcripts/promptsText, NO fs; the ONE external dep (CONDUCTOR_ROOT_RE)
+// is prepended by the coverage wrapper. ===
+
+// allUserTexts (INH-1 capture): EVERY user-role TEXT turn in order - the full sequence
+// of self-written human inputs in a session - as an array. The ALL-turns sibling of
+// firstUserText (which returns only the first); selfWrittenCaptureFindings needs the
+// whole sequence to prove each typed turn (answer / note / clarification / steer) rode
+// verbatim into PROMPTS.txt. SKIPS tool_result-only user turns (gate results and canned
+// menu answers, not typed text) and whitespace-only content - so a bare `mode=wide`
+// selection never appears here. Pure, total; fail-closed ([]) on non-array/garbage.
+function allUserTexts(events) {
+  const out = []
+  for (const event of (Array.isArray(events) ? events : [])) {
+    if (!event || typeof event !== 'object') continue
+    const msg = event.message || event
+    const role = msg.role || event.type
+    if (role !== 'user') continue
+    const content = msg.content
+    if (typeof content === 'string') { if (content.trim() !== '') out.push(content) }
+    else if (Array.isArray(content)) {
+      const textParts = content
+        .filter(b => b && b.type === 'text' && typeof b.text === 'string')
+        .map(b => b.text)
+      if (textParts.length) out.push(textParts.join('\n'))
+    }
+  }
+  return out
+}
+
+// selfWrittenCaptureFindings (INH-1 capture teeth): a run that REACHED DONE
+// (ctx.missionDone === true, the SAME sentinel guard as missionSourceOfTruthFindings so
+// NONE of the ~15 not-done fixtures flip) whose 00-conductor ROOT transcript shows a
+// SELF-WRITTEN user text turn (a typed answer / note / re-catch / clarification / steer)
+// that is NOT present verbatim in PROMPTS.txt. This is the "user answers a handshake
+// question or sends a clarification and it's never added to the mission" bug, made
+// structural - the dropped input never rode into every brief the way a steer does.
+//
+// Scoped to the UNSPOOFABLE 00-conductor ROOT (CONDUCTOR_ROOT_RE on the filename, the
+// human boundary - a cl-conductor PERSONA subagent does not match, exactly as in
+// missionFidelityFindings). Subagent briefs are machine-spliced (persona + mission +
+// steers), NOT self-written, and are already owned by missionFidelityFindings; diffing
+// them here would false-flag the whole spliced brief as an uncaptured "turn".
+//
+// Severity P1 (surfaced, NOT run-failing): the classifier of what MUST be captured lives
+// in prose (SKILL.md / GATES.md) + the writers (intake / scribe); this validator only
+// surfaces the structural gap. A benign conductor-root conversational turn the writers
+// legitimately did not capture must be SEEN, not FAIL the run - so P1, never P0 (a P0
+// would turn every "thanks, continue" into a run failure). P1 also keeps `ok`, which
+// keys only on P0, byte-identical on every green fixture.
+//
+// PERMISSIVE-ON-ABSENCE: ctx null, promptsText == null (missionSourceOfTruthFindings owns
+// that absent-source case - no double-fire), missionDone !== true, or no root user turns
+// => []. A turn whose trimmed bytes appear anywhere in PROMPTS.txt is captured.
+function selfWrittenCaptureFindings(ctx) {
+  const findings = []
+  if (ctx == null) return findings
+  if (ctx.promptsText == null) return findings                 // no source of truth -> SOT arm owns it
+  if (ctx.missionDone !== true) return findings                // same DONE guard: no not-done fixture flips
+  const promptsText = String(ctx.promptsText)
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || typeof t !== 'object') continue
+    if (!CONDUCTOR_ROOT_RE.test(t.path || '')) continue        // ONLY the human boundary (unspoofable root filename)
+    const turns = Array.isArray(t.userTurnTexts) ? t.userTurnTexts : []
+    for (const turn of turns) {
+      const typed = typeof turn === 'string' ? turn.trim() : ''
+      if (typed === '') continue
+      if (promptsText.includes(typed)) continue                // captured verbatim -> ok
+      const where = t.path                                     // truthy: it already matched CONDUCTOR_ROOT_RE above
+      const snippet = typed.length > 80 ? typed.slice(0, 80) + '…' : typed
+      findings.push({
+        severity: 'P1', rule: 'selfWrittenCaptureFindings',
+        title: `SELF-WRITTEN INPUT DROPPED in ${where}: a user text turn ("${snippet}") is NOT present verbatim in PROMPTS.txt on a DONE run - a typed answer/note/clarification never rode into the mission ledger (INH-1). Append it as the next "=== PROMPT N ===" block so it inherits into every brief, exactly like a steer.`,
+      })
+    }
+  }
+  return findings
+}
+// === SELFWRITTEN-CAPTURE-SLICE:END ===
+// === END MISSION-FIDELITY =====================================================
+
+// === E2E-VERIFY-SLICE:START - test-only export seam; sliced by e2e-verify-coverage.cjs.
+// Self-contained: PURE string helpers + one ctx-rule over injected goalCheckArtifacts,
+// NO fs. ===
+
+// parseE2EAxis (PLAN-e2e-verify axis B): read the tri-axis machine line
+// `E2E: scope=<pass|gap> prompt=<pass|gap> flaws=<n> ran=<what-was-executed>` from a
+// goal-check artifact body. Returns { present, scope, prompt, flaws, ran }. A missing
+// or malformed line is FAIL-CLOSED: { present:false, scope:null, prompt:null,
+// flaws:null, ran:'' } - an absent axis can only make openFlawFindings fire, never
+// falsely clear it. `ran` trims trailing whitespace but preserves internal spaces.
+function parseE2EAxis(text) {
+  const fail = { present: false, scope: null, prompt: null, flaws: null, ran: '' }
+  if (typeof text !== 'string') return fail
+  const m = E2E_AXIS_RE.exec(text)
+  if (!m) return fail
+  return { present: true, scope: m[1], prompt: m[2], flaws: Number(m[3]), ran: m[4].trim() }
+}
+
+// parseOpenBlockers (PLAN-e2e-verify axis A - the zero-open-any-severity count): read
+// the `OPEN-BLOCKERS:<n>` machine line from a goal-check artifact body -> the integer.
+// Fail-closed: an absent line or non-string -> null (the caller treats null as "count
+// not attested" = a blocker, never as zero).
+function parseOpenBlockers(text) {
+  if (typeof text !== 'string') return null
+  const m = OPEN_BLOCKERS_RE.exec(text)
+  return m ? Number(m[1]) : null
+}
+
+// openFlawFindings (PLAN-e2e-verify teeth): a run that REACHED DONE (ctx.missionDone
+// === true, the SAME sentinel guard as missionSourceOfTruthFindings so NONE of the
+// not-done fixtures flip) whose LATEST goal-check artifact does not carry a CLEAN seal
+// is a P0. Clean = OPEN-BLOCKERS:0 AND the E2E axis reads scope=pass prompt=pass
+// flaws=0 with a non-empty, non-`none` ran=. ANY open finding at ANY severity
+// (OPEN-BLOCKERS>0 or flaws>0), a scope/prompt gap, an empty/`none` run, or an absent
+// machine line blocks DONE - the zero-open-any-severity bar (§A/§B). The latest
+// artifact wins (append-only vN chronology: the last entry is the frontier).
+//
+// PERMISSIVE-ON-ABSENCE done right, keyed on REACHING DONE not on bare artifact
+// presence: ctx null, missionDone !== true, or NO goal-check artifact -> [] (a run
+// that never sealed, or one with no goal-check on disk, is owned elsewhere - this rule
+// only refuses to let a DONE seal ride over its OWN goal-check's open flaws).
+function openFlawFindings(ctx) {
+  const findings = []
+  if (ctx == null) return findings
+  if (ctx.missionDone !== true) return findings                 // same DONE guard: no not-done fixture flips
+  const artifacts = Array.isArray(ctx.goalCheckArtifacts) ? ctx.goalCheckArtifacts : []
+  let latest = null
+  for (const a of artifacts) {
+    if (!a || typeof a !== 'object' || typeof a.text !== 'string') continue
+    latest = a                                                  // append-only order: last valid entry is the frontier
+  }
+  if (latest == null) return findings                           // no goal-check on disk -> not this rule's business
+  const where = latest.path || '(unknown goal-check)'
+  const open = parseOpenBlockers(latest.text)
+  const axis = parseE2EAxis(latest.text)
+  const blockers = []
+  if (open == null) blockers.push('OPEN-BLOCKERS line absent (count not attested - fail-closed)')
+  else if (open > 0) blockers.push(`OPEN-BLOCKERS=${open} (>0 - a flaw at ANY severity is still a flaw that must be fixed before DONE)`)
+  if (!axis.present) {
+    blockers.push('E2E axis line absent (the tri-axis end-to-end verification was never recorded - fail-closed)')
+  } else {
+    if (axis.scope !== 'pass') blockers.push('scope=gap (a scope-map/roadmap item was not delivered)')
+    if (axis.prompt !== 'pass') blockers.push('prompt=gap (an ask re-derived from the ORIGINAL mission text was not delivered - a too-small scope cannot hide it)')
+    if (axis.flaws > 0) blockers.push(`flaws=${axis.flaws} (open adversarial findings remain - must be 0 to seal)`)
+    if (axis.ran === '' || /^none$/i.test(axis.ran)) blockers.push('ran= empty/none (no captured end-to-end exercise - "run the thing" evidence is missing)')
+  }
+  if (blockers.length > 0) {
+    findings.push({
+      severity: 'P0', rule: 'openFlawFindings',
+      title: `DONE SEALED OVER OPEN FLAWS in ${where}: the run reached DONE but its latest goal-check does not carry a clean tri-axis seal - ${blockers.join('; ')}. Every task ends with a real end-to-end run judged against scope + ORIGINAL prompt + potential flaws, and EVERY finding is fixed (or CLOSED with an evidenced WONTFIX-with-reason) before DONE - zero open findings at any severity.`,
+    })
+  }
+  return findings
+}
+// === E2E-VERIFY-SLICE:END ===
+
+// === STARTUP-HANDSHAKE-SLICE:START - test-only export seam; sliced by
+// startup-handshake-coverage.cjs. Self-contained: one pure BRIEF.md parser + one
+// ctx-rule over injected transcripts, NO fs; the ONE external dep (CONDUCTOR_ROOT_RE)
+// is defined above this block in the module. ===
+
+// parseUnattendedFromBrief (PLAN-startup-handshake): read the `UNATTENDED: yes|no` line
+// BRIEF.md records (SKILL.md/MODES.md §Axis-3: INTAKE/SCRIBE writes it). Returns true
+// ONLY for an explicit `yes`. ABSENT or `no` -> false (ATTENDED) - the stricter default
+// per spec (absent treated as attended so the gate still fires). Non-string -> false.
+function parseUnattendedFromBrief(text) {
+  if (typeof text !== 'string') return false
+  return /^\s*UNATTENDED:\s*yes\s*$/im.test(text)
+}
+
+// startupHandshakeFindings (PLAN-startup-handshake teeth - the pre-spawn handshake HARD
+// GATE, JA4-Factory bug). P0. The startup-drift signature: an ATTENDED run whose ONE
+// unspoofable 00-conductor ROOT (CONDUCTOR_ROOT_RE on the filename) did some OTHER tool
+// call before ever asking the forced handshake question - it "ran git status, read files,
+// drifted, and NEVER asked" whether the user wants billionaire/tokensaver + which agents.
+//
+// SIGNAL SET (strongest UNAMBIGUOUS scoping, per .handshake-gate-spec.md lines 62-67):
+// the honest on-disk signals cannot separate "knob supplied as a flag" from "knob answered
+// via the question" without circularity (the AskUserQuestion-turn presence IS the
+// disambiguator, so keying knob-given on it would be circular). So the rule is scoped to
+// the two signals it CAN source cleanly:
+//   - attended: ctx.attended (runLedgerCheck derives it from BRIEF.md `UNATTENDED:` via
+//     parseUnattendedFromBrief; absent BRIEF -> attended, the stricter default).
+//   - drift: the ROOT's FIRST tool_use (ctx-scan firstToolUseName, captured in scan order)
+//     is not AskUserQuestion, AND the root shows NO
+//     AskUserQuestion turn anywhere (hasUserInterrupt !== true - asked-then-proceeded is
+//     safe). Agent/Task dispatch is repository work too: missing attended knobs must be
+//     resolved before the hierarchy starts, not silently defaulted by the conductor.
+//
+// Fail-closed (return []): ctx null, transcripts non-array, no 00-conductor ROOT on disk,
+// UNATTENDED (ctx.attended !== true), the ROOT emitted no tool_use (firstToolUseName ''),
+// the first tool IS AskUserQuestion, or an AskUserQuestion turn appears anywhere in the root.
+function startupHandshakeFindings(ctx) {
+  const findings = []
+  if (ctx == null) return findings
+  if (ctx.attended !== true) return findings                    // UNATTENDED / unknown -> handshake legitimately skipped
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || typeof t !== 'object') continue
+    if (!CONDUCTOR_ROOT_RE.test(t.path || '')) continue         // ONLY the unspoofable 00-conductor ROOT filename
+    if (t.hasUserInterrupt === true) continue                   // asked (anywhere) -> safe
+    const first = typeof t.firstToolUseName === 'string' ? t.firstToolUseName : ''
+    if (first === '') continue                                  // no tool_use -> nothing to judge
+    if (first === 'AskUserQuestion') continue                   // asked FIRST -> correct behavior
+    findings.push({
+      severity: 'P0', rule: 'startupHandshakeFindings',
+      title: `STARTUP HANDSHAKE SKIPPED in ${t.path}: an ATTENDED run's 00-conductor ROOT emitted "${first}" as its FIRST tool call and never fired the pre-spawn handshake AskUserQuestion. The handshake is a HARD GATE - before any other tool use the conductor must resolve all missing concurrency and agent-selection knobs in ONE AskUserQuestion. Ask FIRST, then dispatch.`,
+    })
+  }
+  return findings
+}
+// === STARTUP-HANDSHAKE-SLICE:END ===
+
+// toolResults: pull tool_result text out of one event (role:user messages whose
+// content[] carry {type:'tool_result'}; result text is block.content joined, tolerant
+// of string|array shapes). Returns [] for any event with none. Shared by the lean-L0
+// parent-fleet-synthesis rule.
+function toolResults(event) {
+  const out = []
+  if (!event || typeof event !== 'object') return out
+  const msg = event.message || event
+  const content = msg.content
+  const blocks = Array.isArray(content) ? content : (Array.isArray(event.content) ? event.content : [])
+  for (const b of blocks) {
+    if (!b || b.type !== 'tool_result') continue
+    const c = b.content
+    if (typeof c === 'string') out.push(c)
+    else if (Array.isArray(c)) out.push(c.map(x => (x && typeof x.text === 'string') ? x.text : (typeof x === 'string' ? x : '')).join('\n'))
+    else if (c && typeof c.text === 'string') out.push(c.text)
+  }
+  return out
+}
+
+// hasAssistantText: true when an event is an assistant message carrying a non-empty
+// text block (a fold/narration turn). Tolerant of the string and content[] shapes.
+function hasAssistantText(event) {
+  if (!event || typeof event !== 'object') return false
+  const msg = event.message || event
+  const role = msg.role || event.type
+  if (role !== 'assistant') return false
+  const content = msg.content
+  if (typeof content === 'string') return content.trim() !== ''
+  if (!Array.isArray(content)) return false
+  return content.some(b => b && b.type === 'text' && typeof b.text === 'string' && b.text.trim() !== '')
+}
+
+// A path is "production" when it is a source file the work changed, NOT a test
+// file and NOT a run artifact/ledger checkpoint. Editing a test or reading/
+// running the repo's own tests is always allowed (FIX-01 freedom).
+function isProductionPath(filePath) {
+  const p = filePath.replace(/\\/g, '/').toLowerCase()
+  if (/(^|\/)tests?\//.test(p)) return false
+  if (/(^|\/)test_[^/]*$/.test(p) || /_test\.[a-z]+$/.test(p) || /\.test\.[a-z]+$/.test(p) || /\.spec\.[a-z]+$/.test(p)) return false
+  if (/(^|\/)(artifacts|\.artifacts)\//.test(p)) return false
+  if (/(gatelog|agents|coverage|brief|backlog|bucketlist|roadmap|plan)\.md$/.test(p)) return false
+  return true
+}
+
+// Pull tool_use objects out of one transcript event, tolerant of the common
+// shapes: a top-level {type:'tool_use'}, or an assistant message whose content
+// array carries tool_use blocks.
+function toolUses(event) {
+  const uses = []
+  if (!event || typeof event !== 'object') return uses
+  if (event.type === 'tool_use' && event.name) uses.push(event)
+  const content = event.message && event.message.content
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (block && block.type === 'tool_use' && block.name) uses.push(block)
+    }
+  }
+  if (Array.isArray(event.content)) {
+    for (const block of event.content) {
+      if (block && block.type === 'tool_use' && block.name) uses.push(block)
+    }
+  }
+  return uses
+}
+
+// selfReviewSignatureFindings (FIX-06 #5 - the REAL F5-18 catch): a single
+// transcript that BOTH edited a production file AND ran that feature's verify/
+// goal-check pytest is a one-context implement+verify (self-review) signature -
+// the exact F5-18 failure. Each such transcript is a P0 finding.
+// ctx.transcripts = [{ path, feature, hasProductionEditOrWrite, hasVerifyOrGoalCheckPytest }].
+function selfReviewSignatureFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (t && t.hasProductionEditOrWrite === true && t.hasVerifyOrGoalCheckPytest === true) {
+      findings.push({
+        severity: 'P0',
+        rule: 'selfReviewSignatureFindings',
+        title: `F5-18 one-context implement+verify (self-review) in ${t.path || '(unknown transcript)'}${t.feature ? ` for ${t.feature}` : ''}: a single transcript both edited a production file AND ran the verify/goal-check test`,
+      })
+    }
+  }
+  return findings
+}
+
+// The L1 COORDINATOR personas. Kept in lockstep with gate.js LEVEL_OF (duplicated
+// by necessity, same as GATE_EXPECTED_PERSONA). The live harness spawns the
+// -coordinator names; the -supervisor names are accepted here for BACKWARD COMPAT
+// so a historical transcript (recorded before the rename) still parses to L1 and is
+// held to the same L1 doctrine. New-name and old-name both classify as L1.
+// (BACKWARD-COMPAT ACCEPTOR: parses both -coordinator and -supervisor L1 strings.)
+const L1_PERSONAS = new Set([
+  'ap-scope-coordinator', 'ap-feature-coordinator', 'ap-sweep-coordinator',
+  'ap-scope-supervisor', 'ap-feature-supervisor', 'ap-sweep-supervisor',
+])
+
+// isFeatureL1 - the feature-owning L1 under either naming (live -coordinator or the
+// -supervisor legacy string). BACKWARD-COMPAT ACCEPTOR used by the billionaire
+// serial-feature parser so a historical feature-supervisor transcript still parses.
+function isFeatureL1(persona) {
+  return persona === 'ap-feature-coordinator' || persona === 'ap-feature-supervisor'
+}
+
+// The L3 EXECUTOR personas - the "workers" an L2 ap-manager fans for a feature's real
+// disjoint parts. L4 leaves (fresh-verifier/juror/scribe/janitor/goal-checker/depth-prober/
+// arbiter/re-anchor/preflight-probe) are terminal attestors, NOT splittable-work workers,
+// so they are EXCLUDED from the worker-starvation count.
+const L3_EXECUTORS = new Set([
+  'ap-scoper', 'ap-planner', 'ap-synthesizer', 'ap-implementer',
+  'ap-reviewer', 'ap-verifier', 'ap-sweeper', 'ap-researcher',
+  'ap-execharness-resolver', 'ap-framework-generator',
+])
+
+// L1_LEGAL_CHILDREN (SCOPE-AT-EVERY-TIER / manager-optional doctrine): an L1
+// coordinator may spawn the L2 ap-manager (multi-feature slice) OR - for a single
+// bounded feature - dispatch L3 executors + L4 leaves DIRECTLY (the L1->L3 hop is a
+// legal manager-skip). Mirrors gate.js LEGAL_CHILDREN_BY_LEVEL.L1. The only ILLEGAL
+// L1 children are L0 pre-hierarchy leaves and other L1 coordinators (a coordinator
+// may not stand up preflight/intake or a sibling coordinator).
+const L4_LEAVES = new Set([
+  'ap-fresh-verifier', 'ap-depth-prober', 'ap-framework-validator', 'ap-juror',
+  'ap-goal-checker', 'ap-preflight-probe', 'ap-arbiter', 'ap-re-anchor', 'ap-scribe',
+  'ap-janitor',
+])
+const L1_LEGAL_CHILDREN = new Set(['ap-manager', ...L3_EXECUTORS, ...L4_LEAVES,
+  // ap-intake is L0-only; ap-preflight-probe already in L4_LEAVES as a leaf spawn.
+])
+// ap-preflight-probe is the one leaf an L1 must NOT re-spawn (L0 owns it); drop it
+// from the L1-legal set so a coordinator re-standing preflight is caught.
+L1_LEGAL_CHILDREN.delete('ap-preflight-probe')
+
+// PLAN-dispatch-contract-enforcement - L0's ENTIRE legal spawn set (the CANONICAL
+// new-name allowlist the live conductor spawns). Every other persona (the L2
+// ap-manager, all L3/L4 workers) is reached ONLY through an L1 coordinator.
+const L0_LEGAL_SPAWN_TYPES = new Set([
+  'ap-preflight-probe', 'ap-intake',
+  'ap-scope-coordinator', 'ap-feature-coordinator', 'ap-sweep-coordinator',
+])
+
+// BACKWARD-COMPAT ACCEPTOR: a historical conductor transcript (recorded before the
+// supervisor->coordinator rename) that spawned the old L1 -supervisor names is still
+// a LEGAL L0 spawn - the allowlist check tolerates these so old ledgers never
+// retroactively fail. The live path only ever emits the -coordinator names above.
+const L0_LEGACY_SPAWN_TYPES = new Set([
+  'ap-scope-supervisor', 'ap-feature-supervisor', 'ap-sweep-supervisor',
+])
+
+// managerExecFindings (FIX-10 - F5-04/07/10/15/23): an L2 ap-manager coordinates
+// only; it emits ZERO Bash/Edit/Write. A ap-manager transcript that ran any such
+// tool is a P0. Fail-closed: a persona-less ('') or non-manager transcript never
+// fires; an absent/non-true hasBashEditWrite never fires.
+function managerExecFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (t && t.persona === 'ap-manager' && t.hasBashEditWrite === true) {
+      findings.push({
+        severity: 'P0',
+        rule: 'managerExecFindings',
+        title: `L2 manager executed in ${t.path || '(unknown transcript)'}: a ap-manager transcript carries a Bash/Edit/Write tool_use, but the manager coordinates only (FIX-10) - execution belongs to the L3 executors it dispatches`,
+      })
+    }
+  }
+  return findings
+}
+
+// conductorToolUseFindings (FIX-11 / SMASH-1 - F5-19): the L0 conductor is Agent-
+// only. A 00-conductor transcript (isConductor) carrying ANY non-Agent tool_use is
+// a P0. Fail-closed: a non-conductor transcript NEVER fires, no matter how many
+// non-Agent tool_uses it has; an absent/non-true hasNonAgentToolUse never fires.
+function conductorToolUseFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (t && t.isConductor === true && t.hasNonAgentToolUse === true) {
+      findings.push({
+        severity: 'P0',
+        rule: 'conductorToolUseFindings',
+        title: `L0 conductor emitted a non-Agent tool in ${t.path || '(unknown transcript)'}: the conductor is Agent-only (FIX-11) - it dispatches the hierarchy and touches nothing itself; every Read/Edit/Write/Bash/Grep/Glob is a subagent's job`,
+      })
+    }
+  }
+  return findings
+}
+
+// l1ChildrenFindings (FIX-13, MANAGER-OPTIONAL doctrine): an L1 coordinator may
+// spawn the L2 ap-manager (multi-feature slice) OR dispatch L3 executors + L4 leaves
+// DIRECTLY (single bounded feature; the L1->L3 hop is a legal manager-skip). The only
+// ILLEGAL L1 children are L0 pre-hierarchy leaves (ap-intake/ap-preflight-probe) and
+// sibling L1 coordinators. SEPARATELY enforces the L1 TOOL DOCTRINE (base:68): an L1
+// coordinator is Agent-ONLY - ANY non-Agent tool use (Read/Glob/Grep included, plus
+// Write/Edit/Bash/WebSearch/WebFetch) is a P0; it keys on hasNonAgentToolUse, not the
+// general hasWriteEditBashWebTool flag. Fleet state flows up via Agent-tool results, or
+// a reader-leaf reads on its behalf. Fail-closed: a non-L1 persona never fires; an
+// absent/non-array spawnedTypes never fires; a clean Agent-only L1 returns [].
+function l1ChildrenFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || !L1_PERSONAS.has(t.persona)) continue
+    const children = Array.isArray(t.spawnedTypes) ? t.spawnedTypes : []
+    const illegal = children.filter(c => !L1_LEGAL_CHILDREN.has(c))
+    if (illegal.length) {
+      findings.push({
+        severity: 'P0',
+        rule: 'l1ChildrenFindings',
+        title: `L1 coordinator spawned an out-of-band child in ${t.path || '(unknown transcript)'}: "${t.persona}" spawned ${illegal.join(', ')}, but an L1 coordinator's legal children are the L2 ap-manager (multi-feature) OR L3 executors + L4 leaves dispatched directly (single feature) - never an L0 leaf or a sibling L1 (FIX-13, manager-optional)`,
+      })
+    }
+    if (t.hasNonAgentToolUse === true) {
+      findings.push({
+        severity: 'P0',
+        rule: 'l1ChildrenFindings',
+        title: `L1 coordinator used a non-Agent tool in ${t.path || '(unknown transcript)'}: "${t.persona}" - an L1 coordinator is Agent-only - Read/Glob/Grep included; fleet state flows up via Agent-tool results, a reader-leaf reads on its behalf`,
+      })
+    }
+  }
+  return findings
+}
+
+// goalCheckJanitorFindings (FIX-14 - F5-07/F5-15): the GOAL-CHECK verdict is
+// authored by ap-goal-checker; the DONE-sentinel is written by ap-janitor. A
+// transcript that wrote the sentinel but is not ap-janitor, or authored the
+// goal-check but is not ap-goal-checker, is a P0. Fail-closed: absent booleans
+// never fire; the correct author returns [].
+function goalCheckJanitorFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t) continue
+    if (t.wroteDoneSentinel === true && t.persona !== 'ap-janitor') {
+      findings.push({
+        severity: 'P0',
+        rule: 'goalCheckJanitorFindings',
+        title: `non-janitor wrote the DONE-sentinel in ${t.path || '(unknown transcript)'}: persona "${t.persona || '(none)'}" wrote /DONE, but only the typed L4 leaf ap-janitor may write the sentinel (FIX-14) - an L2-written /DONE is INVALID`,
+      })
+    }
+    if (t.wroteGoalCheck === true && t.persona !== 'ap-goal-checker') {
+      findings.push({
+        severity: 'P0',
+        rule: 'goalCheckJanitorFindings',
+        title: `non-goal-checker authored the goal-check in ${t.path || '(unknown transcript)'}: persona "${t.persona || '(none)'}" wrote the goal-check verdict, but only the typed L4 leaf ap-goal-checker may author it (FIX-14) - a manager-authored goal-check is INVALID`,
+      })
+    }
+    if (t.wroteAnchor === true && t.persona !== 'ap-scribe') {
+      findings.push({
+        severity: 'P0',
+        rule: 'goalCheckJanitorFindings',
+        title: `non-scribe wrote ANCHOR.md in ${t.path || '(unknown transcript)'}: persona "${t.persona || '(none)'}" wrote the parent anchor file, but ANCHOR.md is SCRIBE-only (the upper levels never write files) - an L0/L1/L2-written ANCHOR.md is INVALID`,
+      })
+    }
+  }
+  return findings
+}
+
+// preflightEditFindings (FIX-17 - F5-22): the PREFLIGHT probe proves RUN/READ/WRITE
+// on a SCRATCH file then returns; it NEVER edits a production source file (the G4
+// IMPLEMENT role is a separate dispatched ap-implementer). A ap-preflight-probe
+// transcript with a production Edit/Write is a P0. Fail-closed: a non-probe persona
+// never fires (the implementer SHOULD edit production); a scratch/artifact write
+// (editsProductionFile false) returns []. editsProductionFile is the existing
+// hasProductionEditOrWrite field surfaced per-persona.
+function preflightEditFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (t && t.persona === 'ap-preflight-probe' && t.editsProductionFile === true) {
+      findings.push({
+        severity: 'P0',
+        rule: 'preflightEditFindings',
+        title: `PREFLIGHT probe edited production in ${t.path || '(unknown transcript)'}: a ap-preflight-probe transcript edited a production source file, but the probe only proves RUN/READ/WRITE on a SCRATCH file then returns (FIX-17) - IMPLEMENT belongs to a dispatched ap-implementer`,
+      })
+    }
+  }
+  return findings
+}
+
+// normalizeFrontier: array|string|null -> a stable comparable string. An array of
+// {feature,status} (or strings) is sorted and joined; a string is trimmed; null/
+// undefined -> '' (so empty===empty is a match). Pure, total.
+function normalizeFrontier(frontier) {
+  if (frontier == null) return ''
+  if (Array.isArray(frontier)) {
+    return frontier
+      .map(e => (e && typeof e === 'object') ? `${e.feature || ''}:${e.status || ''}` : String(e))
+      .map(s => s.trim()).filter(Boolean).sort().join('|')
+  }
+  return String(frontier).trim()
+}
+
+// selfBlockYieldFindings (PLAN-anchor - MISSION: "theres no such thing as a self
+// block"; "dont interrupt this shit ever again"): FLAGS (P0) a run where L0 RETURNED
+// CONTROL to the user with open in-flight tracks AND no irreversible question
+// pending. ctx.yieldState = { returnedToUser, openInFlightTracks,
+// irreversibleQuestionPending }. Fail-closed: absent/malformed yieldState -> [].
+// A legitimate ATTENDED irreversible/credential yield (arbiter-deferred ->
+// irreversibleQuestionPending true) NEVER fires. openInFlightTracks coerced:
+// a non-finite/negative value is treated as 0 (no open tracks -> no finding).
+function selfBlockYieldFindings(ctx) {
+  const findings = []
+  const y = ctx && typeof ctx.yieldState === 'object' && ctx.yieldState ? ctx.yieldState : null
+  if (!y) return findings
+  const openTracks = Number.isFinite(y.openInFlightTracks) && y.openInFlightTracks > 0 ? y.openInFlightTracks : 0
+  if (y.returnedToUser === true && openTracks > 0 && y.irreversibleQuestionPending !== true) {
+    findings.push({
+      severity: 'P0',
+      rule: 'selfBlockYieldFindings',
+      title: `SELF-BLOCK / MID-LOOP YIELD: L0 returned control to the user with ${openTracks} open in-flight track(s) and no ARBITER-deferred irreversible question pending - a closed loop drives its own dependencies to done (LAW 3c) and never self-blocks or interrupts`,
+    })
+  }
+  return findings
+}
+
+// idleFinishFindings (MISSION: "agents go IDLE ... finish doing nothing for HOURS ...
+// an agent can never again sit idle / finish having done nothing"): FLAGS (P0) a run
+// that ENDED (terminal audit) with the mission NOT done, open in-flight tracks, NO
+// live agents, and NO irreversible/credential blocker - the SILENT idle-finish the
+// mid-run lints structurally miss. The conjunction of five directly-observable facts:
+//   (1) runEnded === true                  - a terminal audit (--terminal / RUN-ENDED marker);
+//                                             a mid-run snapshot NEVER fires (no false-positive
+//                                             on a healthy between-wave lull)
+//   (2) missionDone !== true               - no DONE-sentinel sealing the mission
+//   (3) openInFlightTracks > 0             - work remains (a feature with gate rows, no G8 seal)
+//   (4) hasLiveAgents !== true             - no fresh sub-*.jsonl, no LIVE frontier entry:
+//                                             nobody is actually driving
+//   (5) irreversibleQuestionPending !== true - not a legitimate ATTENDED credential park
+// DISTINCT from leanIdleFindings (mid-run, P1, keyed on lean+idle NARRATION) and from
+// selfBlockYieldFindings (keyed on an explicit AskUserQuestion user-yield). This rule
+// needs NEITHER a narration nor a yield - it fires on the ABSENCE of progress at the
+// run boundary, which is why it catches the silent stop the others miss. Fail-closed:
+// a non-terminal audit, a sealed mission, zero open tracks, any live agent, or a pending
+// irreversible question all suppress it.
+function idleFinishFindings(ctx) {
+  const findings = []
+  const s = ctx && typeof ctx.idleFinishState === 'object' && ctx.idleFinishState ? ctx.idleFinishState : null
+  if (!s) return findings
+  if (s.runEnded !== true) return findings
+  if (s.missionDone === true) return findings
+  if (s.irreversibleQuestionPending === true) return findings
+  if (s.hasLiveAgents === true) return findings
+  const openTracks = Number.isFinite(s.openInFlightTracks) && s.openInFlightTracks > 0 ? s.openInFlightTracks : 0
+  if (openTracks > 0) {
+    findings.push({
+      severity: 'P0',
+      rule: 'idleFinishFindings',
+      title: `IDLE-FINISH: the run ENDED with ${openTracks} open in-flight track(s), no DONE-sentinel, no live agent on disk, and no ARBITER-deferred irreversible question - a closed loop self-drives to done (LAW 3, iron rule 10) and must never finish having done nothing; the COORDINATOR's progress-heartbeat must re-drive the next unblocked wave`,
+    })
+  }
+  return findings
+}
+
+// anchorIntegrityFindings (PLAN-anchor - MISSION: parent-anchor file refilled,
+// "compacts... not wipes... new agent gets that file- can resume normal"): PAST THE
+// FIRST COMPACTION the anchor file MUST EXIST and its LIVE FRONTIER MUST MATCH
+// GATELOG. ctx.anchorState = { compactionOccurred, anchorExists, anchorFrontier,
+// gatelogFrontier }. Fail-closed: absent/malformed anchorState -> []. Before any
+// compaction (compactionOccurred !== true) the anchor is not yet required -> [].
+// Frontier compared by normalized string equality; empty===empty is a MATCH.
+function anchorIntegrityFindings(ctx) {
+  const findings = []
+  const a = ctx && typeof ctx.anchorState === 'object' && ctx.anchorState ? ctx.anchorState : null
+  if (!a || a.compactionOccurred !== true) return findings
+  if (a.anchorExists !== true) {
+    findings.push({
+      severity: 'P0',
+      rule: 'anchorIntegrityFindings',
+      title: `ANCHOR.md missing after a compaction: a compacted run has no SCRIBE-maintained ANCHOR.md, so a fresh-context agent cannot resume the hierarchy at the frontier - the parent-anchor refill file is mandatory once the run has compacted`,
+    })
+    return findings
+  }
+  const normA = normalizeFrontier(a.anchorFrontier)
+  const normG = normalizeFrontier(a.gatelogFrontier)
+  if (normA !== normG) {
+    findings.push({
+      severity: 'P0',
+      rule: 'anchorIntegrityFindings',
+      title: `ANCHOR.md frontier drifted from GATELOG after a compaction: anchor frontier "${normA}" != gatelog frontier "${normG}" - the resume anchor no longer matches the real gate state; the SCRIBE must rebuild ANCHOR.md from GATELOG`,
+    })
+  }
+  return findings
+}
+
+// parseModeFromBrief (SHARED - SPEC-2 wave-barrier + no-idle): resolve the run mode
+// from BRIEF.md text. 'billionaire' / 'tokensaver' / '' (unknown -> fail-closed, the
+// mode-scoped rules never fire). Add ONCE; reused by both rules.
+function parseModeFromBrief(text) {
+  const t = typeof text === 'string' ? text : ''
+  // WIDE is the professional primary name; BILLIONAIRE is the retained alias; CUSTOM
+  // is wide-fan-out bounded by max_subs. All three are parallel, so they resolve to
+  // the canonical INTERNAL 'billionaire' token, keeping every billionaire-keyed lint
+  // (serial-gate/feature, wave-barrier, provenance) firing for them.
+  if (/EXECUTION MODE:\s*(BILLIONAIRE|WIDE|CUSTOM)/i.test(t)) return 'billionaire'
+  if (/EXECUTION MODE:\s*TOKENSAVER/i.test(t)) return 'tokensaver'
+  return ''
+}
+
+// parseSerializationEnforcement (SPD-3): true when BRIEF.md carries the F-SPEED-era marker
+// `SERIALIZATION ENFORCEMENT: P0` (case/spacing tolerant). The BILLIONAIRE default brief writes it,
+// which escalates serialGateFindings + serialFeatureFindings from surfaced-P1 to run-failing P0. A
+// pre-F-SPEED brief lacks the marker -> the rules stay P1 -> a historical run is never retroactively
+// failed. Non-string -> false (fail-closed).
+function parseSerializationEnforcement(text) {
+  if (typeof text !== 'string') return false
+  return /SERIALIZATION ENFORCEMENT:\s*P0/i.test(text)
+}
+
+// isWaveBarrier (SPEC-2): a BILLIONAIRE conductor that batched a >=2-spawn wave in one
+// turn then made NO further fold/dispatch - the wave-stall ("hallucinates subagents
+// are running and simply waits"). The correct streamed pattern always has a post-wave
+// fold/dispatch, so it is cleared. Fail-closed on missing fields / non-billionaire.
+function isWaveBarrier(scan) {
+  if (!scan || scan.isConductor !== true || scan.isBillionaire !== true) return false
+  return (scan.maxBatchedSpawns || 0) >= 2 && scan.hadFoldOrDispatchAfterWave !== true
+}
+
+// waveBarrierFindings (SPEC-2 - MISSION wave-stall): each BILLIONAIRE conductor
+// transcript that dispatched a wave then stalled is a P0. DISTINCT from
+// conductorToolUseFindings (tool misuse) and livenessReconcileFindings (narrate-
+// without-poll). Fail-closed: non-conductor / non-billionaire / no-wave never fires.
+function waveBarrierFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (isWaveBarrier(t)) {
+      findings.push({
+        severity: 'P0',
+        rule: 'waveBarrierFindings',
+        title: `WAVE-BARRIER in ${t.path || '(unknown transcript)'}: a BILLIONAIRE conductor batched ${t.maxBatchedSpawns} tracks in one wave then made NO further fold/dispatch (SPEC-2 wave-stall) - it dispatched the wave and "hallucinates subagents are running and simply waits"; stream completions and dispatch the next track as results arrive, never stall on the wave (see ASSESSMENT-ARCHIVE.md round-2)`,
+      })
+    }
+  }
+  return findings
+}
+
+// thinSprawlFindings (PLAN-fanout-fix - DEFECT-1's preserved anti-sprawl guard): a P0
+// for either (i) a non-spawning L3 persona that recursed (spawned anything), or (ii)
+// identical (persona, description) spawns repeated >= THIN_SPRAWL_REPEAT in one
+// transcript (templated 1-per-query batch). The ONLY new fanout rule - NO count rule.
+// Fail-closed: absent/empty spawnedTypes never fires; ap-implementer with distinct
+// descriptions (the L3 that MAY fan out) is never flagged.
+function thinSprawlFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || typeof t !== 'object') continue
+    const spawns = Array.isArray(t.spawnedTypes) ? t.spawnedTypes : []
+    if (spawns.length === 0) continue
+    if (L3_NON_SPAWNING.has(t.persona)) {
+      findings.push({
+        severity: 'P0',
+        rule: 'thinSprawlFindings',
+        title: `thin-sprawl in ${t.path || '(unknown transcript)'}: an L3 recursed on its own job - the non-spawning L3 persona "${t.persona}" spawned ${spawns.join(', ')}, but only ap-implementer/ap-intake may fan out; every other L3 does its one job in its own context`,
+      })
+      continue
+    }
+    const descriptions = Array.isArray(t.spawnedDescriptions) ? t.spawnedDescriptions : []
+    const counts = new Map()
+    for (let i = 0; i < descriptions.length; i++) {
+      const key = `${spawns[i] || ''}::${descriptions[i]}`
+      counts.set(key, (counts.get(key) || 0) + 1)
+    }
+    const maxRepeat = counts.size ? Math.max(...counts.values()) : 0
+    if (maxRepeat >= THIN_SPRAWL_REPEAT) {
+      findings.push({
+        severity: 'P0',
+        rule: 'thinSprawlFindings',
+        title: `thin-sprawl in ${t.path || '(unknown transcript)'}: ${maxRepeat} identical (persona, description) spawns in one transcript (batch 1..N / 1-per-query) - fan out by genuine distinct work, never by templated identical leaves`,
+      })
+    }
+  }
+  return findings
+}
+
+// conductorSpawnAllowlistFindings (PLAN-dispatch-contract-enforcement): the L0
+// conductor's ENTIRE legal spawn set is the L0_LEGAL_SPAWN_TYPES allowlist. A
+// conductor transcript that spawned anything outside it skipped the supervisor
+// (solo-collapse) - P0, naming every illegal child. Reuses the existing isConductor
+// + spawnedTypes fields (NO scanner change). Fail-closed: non-conductor never fires.
+function conductorSpawnAllowlistFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || t.isConductor !== true) continue
+    const children = Array.isArray(t.spawnedTypes) ? t.spawnedTypes : []
+    const illegal = children.filter(c => !L0_LEGAL_SPAWN_TYPES.has(c) && !L0_LEGACY_SPAWN_TYPES.has(c))
+    if (illegal.length) {
+      findings.push({
+        severity: 'P0',
+        rule: 'conductorSpawnAllowlistFindings',
+        title: `L0 conductor spawned a worker directly in ${t.path || '(unknown transcript)'}: spawned ${illegal.join(', ')}, but L0's ENTIRE legal spawn set is ap-preflight-probe / ap-intake / cl-scope|feature|sweep-coordinator - every other persona (the L2 ap-manager, all L3/L4 workers) is reached ONLY through an L1 coordinator (skip-the-supervisor solo-collapse)`,
+      })
+    }
+  }
+  return findings
+}
+
+// leanIdleFindings (PLAN-no-idle-pushwork - MISSION: "lean means lean on CONTEXT, not
+// lean on WORK"): P1 (surfaced, not run-failing) for a BILLIONAIRE conductor turn that
+// idled on a lean-excuse (lean+idle narration, no dependency justification) AND
+// dispatched ZERO tracks. Fail-closed: non-conductor / non-billionaire / absent flag /
+// a turn that DID dispatch never fires.
+function leanIdleFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || t.isConductor !== true) continue
+    if (t.mode !== 'billionaire') continue
+    if (t.hasLeanAsIdleNarration !== true) continue
+    if (t.dispatchedAnyTrack !== false) continue
+    findings.push({
+      severity: 'P1',
+      rule: 'leanIdleFindings',
+      title: `LEAN-AS-IDLE in ${t.path || '(unknown transcript)'}: a BILLIONAIRE L0 conductor turn idled on a "staying lean" excuse (lean + wait narration, no dependency/convergence justification) and dispatched NO track - leanness is a CONTEXT directive, never a reason to withhold dispatchable independent work (PUSH-WORK LOOP); only genuine dependency-blocks wait`,
+    })
+  }
+  return findings
+}
+
+// parentFleetSynthesisFindings (PLAN-lean-L0-coordinator - MISSION: "parent agent ...
+// getting dumber by each time someone finishes ... HAS TO STAY LEAN"): FLAGS (P0) a
+// CONDUCTOR transcript doing the COORDINATOR's job in L0's own context - synthesis
+// accumulation. Either an over-budget ingested report OR a fleet-table rebuilt across
+// turns fires. Fail-closed: non-conductor / absent flags never fire.
+function parentFleetSynthesisFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || t.isConductor !== true) continue
+    const oversized = t.hasOversizedReport === true
+    const tableTurns = Number.isFinite(t.fleetTableTurns) && t.fleetTableTurns > 0 ? t.fleetTableTurns : 0
+    if (oversized) {
+      findings.push({
+        severity: 'P0',
+        rule: 'parentFleetSynthesisFindings',
+        title: `PARENT-SIDE FLEET SYNTHESIS in ${t.path || '(unknown transcript)'}: the L0 conductor ingested an over-budget report (${t.maxToolResultChars || 0} chars, or a diff / test-runner dump) instead of a <=150-word verdict - the collecting belongs to the COORDINATOR (disk-sourced), L0 stays lean`,
+      })
+    }
+    if (tableTurns >= FLEET_TABLE_TURN_MIN) {
+      findings.push({
+        severity: 'P0',
+        rule: 'parentFleetSynthesisFindings',
+        title: `PARENT-SIDE FLEET SYNTHESIS in ${t.path || '(unknown transcript)'}: the L0 conductor rebuilt a fleet-state table across ${tableTurns} turns - re-synthesizing fleet state each time a track finishes is what makes the parent "dumber each time someone finishes"; that reasoning is the COORDINATOR's job`,
+      })
+    }
+  }
+  return findings
+}
+
+// midRunCancelCheckpointFindings (PLAN-midrun-insertion - MISSION: "if its urgent:
+// save state, cancel the prompt, continue"): FLAGS (P0) an URGENT mid-run steer that
+// CANCELLED a track WITHOUT first checkpointing its frontier to disk. The save MUST
+// precede the cancel. ctx.steerState = { urgentCancels: [{feature,
+// checkpointedBeforeCancel}] }. Fail-closed: absent/malformed steerState -> [];
+// checkpointedBeforeCancel must be EXACTLY true to be safe.
+function midRunCancelCheckpointFindings(ctx) {
+  const findings = []
+  const s = ctx && typeof ctx.steerState === 'object' && ctx.steerState ? ctx.steerState : null
+  if (!s) return findings
+  const cancels = Array.isArray(s.urgentCancels) ? s.urgentCancels : []
+  for (const c of cancels) {
+    if (!c || typeof c !== 'object') continue
+    if (c.checkpointedBeforeCancel !== true) {
+      findings.push({
+        severity: 'P0',
+        rule: 'midRunCancelCheckpointFindings',
+        title: `MID-RUN STEER data loss: track "${c.feature || '(unknown)'}" was CANCELLED (TaskStop) for an urgent steer WITHOUT its frontier checkpointed to disk first - the URGENT mode MUST save state (ANCHOR.md/GATELOG frontier, atomic .tmp->rename) BEFORE the cancel, else the track's progress is lost`,
+      })
+    }
+  }
+  return findings
+}
+
+// deriveSteerCancels (PLAN-midrun-insertion): own raw line-scan over GATELOG lines
+// (NOT parseGatelogRow). For each `STEER URGENT <feature>`, checkpointedBeforeCancel is
+// true IFF a `CHECKPOINT <feature>` row precedes the matching `CANCEL <feature>` row in
+// append-only chronological order. A CANCEL with no preceding CHECKPOINT -> false.
+// Pure, total; [] on no urgent steer rows. Accepts an array of raw line strings.
+function deriveSteerCancels(lines) {
+  const rows = Array.isArray(lines) ? lines : []
+  const urgentFeatures = new Set()
+  const checkpointIndex = new Map()
+  const cancelIndex = new Map()
+  for (let i = 0; i < rows.length; i++) {
+    const line = String(rows[i] || '').replace(/^\[at[^\]]*\]\s*/, '').trim()
+    let m
+    if ((m = line.match(/^STEER\s+URGENT\s+(\S+)/))) {
+      if (m[1] !== 'GLOBAL') urgentFeatures.add(m[1])
+    } else if ((m = line.match(/^CHECKPOINT\s+(\S+)/))) {
+      if (!checkpointIndex.has(m[1])) checkpointIndex.set(m[1], i)
+    } else if ((m = line.match(/^CANCEL\s+(\S+)/))) {
+      if (!cancelIndex.has(m[1])) cancelIndex.set(m[1], i)
+    }
+  }
+  const out = []
+  for (const feature of urgentFeatures) {
+    if (!cancelIndex.has(feature)) continue
+    const cancelAt = cancelIndex.get(feature)
+    const checkpointAt = checkpointIndex.has(feature) ? checkpointIndex.get(feature) : Infinity
+    out.push({ feature, checkpointedBeforeCancel: checkpointAt < cancelAt })
+  }
+  return out
+}
+
+// deriveFeatureTargets (PLAN-proportional-gates): own raw line-scan over GATELOG lines
+// for the EXPLICIT per-feature target-file token (`target=<path>` or `file=<path>`).
+// The soundness bar forbids guessing a feature's file from prose - only an explicit
+// token counts, so an absent token yields nothing (fail-closed). Pure, total; [] on a
+// non-array input. Deduped on feature+file. Accepts an array of raw line strings.
+function deriveFeatureTargets(lines) {
+  const rows = Array.isArray(lines) ? lines : []
+  const seen = new Set()
+  const out = []
+  for (const raw of rows) {
+    const line = String(raw || '').replace(/^\[at[^\]]*\]\s*/, '').trim()
+    const m = FEATURE_TARGET_RE.exec(line)
+    if (!m) continue
+    const key = `${m[1]}::${m[2]}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push({ feature: m[1], file: m[2] })
+  }
+  return out
+}
+
+// deriveFeatureDecomposition (cohort): parse the mandatory DECOMPOSE rows from raw GATELOG
+// lines into [{feature, phase, deps:Set, owns:Set}]. Pure, total; [] on non-array. First decl wins.
+function deriveFeatureDecomposition(lines) {
+  const rows = Array.isArray(lines) ? lines : []
+  const byFeature = new Map()
+  for (const raw of rows) {
+    const line = String(raw || '').replace(/^\[at[^\]]*\]\s*/, '').trim()
+    const m = FEATURE_DECL_RE.exec(line)
+    if (!m) continue
+    const feature = m[1].toUpperCase()
+    if (byFeature.has(feature)) continue
+    const deps = new Set(m[3].toLowerCase() === 'none' ? [] : m[3].split(',').map(s => s.trim().toUpperCase()).filter(Boolean))
+    const owns = new Set(m[4].split(',').map(s => s.trim()).filter(Boolean))
+    byFeature.set(feature, { feature, phase: m[2], deps, owns })
+  }
+  return [...byFeature.values()]
+}
+
+// deriveFeatureDispatches (the FIRING signal): parse the mandatory DISPATCH rows from raw GATELOG
+// lines into [{feature, wave}]. The [at …] prefix is stripped before matching. Deduped on
+// feature|wave so a duplicated row never inflates wave cardinality. Pure, total; [] on non-array.
+function deriveFeatureDispatches(lines) {
+  const rows = Array.isArray(lines) ? lines : []
+  const seen = new Set()
+  const out = []
+  for (const raw of rows) {
+    const line = String(raw || '').replace(/^\[at[^\]]*\]\s*/, '').trim()
+    const m = DISPATCH_RE.exec(line)
+    if (!m) continue
+    const key = `${m[1].toUpperCase()}|${m[2]}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push({ feature: m[1].toUpperCase(), wave: m[2] })
+  }
+  return out
+}
+
+// deriveFeatureMeta (SPD-1): parse the mandatory FEATURE-META rows from raw GATELOG lines into
+// [{feature, tier, framework, issues, tag}]. The [at …] prefix is stripped before matching. First-decl-wins
+// per feature. issues coerced to a number. The optional trailing `tag=` carries the AUTHORITATIVE playbook
+// classification derived from ROADMAP.md on new runs or INTAKE on legacy resumes ('' when absent). Pure, total; [] on non-array.
+// Byte-identical pattern to deriveFeatureDispatches/deriveFeatureDecomposition.
+function deriveFeatureMeta(lines) {
+  const rows = Array.isArray(lines) ? lines : []
+  const byFeature = new Map()
+  for (const raw of rows) {
+    const line = String(raw || '').replace(/^\[at[^\]]*\]\s*/, '').trim()
+    const m = FEATURE_META_RE.exec(line)
+    if (!m) continue
+    const feature = m[1].toUpperCase()
+    if (byFeature.has(feature)) continue
+    byFeature.set(feature, { feature, tier: m[2], framework: m[3], issues: parseInt(m[4], 10), tag: m[5] || '' })
+  }
+  return [...byFeature.values()]
+}
+
+// deriveCeremonyRows (SPD-1): own raw line-scan over GATELOG lines for the over-tiering ceremony rows
+// attributed to a feature - SCOPE / SCOPE-AND-ROADMAP and END-VERDICT. Returns two Sets of feature ids.
+// Pure, total; empty sets on a non-array input (fail-closed).
+function deriveCeremonyRows(lines) {
+  const rows = Array.isArray(lines) ? lines : []
+  const scopeFeatures = new Set()
+  const endVerdictFeatures = new Set()
+  for (const raw of rows) {
+    const line = String(raw || '').replace(/^\[at[^\]]*\]\s*/, '').trim()
+    let m
+    if ((m = SCOPE_ROW_RE.exec(line))) scopeFeatures.add(m[1].toUpperCase())
+    else if ((m = END_VERDICT_ROW_RE.exec(line))) endVerdictFeatures.add(m[1].toUpperCase())
+  }
+  return { scopeFeatures, endVerdictFeatures }
+}
+
+// isSingleFileSingleIssue (SPD-1 helper): a feature is the lean-T1 class when its FEATURE-META issues
+// count is exactly 1 AND its DECOMPOSE owns set is exactly ONE concrete path (no glob wildcard). The
+// single owned path is returned for the finding title; null when the feature is NOT single-file+single-
+// issue (multi-file, glob, multi-issue, or no DECOMPOSE owns) so the rule fail-closes.
+function singleOwnedFile(metaRow, decompByFeature) {
+  if (!metaRow || metaRow.issues !== 1) return null
+  const decomp = decompByFeature.get(metaRow.feature)
+  if (!decomp || !(decomp.owns instanceof Set) || decomp.owns.size !== 1) return null
+  const only = [...decomp.owns][0]
+  if (typeof only !== 'string' || only === '' || only.includes('*')) return null
+  return only
+}
+
+// tierProportionalityFindings (SPD-1 - P0, fail-closed): a single-file + single-issue feature that
+// recorded an over-tiered shape ran the T2/T3 ceremony the DIAGNOSIS §3 lever targets. ANY of FOUR
+// signals fires it: (1) recorded tier T2/T3; (2) a SCOPE-AND-ROADMAP row attributed to it, OR a
+// plan-scope framework on a single-file fix; (3) a 3-juror (>=3) G7 panel; (4) an over-tiered END-VERDICT
+// row. The single-file+single-issue floor is the GATE: a multi-file/glob/multi-issue feature, or one
+// with no FEATURE-META row, NEVER fires (a legacy ledger is never retroactively failed; pylint-7080's
+// correct lean T1 produces ZERO). Severity P0 -> flips ok to false.
+function tierProportionalityFindings(ctx) {
+  const findings = []
+  const featureMeta = Array.isArray(ctx.featureMeta) ? ctx.featureMeta : []
+  if (featureMeta.length === 0) return findings
+  const gatelog = Array.isArray(ctx.gatelog) ? ctx.gatelog : []
+  const decomp = Array.isArray(ctx.featureDecomposition) ? ctx.featureDecomposition : []
+  const ceremony = ctx.ceremonyRows && typeof ctx.ceremonyRows === 'object'
+    ? ctx.ceremonyRows : { scopeFeatures: new Set(), endVerdictFeatures: new Set() }
+  const scopeFeatures = ceremony.scopeFeatures instanceof Set ? ceremony.scopeFeatures : new Set()
+  const endVerdictFeatures = ceremony.endVerdictFeatures instanceof Set ? ceremony.endVerdictFeatures : new Set()
+  const decompByFeature = new Map()
+  for (const d of decomp) if (d && d.feature) decompByFeature.set(d.feature, d)
+  const g7CountByFeature = new Map()
+  for (const r of gatelog) {
+    if (!r || r.gate !== 'G7' || !r.feature) continue
+    g7CountByFeature.set(r.feature, (g7CountByFeature.get(r.feature) || 0) + 1)
+  }
+  for (const metaRow of featureMeta) {
+    const file = singleOwnedFile(metaRow, decompByFeature)
+    if (!file) continue                                            // fail-closed: not single-file+single-issue
+    const signals = []
+    if (metaRow.tier === 'T2' || metaRow.tier === 'T3') signals.push(`tier ${metaRow.tier}`)
+    if (scopeFeatures.has(metaRow.feature) || metaRow.framework === 'plan-scope') signals.push('SCOPE-AND-ROADMAP')
+    if ((g7CountByFeature.get(metaRow.feature) || 0) >= THREE_JUROR_PANEL) signals.push('3-juror G7 panel')
+    if (endVerdictFeatures.has(metaRow.feature)) signals.push('END-VERDICT')
+    if (signals.length === 0) continue
+    findings.push({
+      severity: 'P0',
+      rule: 'tierProportionalityFindings',
+      title: `OVER-TIERED in ${metaRow.feature}: a single-file (${file}) single-issue feature recorded ${signals.join(' / ')} - a single-file single-issue bug fix runs the T1 debug path (implement->review->verify-once->goal-check->scribe), never the T2/T3 ceremony (SCOPE-AND-ROADMAP, a 3-juror G7 panel, an over-tiered END-VERDICT). DIAGNOSIS §3: the lever is the T2 threshold + single-issue floor, not a blanket de-tier`,
+    })
+  }
+  return findings
+}
+
+// evidencePackFindings (SPD-2 - P1, fail-closed): when >1 gate transcript of the SAME feature
+// independently Reads the SAME production file AND no <feature>-context.md evidence pack exists on
+// disk, the L2 manager skipped the once-per-feature pack and every gate re-Read the repo - the
+// DIAGNOSIS §3 main-orchestrator + intake re-read cost (42%+ of spend). NOTE the honest scope: this
+// rule proves DUPLICATE gate prod-file reads with no pack; it does NOT itself prove the 42%
+// main-orchestrator figure (that burn is addressed by F-INH's cached-prefix work per DIAGNOSIS §6,
+// not by these teeth). P1 surfaces it; ok is unaffected. Fail-closed: <2 readers of a file, the pack
+// present, a feature with no label, or non-array fields -> nothing.
+function evidencePackFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  const artifactExists = typeof ctx.artifactExists === 'function' ? ctx.artifactExists : () => false
+  // group: feature -> (file -> count of distinct gate transcripts that Read it)
+  const byFeature = new Map()
+  for (const t of transcripts) {
+    if (!t || typeof t !== 'object' || !t.feature) continue
+    const reads = Array.isArray(t.readsProductionFiles) ? t.readsProductionFiles : []
+    if (reads.length === 0) continue
+    if (!byFeature.has(t.feature)) byFeature.set(t.feature, new Map())
+    const fileCounts = byFeature.get(t.feature)
+    for (const file of new Set(reads)) fileCounts.set(file, (fileCounts.get(file) || 0) + 1)
+  }
+  for (const [feature, fileCounts] of byFeature) {
+    if (artifactExists(`${feature}-context.md`)) continue          // the pack did its job
+    for (const [file, count] of fileCounts) {
+      if (count < 2) continue                                      // a single reader needs no pack
+      findings.push({
+        severity: 'P1',
+        rule: 'evidencePackFindings',
+        title: `EVIDENCE-PACK MISSING in ${feature}: ${count} gates independently Read ${file} with no ${feature}-context.md pack on disk - the L2 manager must assemble the touched-file evidence pack ONCE before the first gate (DIAGNOSIS §3: main-orchestrator + intake re-read is 42%+ of spend); gates pull from the pack, not re-Read the repo`,
+      })
+    }
+  }
+  return findings
+}
+
+// frameworkTierFindings (SPD-4 - P1, fail-closed): every feature records a FEATURE-META tier+framework
+// row; a recorded leaf whose tier band does NOT admit the recorded tier (a T3-only build leaf on a T1
+// single-file fix) is a FRAMEWORK-TIER MISMATCH. Uses the pure leafTierConsistent inlined above:
+// only a KNOWN leaf with a KNOWN-bad tier fires; an unknown leaf (a generated gen-* leaf, MISS) or an
+// unparseable tier yields { known:false } -> no fire (fail-closed). Absent FEATURE-META -> nothing.
+function frameworkTierFindings(ctx) {
+  const findings = []
+  const featureMeta = Array.isArray(ctx.featureMeta) ? ctx.featureMeta : []
+  for (const metaRow of featureMeta) {
+    if (!metaRow || typeof metaRow.framework !== 'string' || typeof metaRow.tier !== 'string') continue
+    const verdict = leafTierConsistent(metaRow.framework, metaRow.tier)
+    if (!verdict.known || verdict.ok) continue                     // unknown leaf/tier or consistent -> no fire
+    const band = LEAF_TIER_BANDS[metaRow.framework].join('/')
+    findings.push({
+      severity: 'P1',
+      rule: 'frameworkTierFindings',
+      title: `FRAMEWORK-TIER MISMATCH in ${metaRow.feature}: framework '${metaRow.framework}' (tiers ${band}) recorded on a tier ${metaRow.tier} feature - the recorded leaf must match the feature's true tier; no T3 leaf on T1 work (SPD-4)`,
+    })
+  }
+  return findings
+}
+
+// proportionalGatesFindings (PLAN-proportional-gates - the mission's core fix): P1
+// (surfaced, does NOT flip ok - same class as commitCheckpointFindings/leanIdleFindings).
+// ARM A - a feature whose GATELOG carries a FRESH G1/G2/G3 design row AND a frozen-plan
+// artifact for it already exists on disk that those design rows did NOT produce (it was
+// not named among their own artifacts) - re-running G1-G3 over a frozen spec, which earns
+// apply->diff-review->verify-green (G4-G6) only. ARM B - >= PROPORTIONAL_SIBLING_FLOOR
+// distinct sibling features that EACH ran a full G1..G8 pipeline yet all target ONE file -
+// N gated features where the mission demands ONE batched implementer pass + ONE verify.
+// Soundness: every signal is derived from ledger data actually present (GATELOG gate rows,
+// on-disk frozen artifacts, explicit per-feature target tokens). A missing discriminator
+// is never guessed -> fail-closed (emit nothing). Fail-closed on non-array ctx fields.
+function proportionalGatesFindings(ctx) {
+  const findings = []
+  const gatelog = Array.isArray(ctx.gatelog) ? ctx.gatelog : []
+  const artifactExists = typeof ctx.artifactExists === 'function' ? ctx.artifactExists : () => false
+  const readArtifact = typeof ctx.readArtifact === 'function' ? ctx.readArtifact : () => null
+  const featureTargets = Array.isArray(ctx.featureTargets) ? ctx.featureTargets : []
+
+  const gatesByFeature = new Map()
+  const designArtifactsByFeature = new Map()
+  for (const r of gatelog) {
+    if (!r || !r.feature || !r.gate) continue
+    if (!gatesByFeature.has(r.feature)) {
+      gatesByFeature.set(r.feature, new Set())
+      designArtifactsByFeature.set(r.feature, new Set())
+    }
+    gatesByFeature.get(r.feature).add(r.gate)
+    if (DESIGN_GATES.includes(r.gate)) {
+      for (const a of (Array.isArray(r.artifacts) ? r.artifacts : [])) designArtifactsByFeature.get(r.feature).add(a)
+    }
+  }
+
+  for (const [feature, gates] of gatesByFeature) {
+    const ranDesign = DESIGN_GATES.some(g => gates.has(g))
+    if (!ranDesign) continue
+    const frozen = findFrozenPlanArtifact(feature, designArtifactsByFeature.get(feature), artifactExists, readArtifact)
+    if (frozen) {
+      findings.push({
+        severity: 'P1',
+        rule: 'proportionalGatesFindings',
+        title: `OVER-CEREMONY (re-ran design on a frozen spec) in ${feature}: a fresh G1-G3 design cycle ran while the frozen plan ${frozen} already exists on disk and was not produced by those rows - applying an already-frozen/reviewed/fresh-verified spec earns apply->diff-review->verify-green (G4-G6) ONLY, never a fresh G1-G3 design cycle`,
+      })
+    }
+  }
+
+  const targetByFeature = new Map()
+  for (const e of featureTargets) {
+    if (e && e.feature && typeof e.file === 'string') targetByFeature.set(e.feature, e.file)
+  }
+  const siblingsByFile = new Map()
+  for (const [feature, gates] of gatesByFeature) {
+    const ranFullPipeline = FULL_PIPELINE_GATES.every(g => gates.has(g))
+    if (!ranFullPipeline) continue
+    const file = targetByFeature.get(feature)
+    if (!file) continue
+    if (!siblingsByFile.has(file)) siblingsByFile.set(file, [])
+    siblingsByFile.get(file).push(feature)
+  }
+  for (const [file, siblings] of siblingsByFile) {
+    if (siblings.length < PROPORTIONAL_SIBLING_FLOOR) continue
+    findings.push({
+      severity: 'P1',
+      rule: 'proportionalGatesFindings',
+      title: `BATCHABLE SIBLINGS over-gated: ${siblings.length} sibling features (${siblings.join(', ')}) each ran a full G1..G8 pipeline yet all target the single file ${file} - N homogeneous units into one file demand ONE batched implementer pass + ONE verify, not ${siblings.length} per-unit gated features`,
+    })
+  }
+  return findings
+}
+
+// findFrozenPlanArtifact (PLAN-proportional-gates): the frozen-plan artifact that proves a
+// feature's spec was already frozen BEFORE the design rows in question - a /-plan-final.md/
+// for the feature, OR a /-fresh-verify*.md/ whose body carries an APPROVE verdict. It must
+// exist on disk AND NOT be one of the design rows' OWN cited artifacts (else it is the
+// legitimate first-time freeze those rows produced). Returns the artifact name, or '' when
+// none qualifies (fail-closed). ownArtifacts is the Set of artifacts cited by the rows.
+function findFrozenPlanArtifact(feature, ownArtifacts, artifactExists, readArtifact) {
+  const own = ownArtifacts
+  const planFinal = `${feature}-plan-final.md`
+  if (artifactExists(planFinal) && !own.has(planFinal)) return planFinal
+  for (const candidate of frozenFreshverifyCandidates(feature, own, artifactExists)) {
+    if (own.has(candidate)) continue
+    const body = readArtifact(candidate)
+    if (typeof body === 'string' && FRESHVERIFY_APPROVE_RE.test(body)) return candidate
+  }
+  return ''
+}
+
+// frozenFreshverifyCandidates: the on-disk -fresh-verify artifacts to test for an APPROVE.
+// The conventional name is <feature>-fresh-verify*.md; a few real ledgers also revise to
+// -fresh-verify-vN.md. We probe the bare and -v2..-v4 forms (best-effort, fail-closed: a
+// name that does not exist on disk is skipped).
+function frozenFreshverifyCandidates(feature, own, artifactExists) {
+  const out = []
+  const probes = [
+    `${feature}-fresh-verify.md`, `${feature}-fresh-verify-v2.md`,
+    `${feature}-fresh-verify-v3.md`, `${feature}-fresh-verify-v4.md`,
+    `${feature}-freshverify.md`,
+  ]
+  for (const name of probes) if (artifactExists(name)) out.push(name)
+  for (const name of own) if (FROZEN_FRESHVERIFY_RE.test(name) && artifactExists(name)) out.push(name)
+  return out
+}
+
+// isLivenessGap (PLAN-liveness-reconcile v4): a transcript has a per-turn liveness gap
+// when ANY narrating turn names a claimed id OR feature label with NO backing ground-
+// truth signal - a result-bound same-turn poll of THAT id/label, a fresh on-disk
+// sub-<id>.jsonl, or a LIVE (non-sealed) FRONTIER entry for it. Lean L0 EXEMPT (cannot
+// poll by design). Fail-closed: absent/empty fields never fire.
+function isLivenessGap(t, liveSignals) {
+  if (!t) return false
+  const isPureLeanConductor = t.isConductor === true && t.hasNonAgentToolUse !== true
+  if (isPureLeanConductor) return false
+  const turns = Array.isArray(t.livenessTurns) ? t.livenessTurns : []
+  const signals = liveSignals || {
+    freshTranscriptIds: new Set(), agentsMdIds: new Set(),
+    frontierIds: new Set(), frontierLabels: new Set(),
+  }
+  for (const turn of turns) {
+    for (const id of turn.claimedAgentIds) {
+      const backedBySameTurnPoll = turn.polledThisTurn === true &&
+        (turn.polledAgentIds.has(id) || (id === '__unnamed__' && turn.polledAgentIds.size > 0))
+      const backedOnDisk = signals.freshTranscriptIds.has(id) || signals.agentsMdIds.has(id) ||
+        signals.frontierIds.has(id)
+      if (!backedBySameTurnPoll && !backedOnDisk) return true
+    }
+    for (const label of turn.claimedLabels) {
+      const backedBySameTurnPoll = turn.polledThisTurn === true && turn.polledLabels.has(label)
+      const backedByFrontier = signals.frontierLabels.has(label)
+      if (!backedBySameTurnPoll && !backedByFrontier) return true
+    }
+  }
+  return false
+}
+
+// livenessReconcileFindings (PLAN-liveness-reconcile / P18 - the hallucinated-running
+// catch): each non-lean-L0 transcript with a per-turn liveness gap is a P0. Reads
+// ctx.liveSignals. Fail-closed on empty input.
+function livenessReconcileFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!isLivenessGap(t, ctx.liveSignals)) continue
+    findings.push({
+      severity: 'P0',
+      rule: 'livenessReconcileFindings',
+      title: `HALLUCINATED-RUNNING (per-turn liveness gap) in ${t.path || '(unknown transcript)'}: a turn narrated an agent as "Running / in flight / standing by" but that claimed id had NO backing live signal - no result-bound same-turn poll of it, no fresh sub-<id>.jsonl, no LIVE FRONTIER entry. Reconcile EACH turn against ACTUAL liveness per agent (poll, never assume; a poll of A never clears a claim of B; a "dead"/ConnectionRefused/stale signal never clears). COORDINATOR's job, not lean L0's (FIX-016-2)`,
+    })
+  }
+  return findings
+}
+
+// idTokenMatch (PLAN-false-negative-liveness EDIT 3): a spawned id (the bare token a spawn description names,
+// e.g. "f09") matches an ownership key (the FILENAME-derived id collectLiveSignals produces, e.g.
+// "ap-planner-f09" / "sub-ap-planner-f09") when they are equal OR one is a hyphen-delimited SUFFIX of the
+// other. Hyphen-boundary anchored so "f09" matches "ap-planner-f09" but NOT "f090"/"f9".
+const idTokenMatch = (key, id) => key === id || key.endsWith('-' + id) || id.endsWith('-' + key)
+
+// isFalseNegativeLivenessGap (FIX-016 MIRROR of isLivenessGap): a transcript has a false-NEGATIVE liveness
+// gap when a dead-conclusion turn (a) SPAWNS an Agent onto an id/label OWNED by a live signal (fresh
+// sub-<id>.jsonl, AGENTS.md row, or LIVE frontier - reconciled by idTokenMatch) AND that id/label is NOT
+// task-status-confirmed-dead this turn, OR (b) concludes a SPECIFIC id/label DEAD while a disk read shows
+// no-artifact-yet and NO task-status poll confirmed THAT id dead. Per-ID. BOTH arms skip taskStatusDeadIds
+// (a re-spawn of a CONFIRMED-DEAD agent is a legit re-dispatch the mission requires). Lean L0 EXEMPT.
+// Fail-closed: absent/empty fields never fire.
+function isFalseNegativeLivenessGap(t, liveSignals) {
+  if (!t) return false
+  const isPureLeanConductor = t.isConductor === true && t.hasNonAgentToolUse !== true
+  if (isPureLeanConductor) return false
+  const turns = Array.isArray(t.deadConclusionTurns) ? t.deadConclusionTurns : []
+  const signals = liveSignals || { freshTranscriptIds: new Set(), agentsMdIds: new Set(), frontierIds: new Set(), frontierLabels: new Set() }
+  const ownedById = (id) => {
+    for (const set of [signals.freshTranscriptIds, signals.agentsMdIds, signals.frontierIds]) {
+      if (!set) continue
+      if (set.has(id)) return true
+      for (const k of set) if (idTokenMatch(k, id)) return true
+    }
+    return false
+  }
+  const ownedByLabel = (label) => {
+    if (!signals.frontierLabels) return false
+    if (signals.frontierLabels.has(label)) return true
+    for (const k of signals.frontierLabels) if (idTokenMatch(k, label)) return true
+    return false
+  }
+  const inSet = (set, id) => { if (set.has(id)) return true; for (const k of set) if (idTokenMatch(k, id)) return true; return false }
+  for (const turn of turns) {
+    // arm (a): a SPAWN onto an OWNED id/label = duplicate onto live-owned work, UNLESS task-status-confirmed dead.
+    for (const id of turn.spawnedIdsThisTurn) {
+      if (inSet(turn.taskStatusDeadIds, id)) continue
+      if (ownedById(id)) return true
+    }
+    for (const label of turn.spawnedLabelsThisTurn) {
+      if (inSet(turn.taskStatusDeadLabels, label)) continue
+      if (ownedByLabel(label)) return true
+    }
+    // arm (b): per dead-concluded id, the conclusion is LEGIT only if a task-status poll confirmed THAT id dead.
+    for (const id of turn.deadConcludedIds) {
+      if (inSet(turn.taskStatusDeadIds, id)) continue
+      if (turn.diskReadThisTurn === true) return true
+      if (inSet(turn.taskStatusRunningIds, id)) return true
+    }
+    for (const label of turn.deadConcludedLabels) {
+      if (inSet(turn.taskStatusDeadLabels, label)) continue
+      if (turn.diskReadThisTurn === true) return true
+      if (inSet(turn.taskStatusRunningLabels, label)) return true
+    }
+  }
+  return false
+}
+
+// falseNegativeLivenessFindings (PLAN-false-negative-liveness EDIT 4 - the MIRROR of
+// livenessReconcileFindings): each non-lean-L0 transcript with a false-negative liveness gap is a P0. Reads
+// ctx.liveSignals. Fail-closed on empty input.
+function falseNegativeLivenessFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!isFalseNegativeLivenessGap(t, ctx.liveSignals)) continue
+    findings.push({
+      severity: 'P0',
+      rule: 'falseNegativeLivenessFindings',
+      title: `DECLARED-DEAD / DUPLICATE-SPAWN (false-negative liveness gap) in ${t.path || '(unknown transcript)'}: a turn concluded a spawned agent DEAD/absent from a DISK-ONLY read (no artifact yet) WITHOUT a task-status poll confirming death, and/or SPAWNED a DUPLICATE onto an id a live agent already OWNED (fresh sub-<id>.jsonl / AGENTS.md / LIVE frontier / running task-status). 'no artifact yet' is AMBIGUOUS - a slow-but-alive agent looks identical to a dead one on disk; check TASK-STATUS before concluding dead (running-no-artifact-yet = ALIVE, never re-spawn). The MIRROR of livenessReconcileFindings (FIX-016)`,
+    })
+  }
+  return findings
+}
+
+// serialGateFindings (PLAN-time-optimization - P1, EXTENDING the waveBarrier/leanIdle family): a BILLIONAIRE
+// feature-manager that dispatched a STATICALLY-INDEPENDENT gate pair ({G2,G3} or {G5,G6} for the same feature)
+// in TWO different turns rather than ONE batched turn. The pair independence is STATIC (always true by gate
+// contract), so the only question is batched-vs-serialized - answered by the per-turn gateSpawnTurns data,
+// identical in kind to wave-barrier, NOT a flat count. Fail-closed: non-billionaire, non-manager, or
+// unclassifiable gate labels never fire. A pair seen in ONE turn (batched, the win state) never fires.
+function serialGateFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  const severity = ctx.serializationEnforcement === true ? 'P0' : 'P1'
+  for (const t of transcripts) {
+    if (!t || t.mode !== 'billionaire' || t.persona !== 'ap-manager') continue
+    const turns = Array.isArray(t.gateSpawnTurns) ? t.gateSpawnTurns : []
+    if (turns.length === 0) continue
+    for (const [a, b] of INDEPENDENT_GATE_PAIRS) {
+      const batchedTogether = turns.some(turn => turn.gateLabels.has(a) && turn.gateLabels.has(b))
+      if (batchedTogether) continue
+      const turnA = turns.find(turn => turn.gateLabels.has(a))
+      const turnB = turns.find(turn => turn.gateLabels.has(b))
+      if (turnA && turnB && turnA.index !== turnB.index) {
+        findings.push({
+          severity,
+          rule: 'serialGateFindings',
+          title: `GATE-CHAIN-SERIALIZATION in ${t.path || '(unknown transcript)'}: a BILLIONAIRE feature-manager dispatched the INDEPENDENT gate pair {${a}, ${b}} in two separate turns (serial) instead of one batched turn - ${a} and ${b} are independent by gate contract and run CONCURRENTLY by default in BILLIONAIRE (the within-feature gate-DAG); batch the pair, never serialize it`,
+        })
+      }
+    }
+  }
+  return findings
+}
+
+// serialFeatureFindings (PLAN-autoprompt-enforcement - P1, EXTENDING the serialGate/leanIdle family):
+// a BILLIONAIRE ap-feature-coordinator that dispatched a cohort of DECLARED-DISJOINT same-phase features
+// SERIALLY / never wider than the floor. The COHORT is built ONLY from the mandatory DECOMPOSE rows;
+// features with a dep edge, shared file ownership, a different phase, or no DECOMPOSE row are EXCLUDED.
+// The FIRING WIDTH is grouped by wave from the mandatory DISPATCH rows ALONE - the guaranteed signal,
+// NOT prose descriptions (which a mission-first run leaves FID-less). Fires once per cohort per
+// transcript when a cohort >= SERIAL_FEATURE_FLOOR existed yet max wave width < the floor.
+function serialFeatureFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  const decomp = Array.isArray(ctx.featureDecomposition) ? ctx.featureDecomposition : []
+  if (decomp.length === 0) return findings                       // defensive fail-closed: no DECOMPOSE rows
+  const dispatches = Array.isArray(ctx.featureDispatches) ? ctx.featureDispatches : []
+  const severity = ctx.serializationEnforcement === true ? 'P0' : 'P1'
+  for (const t of transcripts) {
+    if (!t || t.mode !== 'billionaire' || !isFeatureL1(t.persona)) continue
+    const byPhase = new Map()
+    for (const f of decomp) {
+      if (!byPhase.has(f.phase)) byPhase.set(f.phase, [])
+      byPhase.get(f.phase).push(f)
+    }
+    for (const [, members] of byPhase) {
+      const cohort = members.filter(f => members.every(g =>
+        g.feature === f.feature ||
+        (!f.deps.has(g.feature) && !g.deps.has(f.feature) && disjointOwns(f.owns, g.owns))))
+      const ids = new Set(cohort.map(f => f.feature))
+      if (ids.size < SERIAL_FEATURE_FLOOR) continue              // proportionality floor
+      const byWave = new Map()
+      const dispatched = new Set()
+      for (const d of dispatches) {
+        if (!ids.has(d.feature)) continue
+        dispatched.add(d.feature)
+        if (!byWave.has(d.wave)) byWave.set(d.wave, new Set())
+        byWave.get(d.wave).add(d.feature)
+      }
+      if (dispatched.size < SERIAL_FEATURE_FLOOR) continue       // judge only a cohort actually dispatched
+      let maxWidth = 0
+      for (const [, w] of byWave) if (w.size > maxWidth) maxWidth = w.size
+      if (maxWidth < SERIAL_FEATURE_FLOOR) {
+        findings.push({
+          severity,
+          rule: 'serialFeatureFindings',
+          title: `SERIAL-FEATURE in ${t.path || '(unknown transcript)'}: a BILLIONAIRE feature-supervisor dispatched ${dispatched.size} declared-disjoint same-phase features at max concurrent wave width ${maxWidth} (< ${SERIAL_FEATURE_FLOOR}) - independent features MUST be dispatched in ONE wide PUSH-WORK wave, not one-after-another like TOKENSAVER`,
+        })
+      }
+    }
+  }
+  return findings
+}
+
+// serialDispatchFindings (P-22 non-blocking dispatch - P1, the mode-AGNOSTIC mirror of
+// serialFeatureFindings). serialFeatureFindings owns ONLY the BILLIONAIRE floor-6 case;
+// the OTHER parallel modes (wide / custom / tokensaver) had the never-serialize invariant
+// UNENFORCED - yet the harness fans out in every one of them (all EXECUTION_MODES set
+// parallelFeatures:true). This rule closes that gap: a parallel-mode feature-coordinator
+// that dispatched a DECLARED-DISJOINT same-phase cohort of >= SERIAL_DISPATCH_FLOOR features
+// STRICTLY one at a time (every DISPATCH wave width 1 - pure spawn-wait-spawn) is the F-5
+// "firing N then fired 1" defect. Cohort independence is DECLARED via DECOMPOSE rows (the
+// same disjointness test serialFeatureFindings uses - SOUND, no static-independence guess);
+// the width is grouped from DISPATCH rows ALONE. Scoped to NON-billionaire (billionaire is
+// owned above) so the two rules never double-fire. Fail-closed: billionaire, non-coordinator,
+// no DECOMPOSE rows, a cohort < floor, or ANY wave wider than 1 -> no finding.
+const SERIAL_DISPATCH_FLOOR = 2
+const PARALLEL_NONBILLIONAIRE_MODES = new Set(['wide', 'custom', 'tokensaver'])
+function serialDispatchFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  const decomp = Array.isArray(ctx.featureDecomposition) ? ctx.featureDecomposition : []
+  if (decomp.length === 0) return findings                       // defensive fail-closed: no DECOMPOSE rows
+  const dispatches = Array.isArray(ctx.featureDispatches) ? ctx.featureDispatches : []
+  for (const t of transcripts) {
+    if (!t || !PARALLEL_NONBILLIONAIRE_MODES.has(t.mode) || !isFeatureL1(t.persona)) continue
+    const byPhase = new Map()
+    for (const f of decomp) {
+      if (!byPhase.has(f.phase)) byPhase.set(f.phase, [])
+      byPhase.get(f.phase).push(f)
+    }
+    for (const [, members] of byPhase) {
+      const cohort = members.filter(f => members.every(g =>
+        g.feature === f.feature ||
+        (!f.deps.has(g.feature) && !g.deps.has(f.feature) && disjointOwns(f.owns, g.owns))))
+      const ids = new Set(cohort.map(f => f.feature))
+      if (ids.size < SERIAL_DISPATCH_FLOOR) continue             // proportionality floor
+      const byWave = new Map()
+      const dispatched = new Set()
+      for (const d of dispatches) {
+        if (!ids.has(d.feature)) continue
+        dispatched.add(d.feature)
+        if (!byWave.has(d.wave)) byWave.set(d.wave, new Set())
+        byWave.get(d.wave).add(d.feature)
+      }
+      if (dispatched.size < SERIAL_DISPATCH_FLOOR) continue      // judge only a cohort actually dispatched
+      let maxWidth = 0
+      for (const [, w] of byWave) if (w.size > maxWidth) maxWidth = w.size
+      if (maxWidth === 1) {                                      // STRICTLY serial: every wave a single feature
+        findings.push({
+          severity: 'P1', rule: 'serialDispatchFindings',
+          title: `SERIAL-DISPATCH in ${t.path || '(unknown transcript)'}: a ${String(t.mode).toUpperCase()} feature-coordinator dispatched ${dispatched.size} declared-disjoint same-phase features STRICTLY one at a time (every wave width 1 - spawn-wait-spawn) though ${String(t.mode).toUpperCase()} fans out concurrently - independent ready work must be spawn-all-then-collect, never serialized (P-22 / F-5 "firing N then fired 1")`,
+        })
+      }
+    }
+  }
+  return findings
+}
+
+// === P-28 SPAWN-SPLIT (spawn-format hygiene) =================================
+// base:67: "you format it weirdly and the prompt ends up splitting into 2" - one part
+// sends, the tail is queued and lost. gate.js assertSingleBlock is the PRE-dispatch throw
+// (control split markers at brief assembly); spawnSplitFindings is the POST-HOC P1 teeth
+// over the brief that actually REACHED a spawned subagent (firstUserTurnText on disk) -
+// the same deliberate-duplication pattern as GATE_EXPECTED_PERSONA. Three unambiguous
+// split signatures: a control split marker, a truncation/continuation sentinel, or a
+// DOUBLE ORIGINAL-MISSION block (two briefs concatenated = split-then-both-sent).
+const SPAWN_SPLIT_MARKERS = [0x0000, 0x2028, 0x2029].map(c => String.fromCharCode(c))       // NUL / line-separator / paragraph-separator
+const TRUNCATION_SENTINEL_RE = /\[(?:truncated|continued|cont'd|message split|brief split|prompt split)\]|<<<\s*split\s*>>>/i
+// briefSplitReasons(text, missionLabel): the reasons a received brief shows a split /
+// double-block. PURE, total; '' / non-string -> [] (fail-closed, never false-flags).
+function briefSplitReasons(text, missionLabel) {
+  const reasons = []
+  const s = typeof text === 'string' ? text : ''
+  if (s === '') return reasons
+  if (SPAWN_SPLIT_MARKERS.some(m => s.indexOf(m) !== -1)) {
+    reasons.push('carries a control split marker (NUL/LS/PS) - it split in transit (one part sent, the tail queued)')
+  }
+  if (TRUNCATION_SENTINEL_RE.test(s)) {
+    reasons.push('carries a truncation/continuation sentinel - the brief was cut and the remainder queued as a second block')
+  }
+  if (typeof missionLabel === 'string' && missionLabel !== '') {
+    let idx = s.indexOf(missionLabel)
+    let count = 0
+    while (idx !== -1) { count++; idx = s.indexOf(missionLabel, idx + missionLabel.length) }
+    if (count >= 2) reasons.push(`carries ${count} ORIGINAL MISSION blocks - a double-block: two briefs concatenated (the split-then-both-sent signature)`)
+  }
+  return reasons
+}
+// spawnSplitFindings (P-28 teeth, P1): each spawned transcript whose received brief shows a
+// split signature. Fail-closed: ctx null, no transcripts, or an empty firstUserTurnText ->
+// []. The conductor ROOT's first user turn is the RAW human prompt (no mission label / no
+// markers) and never trips.
+function spawnSplitFindings(ctx) {
+  const findings = []
+  if (ctx == null) return findings
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || typeof t !== 'object') continue
+    const brief = typeof t.firstUserTurnText === 'string' ? t.firstUserTurnText : ''
+    if (brief === '') continue
+    const reasons = briefSplitReasons(brief, MISSION_BLOCK_LABEL)
+    if (reasons.length) {
+      findings.push({
+        severity: 'P1', rule: 'spawnSplitFindings',
+        title: `SPLIT SPAWN BRIEF in ${t.path || '(unknown transcript)'}: the brief that reached this spawn ${reasons.join('; ')} - a spawned brief must be ONE clean block (base:67). Emit the whole brief in a single block; never let it split into a sent part + a queued part.`,
+      })
+    }
+  }
+  return findings
+}
+
+// === P-27 DEPLOYED==SOURCE VERIFY ===========================================
+// F-11: subagents ran an OLD installed skill for a whole session; a deployed profile was
+// 397 lines stale, and NOTHING verified installed==built. verifyDeployedMatchesSource hashes
+// the KEY skill files in the installed dir and the source tree and reports every file whose
+// deployed bytes DIFFER (or is missing on either side). The ship ritual calls the
+// `--verify-deployed` CLI and refuses to ship on a MISMATCH. Standalone from runLedgerCheck.
+const DEPLOY_KEY_TOPLEVEL = ['SKILL.md', 'GATES.md']
+const DEPLOY_KEY_DIR_GLOBS = [
+  { dir: 'agents', ext: '.md' },
+  { dir: 'frameworks', ext: '.md' },
+  { dir: 'workflow', ext: '.js' },
+]
+// A workflow/*.js file that is test/coverage scaffolding, NOT shipped runtime - excluded so
+// a source tree carrying test seams the deploy legitimately drops never reads as a mismatch.
+const NON_RUNTIME_JS_RE = /\.(?:test|slice)\.[cm]?js$|-coverage\.[cm]?js$|(?:^|[\/\\])cov-fill|(?:^|[\/\\])smoke-test\.js$/i
+// Normalize CRLF->LF before hashing so a checkout line-ending flip is not a false mismatch.
+function normalizeForHash(text) { return String(text).replace(/\r\n/g, '\n') }
+function hashContent(text) { return crypto.createHash('sha256').update(normalizeForHash(text), 'utf8').digest('hex') }
+// listDeployKeyFiles(rootDir, io): sorted relative key-file paths under rootDir. io.readdir
+// is injectable for hermetic tests; the default swallows a missing dir (fail-soft -> []).
+function listDeployKeyFiles(rootDir, io) {
+  const readdir = io && typeof io.readdir === 'function'
+    ? io.readdir
+    : (d => { try { return fs.readdirSync(d) } catch (e) { return [] } })
+  const rels = [...DEPLOY_KEY_TOPLEVEL]
+  for (const g of DEPLOY_KEY_DIR_GLOBS) {
+    const entries = readdir(path.join(rootDir, g.dir)) || []
+    for (const e of [...entries].sort()) {
+      if (typeof e !== 'string' || !e.endsWith(g.ext)) continue
+      if (g.dir === 'workflow' && NON_RUNTIME_JS_RE.test(e)) continue
+      rels.push(`${g.dir}/${e}`)
+    }
+  }
+  return rels
+}
+// verifyDeployedMatchesSource({installedDir, sourceDir, io}): compares the UNION of key files
+// across both trees. Returns { ok, checked, mismatched, missingInDeployed, missingInSource }.
+// identical bytes pass; differing bytes -> mismatched; present in source but absent/unreadable
+// in the deploy -> missingInDeployed (the stale-deploy case F-11 describes). io.readFile is
+// injectable ((dir, rel) -> string|null) for hermetic tests; the default reads real fs.
+function verifyDeployedMatchesSource(o) {
+  const { installedDir, sourceDir } = o
+  const io = o.io || null
+  const readFile = io && typeof io.readFile === 'function'
+    ? io.readFile
+    : ((d, rel) => { try { return fs.readFileSync(path.join(d, rel), 'utf8') } catch (e) { return null } })
+  const srcRels = listDeployKeyFiles(sourceDir, io)
+  const depRels = listDeployKeyFiles(installedDir, io)
+  const all = [...new Set([...srcRels, ...depRels])].sort()
+  const mismatched = []
+  const missingInDeployed = []
+  const missingInSource = []
+  for (const rel of all) {
+    const srcBody = readFile(sourceDir, rel)
+    const depBody = readFile(installedDir, rel)
+    if (srcBody == null && depBody == null) continue
+    if (srcBody == null) { missingInSource.push(rel); continue }
+    if (depBody == null) { missingInDeployed.push(rel); continue }
+    if (hashContent(srcBody) !== hashContent(depBody)) mismatched.push(rel)
+  }
+  const ok = mismatched.length === 0 && missingInDeployed.length === 0 && missingInSource.length === 0
+  return { ok, checked: all.length, mismatched, missingInDeployed, missingInSource }
+}
+
+// disjointOwns: two features' file-ownership sets share no path. Pure, total.
+function disjointOwns(a, b) {
+  for (const p of a) if (b.has(p)) return false
+  return true
+}
+
+// splittableConcreteParts (worker-starvation): the count of DISTINCT, CONCRETE (non-glob)
+// owned paths in a feature's DECOMPOSE owns set. >=2 concrete paths = >=2 separable parts the
+// L2 manager MUST fan to sibling L3 workers. A glob is ambiguous and NOT counted - fail-closed:
+// a one-file or single-glob feature returns < 2 and never trips the rule. Pure, total.
+function splittableConcreteParts(owns) {
+  if (!(owns instanceof Set)) return 0
+  let n = 0
+  for (const p of owns) if (typeof p === 'string' && p !== '' && !p.includes('*')) n++
+  return n
+}
+
+// managerWorkerStarvationFindings (steer-4b HIERARCHY-CORRECTNESS - the (ii) teeth, the missing
+// half; (i) skip-the-supervisor is owned by conductorSpawnAllowlistFindings + l1ChildrenFindings,
+// never duplicated here): a BILLIONAIRE L2 ap-manager that dispatched EXACTLY ONE L3 worker for a
+// feature whose mandatory DECOMPOSE owns set holds >=2 DISTINCT CONCRETE paths - worker-starvation
+// (steer 4: "managers had only ONE worker each"). NO concurrency floor (steer 5): the fire keys on
+// exactly-one-worker over demonstrably-splittable work, NOT on "fewer than N". Splittability is the
+// decompose-time owns meta (the guaranteed signal); worker count reuses the existing spawnedTypes (no
+// scanner change). Severity escalates P1->P0 under serializationEnforcement, identical to the serial
+// family. Fail-closed: non-billionaire / non-manager / no feature join / owns<2 concrete / workerCount!==1 -> [].
+function managerWorkerStarvationFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  const decomp = Array.isArray(ctx.featureDecomposition) ? ctx.featureDecomposition : []
+  if (decomp.length === 0) return findings                     // fail-closed: no DECOMPOSE meta
+  const byFeature = new Map(decomp.map(f => [f.feature, f]))   // f.feature is UPPER-CASED by deriveFeatureDecomposition
+  const severity = ctx.serializationEnforcement === true ? 'P0' : 'P1'
+  for (const t of transcripts) {
+    if (!t || t.mode !== 'billionaire' || t.persona !== 'ap-manager') continue
+    const fid = typeof t.feature === 'string' ? t.feature.toUpperCase() : ''
+    const row = fid ? byFeature.get(fid) : undefined
+    if (!row) continue                                         // no join -> cannot prove splittable
+    const parts = splittableConcreteParts(row.owns)
+    if (parts < 2) continue                                    // atomic/one-file/glob -> never fires (NO floor)
+    const children = Array.isArray(t.spawnedTypes) ? t.spawnedTypes : []
+    const workerCount = children.filter(c => L3_EXECUTORS.has(c)).length
+    if (workerCount !== 1) continue                            // exactly-one-worker is the steer-4 shape
+    findings.push({
+      severity,
+      rule: 'managerWorkerStarvationFindings',
+      title: `WORKER-STARVATION in ${t.path || '(unknown transcript)'}: a BILLIONAIRE L2 ap-manager for ${fid} dispatched exactly ONE L3 worker on demonstrably-splittable work (its DECOMPOSE owns ${parts} disjoint concrete parts) - independent parts MUST run as sibling L3 workers in parallel (the L2->L3 split site), not one worker serially (steer 4 "managers had only ONE worker each"). This is NOT a concurrency floor: a one-file/atomic feature with one worker is correct and never trips this rule.`,
+    })
+  }
+  return findings
+}
+
+// supervisorWaveCountFindings (PLAN-supervisor-collapse - P1): an L0 conductor that spawned
+// >= SUPERVISOR_WAVE_FLOOR ap-feature-coordinator instances in ONE wave (the supervisor-per-feature
+// signature: there is EXACTLY ONE feature-coordinator per run; features are MANAGER-level concerns).
+// Keys on maxFeatureSupervisorWave (the widest single-turn feature-coordinator count) - NOT a flat
+// total, so sequential convergence re-spawns (one per turn) never trip it. Fail-closed: non-conductor,
+// absent/non-numeric/zero wave -> []. Orthogonal to waveBarrier: fires whether or not the wave folded.
+function supervisorWaveCountFindings(ctx) {
+  const findings = []
+  const transcripts = Array.isArray(ctx.transcripts) ? ctx.transcripts : []
+  for (const t of transcripts) {
+    if (!t || t.isConductor !== true) continue
+    const wave = Number(t.maxFeatureSupervisorWave)
+    if (!Number.isFinite(wave) || wave < SUPERVISOR_WAVE_FLOOR) continue
+    findings.push({
+      severity: 'P1',
+      rule: 'supervisorWaveCountFindings',
+      title: `SUPERVISOR-PER-FEATURE in ${t.path || '(unknown transcript)'}: the L0 conductor spawned ${wave} ap-feature-coordinator instances in ONE wave, but there is EXACTLY ONE feature-coordinator per run - features are MANAGER-level concerns (ONE L2 ap-manager per feature under the single coordinator). Collapse the ${wave} coordinators to ONE feature-coordinator fanning ${wave} managers (SKILL.md dispatch-contract step 4).`,
+    })
+  }
+  return findings
+}
+
+// compactThresholdFindings (PLAN-auto-compact-threshold - P1, LIGHT): a run whose RECORDED PEAK
+// context watermark exceeded the proactive threshold while the supervisor was attached, yet NO
+// compaction occurred - it missed its proactive compaction and rode toward the harness ceiling.
+// ctx.compactState = { peakWatermark, threshold, compactionOccurred, supervisorAttached }. Fail-closed:
+// absent/malformed compactState, non-numeric peak/threshold, compactionOccurred===true, or
+// supervisorAttached!==true -> [].
+function compactThresholdFindings(ctx) {
+  const findings = []
+  const c = ctx && ctx.compactState
+  if (!c || c.supervisorAttached !== true || c.compactionOccurred === true) return findings
+  const peak = Number(c.peakWatermark)
+  const thr = Number(c.threshold)
+  if (!Number.isFinite(peak) || !Number.isFinite(thr) || thr <= 0) return findings
+  if (peak >= thr) {
+    findings.push({
+      severity: 'P1',
+      rule: 'compactThresholdFindings',
+      title: `proactive compaction missed: peak context watermark ${peak} reached/exceeded AUTOPROMPT_COMPACT_AT ${thr} while the supervisor was attached, but no compaction occurred - the run rode toward the harness ceiling instead of compacting proactively`,
+    })
+  }
+  return findings
+}
+// F-FRAMEWORK SMASH-1 - frameworkFallthroughFindings: a structural regression guard on
+// the skill's OWN on-disk routing spec (NOT a phantom GATELOG row). P-26: the prose
+// decision tree in agents/claude/frameworks/README.md is the SINGLE routing source of truth
+// (the competing framework-selector.js was deleted), so this rule no longer keys on the
+// selector module's existence - only on the spec itself:
+//   - README still carries the silent `return backend-implement` global fallback -> P0
+//     (the exact regression the mission forbids - an unmatched task degrades instead of
+//     routing to GENERATE - INV-13 "never silent fallthrough").
+//   - README no longer names the routing authority (the framework-selector token or the
+//     prose GENERATE route) -> P1 (spec-drift guard, non-blocking).
+// FAIL-CLOSED: README unreadable (null) -> emit nothing. A non-skill target repo, or a
+// path the run does not contain, is NEVER false-FAILed. The rule fires ONLY on genuine,
+// present, regressed evidence.
+const FRAMEWORK_README_REL = 'agents/omp/frameworks/README.md'
+const SILENT_FALLBACK_RE = /GLOBAL FALLBACK[^\n]*return\s+backend-implement/i
+const SELECTOR_AUTHORITY_RE = /framework-selector(\.js)?|GENERATE/
+function frameworkFallthroughFindings(ctx) {
+  const findings = []
+  const readRepoFile = ctx && typeof ctx.readRepoFile === 'function' ? ctx.readRepoFile : null
+  if (!readRepoFile) return findings
+  const readme = readRepoFile(FRAMEWORK_README_REL)
+  if (readme == null) return findings // fail-closed: non-skill repo, never false-FAIL
+  if (SILENT_FALLBACK_RE.test(readme)) {
+    findings.push({
+      severity: 'P0',
+      rule: 'frameworkFallthroughFindings',
+      title: 'silent backend-implement fallthrough still present in framework selector spec - an unmatched task degrades instead of routing to GENERATE',
+    })
+  }
+  if (!SELECTOR_AUTHORITY_RE.test(readme)) {
+    findings.push({
+      severity: 'P1',
+      rule: 'frameworkFallthroughFindings',
+      title: 'README §3 no longer names the routing authority (the GENERATE route / selector) - prose<->spec drift',
+    })
+  }
+  return findings
+}
+
+// depthLockFindings (F-DEPTH - P0, the DEPTH-LOCK mechanical teeth): a `debug`
+// feature must not ship a wrong-LAYER / symptom fix whose self-written repro went
+// green. The independently-derived deepest cause (ap-depth-prober's D3) must EQUAL
+// the frozen fix-layer AND the D4 adversarial repro must be proven RED unpatched.
+//
+// AUTHORITATIVE CLASSIFICATION (G5/G6 fix): "is this a debug feature" is NO LONGER
+// keyed on a self-applied inline `tag=debug` token an author can omit. It keys on
+// the RECORDED FEATURE-META `tag=debug` derived from the roadmap on new runs or
+// assigned by INTAKE on legacy resumes - a debug feature cannot hide by dropping a flag.
+// The legacy inline `tag=debug` on a GATELOG row is still honored (back-compat), but
+// the FEATURE-META metadata is the un-omittable source.
+//
+// Three P0 arms, fail-closed everywhere (a non-debug or legacy/unannotated run is
+// never false-FAILed - the discipline proportionalGatesFindings uses):
+//   ARM A - a debug feature that REACHED the fix (a G4 IMPLEMENT row OR a G6 VERIFY
+//           row OR a GOAL-CHECK DONE seal) with NO <feature>-depth-lock.md on disk.
+//           This fires REGARDLESS of session/resume: a debug feature cannot seal
+//           DONE with DEPTH-LOCK skipped, even on a resume path (DEP-5 clause 1).
+//   ARM B - the frozen fix-layer (the `fixlayer=` token a LIVE depthLock row emits)
+//           != the D3 deepest-cause parsed from the depth-lock artifact (DEP-5 cl.2).
+//   ARM C - the depth-lock artifact lacks a captured-RED marker for D4 (DEP-4).
+function depthLockFindings(ctx) {
+  const findings = []
+  const gatelog = Array.isArray(ctx.gatelog) ? ctx.gatelog : []
+  const featureMeta = Array.isArray(ctx.featureMeta) ? ctx.featureMeta : []
+  const goalChecks = Array.isArray(ctx.goalChecks) ? ctx.goalChecks : []
+  const artifactExists = typeof ctx.artifactExists === 'function' ? ctx.artifactExists : () => false
+  const readArtifact = typeof ctx.readArtifact === 'function' ? ctx.readArtifact : () => null
+
+  // AUTHORITATIVE debug set: the recorded FEATURE-META tag (un-omittable, decompose-time)
+  // is the primary source; a legacy inline GATELOG `tag=debug` is still honored.
+  const isDebugByFeature = new Map()
+  for (const m of featureMeta) {
+    if (m && m.feature && m.tag === 'debug') isDebugByFeature.set(m.feature.toUpperCase(), true)
+  }
+  const gatesByFeature = new Map()
+  const fixlayerByFeature = new Map()
+  for (const r of gatelog) {
+    if (!r || !r.feature || !r.gate) continue
+    const fid = r.feature.toUpperCase()
+    if (!gatesByFeature.has(fid)) gatesByFeature.set(fid, new Set())
+    gatesByFeature.get(fid).add(r.gate)
+    if (r.tag === 'debug') isDebugByFeature.set(fid, true)
+    if (r.fixlayer && !fixlayerByFeature.has(fid)) fixlayerByFeature.set(fid, r.fixlayer)
+  }
+  // DONE seals (resume-proof teeth): a feature sealed DONE without a depth-lock
+  // artifact must fire ARM A even when its build was sealed on a resume path that
+  // never re-recorded a G4/G6 row this session.
+  const doneFeatures = new Set()
+  for (const g of goalChecks) if (g && g.feature) doneFeatures.add(String(g.feature).toUpperCase())
+
+  // every feature that is debug AND reached the fix is a candidate (NOT only those
+  // with a gate row - a DONE seal alone is enough to require the artifact).
+  const candidates = new Set([...isDebugByFeature.keys()].filter(f => isDebugByFeature.get(f) === true))
+  for (const feature of candidates) {
+    const gates = gatesByFeature.get(feature) || new Set()
+    const reachedFix = gates.has('G4') || gates.has('G6') || doneFeatures.has(feature)
+    if (!reachedFix) continue                              // a debug feature still in PLAN has nothing to lock yet
+    const artifactName = `${feature}-depth-lock.md`
+    // ARM A - missing prober artifact (resume-proof: keyed on the authoritative tag).
+    if (!artifactExists(artifactName)) {
+      findings.push({
+        severity: 'P0', rule: 'depthLockFindings',
+        title: `depth-lock missing (${feature}): a debug feature reached the fix (G4/G6/DONE) with NO ${artifactName} on disk - every debug fix must pass an independent G3.5 DEPTH-LOCK (ap-depth-prober) that derives the deepest cause from the issue text BEFORE the fix is built; DEPTH-LOCK cannot be skipped on any session/resume path`,
+      })
+      continue
+    }
+    const body = readArtifact(artifactName)
+    if (typeof body !== 'string') continue                 // unreadable -> fail-closed (ARM B/C need the body)
+    const d3Match = DEPTHLOCK_D3_RE.exec(body)
+    const fixlayer = fixlayerByFeature.get(feature) || ''
+    // ARM B - layer mismatch (only when BOTH discriminators are present; else fail-closed).
+    if (d3Match && fixlayer) {
+      const d3 = d3Match[1]
+      if (normalizeLayer(fixlayer) !== normalizeLayer(d3)) {
+        findings.push({
+          severity: 'P0', rule: 'depthLockFindings',
+          title: `depth-miss (${feature}): frozen fix-layer ${fixlayer} != independently-derived deepest-cause ${d3} - a wrong-LAYER / symptom fix (right neighborhood, wrong function) cannot ship; the fix must land at the function that DECIDES the behavior, not a downstream guard`,
+        })
+        continue
+      }
+    }
+    // ARM C - D4 repro not proven RED unpatched.
+    if (!DEPTHLOCK_D4_RED_RE.test(body)) {
+      findings.push({
+        severity: 'P0', rule: 'depthLockFindings',
+        title: `depth-miss (${feature}): the D4 adversarial issue-derived repro in ${artifactName} is not proven RED against unpatched code - a depth-lock without a captured-red baseline cannot prove the chosen layer fixes the real failure`,
+      })
+    }
+  }
+  return findings
+}
+
+// normalizeLayer (F-DEPTH): a file.py::function token compared case-sensitively but
+// tolerant of a leading "./" and surrounding whitespace, so an equal layer in two
+// spellings reconciles while a genuinely different function still differs. Callers
+// guard both operands non-empty before comparing, so the input is always a string.
+function normalizeLayer(layer) {
+  return String(layer).trim().replace(/^\.\//, '')
+}
+
+// FIX-06's F5-18 rule, plus the five FX-HIERARCHY linters (FIX-10/11/13/14/17).
+// FX-HIERARCHY appended its rules here with no change to parsing or the CLI.
+const RULE_REGISTRY = [
+  reconcileProvenance,
+  roadmapClosureFindings,
+  mixedLedgerFormatFindings,
+  selfReviewSignatureFindings,
+  managerExecFindings,
+  conductorToolUseFindings,
+  l1ChildrenFindings,
+  goalCheckJanitorFindings,
+  preflightEditFindings,
+  selfBlockYieldFindings,
+  anchorIntegrityFindings,
+  waveBarrierFindings,
+  commitCheckpointFindings,
+  thinSprawlFindings,
+  conductorSpawnAllowlistFindings,
+  leanIdleFindings,
+  artifactSubstanceFindings,
+  parentFleetSynthesisFindings,
+  midRunCancelCheckpointFindings,
+  livenessReconcileFindings,
+  proportionalGatesFindings,
+  idleFinishFindings,
+  falseNegativeLivenessFindings,
+  serialGateFindings,
+  serialFeatureFindings,
+  serialDispatchFindings,
+  spawnSplitFindings,
+  managerWorkerStarvationFindings,
+  supervisorWaveCountFindings,
+  compactThresholdFindings,
+  frameworkFallthroughFindings,
+  tierProportionalityFindings,
+  evidencePackFindings,
+  frameworkTierFindings,
+  depthLockFindings,
+  missionFidelityFindings,
+  missionSourceOfTruthFindings,
+  selfWrittenCaptureFindings,
+  openFlawFindings,
+  startupHandshakeFindings,
+]
+
+// runLedgerCheck: read the ledger + transcripts with real fs, build ctx, run
+// every registered rule, and decide ok (no P0 finding). The transcript-keyed
+// hierarchy rules (managerExec/conductorToolUse/l1Children/goalCheckJanitor/
+// preflightEdit) ALWAYS run when a transcript dir holds transcripts, EVEN with
+// no GATELOG/AGENTS present - the mission's 0%-input self-test feeds a
+// transcript-only dir and a breach there MUST be caught (no fail-open). The
+// FIX-05 reconcileProvenance rule stays permissive-on-absence: with no GATELOG
+// it sees an empty gatelog and produces nothing, exactly as before. Only a
+// TRULY empty run (no ledger files AND no transcripts) takes the clean-by-
+// absence INFO path, so a non-benchmark interactive run is never false-FAILed.
+function parseJsonObject(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') return null
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function resolveLaunchBinding(options) {
+  if (options && options.launchBinding && typeof options.launchBinding === 'object') {
+    return options.launchBinding
+  }
+  const environment = options && options.environment && typeof options.environment === 'object'
+    ? options.environment
+    : process.env
+  const casting = parseJsonObject(environment.AUTOPROMPT_AGENT_CASTING)
+  if (casting) return casting
+  const attestation = parseJsonObject(environment.AUTOPROMPT_CAPABILITY_ATTESTATION)
+  if (!attestation || typeof attestation.effortStatus !== 'string') return null
+  return {
+    enabled: false,
+    aliases: {},
+    effort: { status: attestation.effortStatus, maximum: null },
+  }
+}
+
+function runLedgerCheck(opts) {
+  const options = opts || {}
+  const ledgerDir = options.ledgerDir
+  const artifactDir = options.artifactDir
+  const transcriptDir = options.transcriptDir
+  const promptsPath = options.promptsPath || (ledgerDir ? path.join(ledgerDir, 'PROMPTS.txt') : '')
+  const info = []
+
+  const gatelogText = readIfExists(ledgerDir, 'GATELOG.md')
+  const agentsText = readIfExists(ledgerDir, 'AGENTS.md')
+  const roadmapText = readIfExists(ledgerDir, 'ROADMAP.md')
+  const promptsText = readIfExists(ledgerDir, 'PROMPTS.txt')
+  const transcripts = scanTranscriptDir(transcriptDir)
+  // New-format detection no longer requires AGENTS.md to be ABSENT: a stale
+  // legacy file must not silently disable root roadmap closure or reroute
+  // provenance through the legacy spawn table. Coexisting parseable AGENTS.md
+  // spawn rows are a CONTRADICTION owned by mixedLedgerFormatFindings (P0);
+  // an empty/heading-only leftover is harmless residue and closure proceeds.
+  const compactLedger = gatelogText != null && roadmapText != null && promptsText != null
+  const hasLedger = gatelogText != null || agentsText != null || roadmapText != null || promptsText != null
+  const roadmapItems = parseRoadmapItems(roadmapText || '')
+  const launchBinding = resolveLaunchBinding(options)
+
+  if (!hasLedger && transcripts.length === 0) {
+    info.push('no GATELOG.md/AGENTS.md found - nothing to reconcile (clean by absence)')
+    return { ok: true, findings: [], info }
+  }
+
+  const gatelog = parseLedgerLines(gatelogText || '', 'gatelog')
+  const agents = parseLedgerLines(agentsText || '', 'agents')
+  const artifactExists = (name) => {
+    if (!artifactDir || !name) return false
+    try { return fs.existsSync(path.join(artifactDir, name)) } catch (e) { return false }
+  }
+  const readArtifact = (name) => {
+    try { return fs.readFileSync(path.join(artifactDir, name), 'utf8') } catch (e) { return null }
+  }
+  // F-FRAMEWORK SMASH-1: read the skill's OWN repo files via a derivable root. Default root
+  // is three levels above this module (agents/claude/workflow -> repo root); options.repoRoot
+  // overrides it (the tests inject a tmp root). Fail-closed: any read error -> null.
+  const repoRoot = options.repoRoot || path.resolve(__dirname, '..', '..', '..')
+  const readRepoFile = (rel) => {
+    try { return fs.readFileSync(path.join(repoRoot, rel), 'utf8') } catch (e) { return null }
+  }
+
+  // SPEC-2 / no-idle: stamp the run mode (from BRIEF.md) onto every transcript so the
+  // mode-scoped rules (wave-barrier, lean-idle) stay per-transcript and unit-testable.
+  const briefText = readIfExists(ledgerDir, 'BRIEF.md')
+  const mode = parseModeFromBrief(briefText || '')
+  for (const t of transcripts) t.mode = mode
+  // PLAN-startup-handshake: ATTENDED is the negation of the BRIEF.md `UNATTENDED: yes`
+  // line (absent -> attended, the stricter default that makes the handshake gate fire).
+  const attended = parseUnattendedFromBrief(briefText || '') === false
+  // SPD-3: the serialization-enforcement marker escalates serialGate/serialFeature P1->P0.
+  const serializationEnforcement = parseSerializationEnforcement(briefText || '')
+
+  // PLAN-e2e-verify: the goal-check-vN.md artifact BODIES from the artifact dir (the
+  // carriers of the OPEN-BLOCKERS / E2E: machine lines). Read the SAME fail-closed way
+  // anyArbiterDeferral/detectCompaction read the dir; openFlawFindings reads the latest.
+  const goalCheckArtifacts = collectGoalCheckArtifacts(artifactDir)
+
+  // SPEC-3 commit doctrine: the GOAL-CHECK DONE seals + COMMIT rows from the raw GATELOG.
+  const goalChecks = parseGoalCheckRows(gatelogText || '')
+  const commits = parseCommitRows(gatelogText || '')
+
+  // PLAN-midrun-insertion: urgent-steer cancel/checkpoint ordering from raw GATELOG lines.
+  const steerState = { urgentCancels: deriveSteerCancels((gatelogText || '').split('\n')) }
+
+  // PLAN-proportional-gates: per-feature target file from explicit target=/file= tokens in
+  // the raw GATELOG (fail-closed - never guessed from prose). Feeds proportionalGatesFindings ARM B.
+  const featureTargets = deriveFeatureTargets((gatelogText || '').split('\n'))
+
+  // PLAN-autoprompt-enforcement: the declared-disjoint cohort (DECOMPOSE rows) + the per-feature
+  // wave assignment (DISPATCH rows) that feed serialFeatureFindings. Both from the SAME gatelogText.
+  const featureDecomposition = deriveFeatureDecomposition((gatelogText || '').split('\n'))
+  const featureDispatches = deriveFeatureDispatches((gatelogText || '').split('\n'))
+
+  // SPD-1 tier-proportionality: the FEATURE-META rows + the over-tiering ceremony rows, both from the
+  // SAME raw gatelogText. Fail-closed - an absent FEATURE-META row yields no firing (legacy ledger safe).
+  const featureMeta = deriveFeatureMeta((gatelogText || '').split('\n'))
+  const ceremonyRows = deriveCeremonyRows((gatelogText || '').split('\n'))
+
+  // PLAN-anchor - yieldState: a run is a self-block when L0 returned control (a
+  // conductor AskUserQuestion turn) with open in-flight tracks and no arbiter
+  // deferral to the user. anchorState: a compaction is observed when a
+  // post-compaction artifact exists; once compacted, ANCHOR.md must exist and its
+  // live frontier must match the GATELOG-derived frontier.
+  const yieldState = {
+    returnedToUser: transcripts.some(t => t.isConductor === true && t.hasUserInterrupt === true),
+    openInFlightTracks: countOpenInFlightTracks(gatelog.records),
+    irreversibleQuestionPending: anyArbiterDeferral(artifactDir),
+  }
+  const anchorText = readIfExists(ledgerDir, 'ANCHOR.md')
+  const anchorState = {
+    compactionOccurred: detectCompaction(artifactDir),
+    anchorExists: anchorText != null,
+    anchorFrontier: parseAnchorFrontier(anchorText || ''),
+    gatelogFrontier: deriveGatelogFrontier(gatelog.records),
+  }
+
+  // PLAN-auto-compact-threshold - compactState: the LIGHT proactive-miss signal. peakWatermark
+  // from the .context-watermark file (token field) OR a GATELOG peak row; threshold from
+  // AUTOPROMPT_COMPACT_AT (default 200000); compactionOccurred reuses the anchor derivation;
+  // supervisorAttached when a RUN-ENDED marker is present. Fail-closed: any read error -> the rule
+  // sees a malformed/absent peak and returns [].
+  const compactState = deriveCompactState(ledgerDir, anchorState.compactionOccurred)
+
+  // PLAN-liveness-reconcile: the THREE ground-truth signal sets from disk.
+  const liveSignals = collectLiveSignals(transcriptDir, artifactDir)
+
+  // PLAN-idle-watchdog L1 - idleFinishState: the run-boundary signals the terminal
+  // IDLE-FINISH rule reads. `terminal` makes the audit run-ended: the CLI --terminal
+  // flag (options.terminal) OR a RUN-ENDED marker the supervisor writes on child-exit-
+  // without-sentinel (§2.4 V5). Both absent -> a mid-run snapshot, the rule never fires.
+  // hasLiveAgents reuses the SAME liveSignals the liveness rule uses (a fresh sub-*.jsonl
+  // OR a LIVE/in-flight FRONTIER entry = real work in flight); each .size read defensively.
+  // missionDone is the DONE-* sentinel at the ledger root. openInFlightTracks /
+  // irreversibleQuestionPending are reused from yieldState - no recomputation.
+  const terminal = options.terminal === true || readIfExists(ledgerDir, 'RUN-ENDED') != null
+  const hasLiveAgents =
+    (liveSignals && liveSignals.freshTranscriptIds && liveSignals.freshTranscriptIds.size > 0) ||
+    (liveSignals && liveSignals.frontierIds && liveSignals.frontierIds.size > 0) ||
+    (liveSignals && liveSignals.frontierLabels && liveSignals.frontierLabels.size > 0)
+  const idleFinishState = {
+    runEnded: terminal,
+    missionDone: detectDoneSentinel(ledgerDir, options.runNonce),
+    openInFlightTracks: yieldState.openInFlightTracks,
+    hasLiveAgents,
+    irreversibleQuestionPending: yieldState.irreversibleQuestionPending,
+  }
+
+  const ctx = {
+    gatelog: gatelog.records,
+    gatelogText: gatelogText || '',
+    agents: agents.records,
+    compactLedger,
+    roadmapItems,
+    terminal,
+    launchBinding,
+    artifactExists,
+    readArtifact,
+    readRepoFile,
+    transcripts,
+    yieldState,
+    anchorState,
+    goalChecks,
+    goalCheckArtifacts,
+    commits,
+    steerState,
+    featureTargets,
+    featureDecomposition,
+    featureDispatches,
+    featureMeta,
+    ceremonyRows,
+    serializationEnforcement,
+    compactState,
+    liveSignals,
+    idleFinishState,
+    // INH-1/INH-5 mission-fidelity inputs: the verbatim user-prompt ledger (PROMPTS.txt)
+    // for the brief-diff arm, and the DONE-sentinel signal for the source-of-truth arm
+    // (reuses the same detectDoneSentinel idleFinishState reads - no recomputation).
+    promptsText,
+    promptsPath,
+    runNonce: typeof options.runNonce === 'string' ? options.runNonce : '',
+    missionDone: idleFinishState.missionDone,
+    // PLAN-startup-handshake: ATTENDED signal (from BRIEF.md UNATTENDED) for the
+    // pre-spawn handshake HARD-GATE teeth; the drift signal is the root scan's firstToolUseName.
+    attended,
+  }
+  const findings = []
+  for (const rule of RULE_REGISTRY) findings.push(...rule(ctx))
+  const ok = findings.every(f => f.severity !== 'P0')
+  return { ok, findings, info }
+}
+
+// countOpenInFlightTracks: a feature is in-flight when it has >=1 GATELOG gate row
+// but no terminal G8 SCRIBE seal. Pure over parsed gatelog records.
+function countOpenInFlightTracks(gatelogRecords) {
+  const records = Array.isArray(gatelogRecords) ? gatelogRecords : []
+  const sealed = new Set()
+  const seen = new Set()
+  for (const r of records) {
+    if (!r || !r.feature) continue
+    seen.add(r.feature)
+    if (r.gate === 'G8') sealed.add(r.feature)
+  }
+  let open = 0
+  for (const f of seen) if (!sealed.has(f)) open++
+  return open
+}
+
+// anyArbiterDeferral: scans the artifact dir's arbiter-*.md rulings for an explicit
+// defer-to-user / userRequired ruling (the only legitimate ATTENDED yield). Best-
+// effort; absent dir or unreadable file -> false (fail-closed: no deferral found).
+function anyArbiterDeferral(artifactDir) {
+  if (!artifactDir) return false
+  let entries
+  try { entries = fs.readdirSync(artifactDir) } catch (e) { return false }
+  for (const name of entries) {
+    if (!/arbiter[^\/\\]*\.md$/i.test(name)) continue
+    let text
+    try { text = fs.readFileSync(path.join(artifactDir, name), 'utf8') } catch (e) { continue }
+    if (/userRequired["'\s:]+true/i.test(text) || /defer to user/i.test(text)) return true
+  }
+  return false
+}
+
+// collectGoalCheckArtifacts (PLAN-e2e-verify): read every goal-check-vN.md artifact
+// BODY from the artifact dir into [{ path, text }], sorted by name so the append-only
+// vN chronology puts the frontier last (openFlawFindings reads the latest). Best-
+// effort, fail-closed: absent dir or unreadable entry -> [] / skipped (no artifact ==
+// nothing for the rule to seal over, exactly the permissive-on-absence contract).
+function collectGoalCheckArtifacts(artifactDir) {
+  if (!artifactDir) return []
+  let entries
+  try { entries = fs.readdirSync(artifactDir) } catch (e) { return [] }
+  const out = []
+  for (const name of entries.slice().sort()) {
+    if (!GOAL_CHECK_ARTIFACT_RE.test(name)) continue
+    let text
+    try { text = fs.readFileSync(path.join(artifactDir, name), 'utf8') } catch (e) { continue }
+    out.push({ path: name, text })
+  }
+  return out
+}
+
+// detectCompaction: a run has compacted when a post-compaction / re-anchor artifact
+// is present on disk. Best-effort; absent dir -> false (not yet compacted).
+function detectCompaction(artifactDir) {
+  if (!artifactDir) return false
+  let entries
+  try { entries = fs.readdirSync(artifactDir) } catch (e) { return false }
+  return entries.some(name => /(post-?compaction|re-?anchor)[^\/\\]*\.md$/i.test(name))
+}
+
+// detectDoneSentinel (PLAN-idle-watchdog L3): when runNonce is supplied, only the
+// active run's exact DONE-<nonce> file with parsed JSON (done===true, embedded
+// nonce === runNonce) seals the mission - another activation's fresh DONE-* must
+// never terminate this run. Without a nonce, the legacy broad scan for any DONE-*
+// entry sealing done:true preserves readability of historical ledgers. Fail-closed:
+// an absent dir, an unreadable entry, malformed JSON, or no match all -> false (an
+// unverifiable sentinel is treated as NOT done - the safe direction: it can only
+// make IDLE-FINISH fire on a genuinely-open run, never falsely suppress it).
+function detectDoneSentinel(ledgerDir, runNonce) {
+  if (!ledgerDir) return false
+  if (typeof runNonce === 'string' && runNonce !== '') {
+    let value
+    try {
+      value = JSON.parse(fs.readFileSync(path.join(ledgerDir, `DONE-${runNonce}`), 'utf8'))
+    } catch (e) { return false }
+    return value != null && value.done === true && value.nonce === runNonce
+  }
+  let entries
+  try { entries = fs.readdirSync(ledgerDir) } catch (e) { return false }
+  for (const name of entries) {
+    if (!/^DONE-/.test(name)) continue
+    let text
+    try { text = fs.readFileSync(path.join(ledgerDir, name), 'utf8') } catch (e) { continue }
+    if (/"done"\s*:\s*true/.test(text)) return true
+  }
+  return false
+}
+
+// parseAnchorFrontier: parse the LIVE FRONTIER section of ANCHOR.md into
+// [{feature,status}]. Lines after a "LIVE FRONTIER" header of the form
+// "- <FEATURE>: <STATUS>" are collected. Returns [] on no header / empty text.
+function parseAnchorFrontier(text) {
+  if (typeof text !== 'string' || text === '') return []
+  const lines = text.split('\n')
+  const frontier = []
+  let inFrontier = false
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (/LIVE FRONTIER/i.test(line)) { inFrontier = true; continue }
+    if (!inFrontier) continue
+    if (line.startsWith('#')) { inFrontier = false; continue }
+    const m = line.match(/^-\s*([A-Za-z0-9_-]+)\s*:\s*(.+)$/)
+    if (m) frontier.push({ feature: m[1], status: m[2].trim() })
+  }
+  return frontier
+}
+
+// deriveGatelogFrontier: the latest verdict per feature -> [{feature,status}].
+// Append-only chronology means the last gatelog row for a feature is its frontier.
+function deriveGatelogFrontier(gatelogRecords) {
+  const records = Array.isArray(gatelogRecords) ? gatelogRecords : []
+  const latest = new Map()
+  for (const r of records) {
+    if (!r || !r.feature) continue
+    latest.set(r.feature, (r.verdict || '').trim())
+  }
+  return [...latest.entries()].map(([feature, status]) => ({ feature, status }))
+}
+
+function readIfExists(dir, name) {
+  if (!dir) return null
+  const full = path.join(dir, name)
+  try {
+    if (!fs.existsSync(full)) return null
+    return fs.readFileSync(full, 'utf8')
+  } catch (e) {
+    return null
+  }
+}
+
+// === SESSION-RESOLVE-SLICE:START - test-only export seam; sliced by session-resolve.test.js. Self-contained: PURE path-NAME helpers over injected arrays/strings, NO fs. ===
+// SPEC-1 session ledger: the path-NAME ALGORITHM lives here as pure functions over
+// injected arrays/strings (the fs-backed resolvePromptDir below applies these names to
+// disk). Fully unit-testable with plain arrays - no fs inside any of these.
+const SESSION_NAME_RE = /^session_(\d+)$/
+const PROMPT_NAME_RE = /^prompt_(\d+)-/
+
+// pad a positive integer to >=2 digits, widening to 3 once it reaches 100.
+function padSession(n) {
+  const s = String(n)
+  return s.length >= 3 ? s : s.padStart(2, '0')
+}
+
+// nextSessionName(existingNames) -> "session_<pad of max+1>"; "session_01" on empty/garbage.
+function nextSessionName(existingNames) {
+  const names = Array.isArray(existingNames) ? existingNames : []
+  let max = 0
+  for (const raw of names) {
+    const m = SESSION_NAME_RE.exec(String(raw || ''))
+    if (!m) continue
+    const n = parseInt(m[1], 10)
+    if (Number.isFinite(n) && n > max) max = n
+  }
+  return `session_${padSession(max + 1)}`
+}
+
+// nextPromptName(existingNames, slug) -> "prompt_<pad of max+1>-<slug>"; "prompt_01-<slug>" on empty.
+function nextPromptName(existingNames, slug) {
+  const names = Array.isArray(existingNames) ? existingNames : []
+  let max = 0
+  for (const raw of names) {
+    const m = PROMPT_NAME_RE.exec(String(raw || ''))
+    if (!m) continue
+    const n = parseInt(m[1], 10)
+    if (Number.isFinite(n) && n > max) max = n
+  }
+  return `prompt_${padSession(max + 1)}-${slug}`
+}
+
+// parseMarker(text) -> {name, token} from "session_NN  <token>". Missing token -> token:'';
+// garbage / non-string -> {name:'', token:''}.
+function parseMarker(text) {
+  if (typeof text !== 'string') return { name: '', token: '' }
+  const m = /^\s*(session_\d+)(?:\s+(\S+))?\s*$/.exec(text)
+  if (!m) return { name: '', token: '' }
+  return { name: m[1], token: m[2] || '' }
+}
+
+// decideSession({markerLine, markerDirExists, liveToken, isResume}) -> {sameSession}: true IFF
+// isResume===true OR (markerDirExists===true AND parsed marker token === non-empty liveToken).
+function decideSession({ markerLine, markerDirExists, liveToken, isResume } = {}) {
+  if (isResume === true) return { sameSession: true }
+  if (markerDirExists !== true) return { sameSession: false }
+  const token = parseMarker(markerLine).token
+  const live = typeof liveToken === 'string' ? liveToken : ''
+  return { sameSession: live !== '' && token === live }
+}
+
+// pickPromptDir(entries, slug) -> {name, reenter}. entries = [{name, hasGatelog, hasArtifacts,
+// hasDone}]. An unfinished prompt (gatelog/artifacts present, no DONE) is re-entered (highest-
+// numbered); else a fresh nextPromptName is minted.
+function pickPromptDir(entries, slug) {
+  const rows = Array.isArray(entries) ? entries : []
+  const unfinished = rows.filter(e => e && (e.hasGatelog || e.hasArtifacts) && !e.hasDone)
+  if (unfinished.length > 0) {
+    let best = unfinished[0]
+    let bestNum = -1
+    for (const e of unfinished) {
+      const m = PROMPT_NAME_RE.exec(String(e.name || ''))
+      const n = m ? parseInt(m[1], 10) : 0
+      if (n > bestNum) { bestNum = n; best = e }
+    }
+    return { name: best.name, reenter: true }
+  }
+  return { name: nextPromptName(rows.map(e => (e && e.name) || ''), slug), reenter: false }
+}
+// === SESSION-RESOLVE-SLICE:END ===
+
+// resolvePromptDir (SPEC-1 - the fs OWNER; OUTSIDE the pure slice). Applies the pure
+// Make a fresh user's repo ignore the ledger by default: drop a self-ignoring .gitignore
+// (the "*" idiom) into the ledger root the first time it is created. The ledger is generated
+// run state, not source - it should never land in the user's git history unless they opt in.
+// Idempotent and best-effort: a pre-existing .gitignore (e.g. a user override) is left alone,
+// and an fs error here never blocks a run (the ledger still works untracked or not).
+function ensureLedgerGitignore(ledgerRoot) {
+  const gitignorePath = path.join(ledgerRoot, '.gitignore')
+  if (fs.existsSync(gitignorePath)) return
+  try {
+    fs.writeFileSync(gitignorePath, '# Auto-generated by autoprompt: the ledger is run state, not source.\n*\n')
+  } catch {
+    // best-effort: ledger creation must not fail because the ignore file could not be written
+  }
+}
+
+// path-NAME helpers to disk: decide same-vs-new session from the .session-current marker,
+// pick/re-enter the prompt folder, mkdir, write the marker atomically, return the resolved
+// PROMPT_DIR. FAIL-LOUD: on an unrecoverable fs error it THROWS (the CLI exits non-zero with
+// no stdout) - never a silent flat-dir fallback (which would defeat SPEC-1 S1-S3/S6).
+function resolvePromptDir({ ledgerRoot, slug, isResume, token, mintToken } = {}) {
+  if (typeof ledgerRoot !== 'string' || ledgerRoot === '') {
+    throw new Error(`resolvePromptDir: ledgerRoot must be a non-empty string (got ${typeof ledgerRoot})`)
+  }
+  const safeSlug = typeof slug === 'string' && slug.trim() !== '' ? slug.trim() : 'run'
+  fs.mkdirSync(ledgerRoot, { recursive: true })
+  ensureLedgerGitignore(ledgerRoot)
+  const markerPath = path.join(ledgerRoot, '.session-current')
+  const markerLine = fs.existsSync(markerPath) ? fs.readFileSync(markerPath, 'utf8') : ''
+  const marker = parseMarker(markerLine)
+  const markerDirExists = marker.name !== '' && fs.existsSync(path.join(ledgerRoot, marker.name))
+  const liveToken = typeof token === 'string' ? token : ''
+  const { sameSession } = decideSession({ markerLine, markerDirExists, liveToken, isResume: isResume === true })
+
+  let sessionName
+  let effectiveToken
+  if (sameSession) {
+    sessionName = marker.name
+    effectiveToken = marker.token || liveToken
+  } else {
+    const existing = fs.readdirSync(ledgerRoot).filter(n => SESSION_NAME_RE.test(n))
+    sessionName = nextSessionName(existing)
+    fs.mkdirSync(path.join(ledgerRoot, sessionName), { recursive: true })
+    const mint = typeof mintToken === 'function' ? mintToken : () => `tok-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+    effectiveToken = liveToken || mint()
+  }
+  const tmp = `${markerPath}.tmp`
+  fs.writeFileSync(tmp, `${sessionName}  ${effectiveToken}`)
+  fs.renameSync(tmp, markerPath)
+
+  const sessionDir = path.join(ledgerRoot, sessionName)
+  const promptNames = fs.readdirSync(sessionDir).filter(n => PROMPT_NAME_RE.test(n))
+  const entries = promptNames.map(name => {
+    const full = path.join(sessionDir, name)
+    return {
+      name,
+      hasGatelog: fs.existsSync(path.join(full, 'GATELOG.md')),
+      hasArtifacts: fs.existsSync(path.join(full, 'artifacts')),
+      hasDone: fs.existsSync(path.join(full, 'DONE')),
+    }
+  })
+  const picked = pickPromptDir(entries, safeSlug)
+  const promptDir = path.join(sessionDir, picked.name)
+  if (!picked.reenter) fs.mkdirSync(promptDir, { recursive: true })
+  return promptDir
+}
+
+// deriveCompactState (PLAN-auto-compact-threshold): build the LIGHT proactive-miss signal from disk.
+// peakWatermark = the token field of the .context-watermark file; threshold = AUTOPROMPT_COMPACT_AT
+// env (default 200000); supervisorAttached when a RUN-ENDED marker exists. Fail-closed: any unreadable
+// input -> peakWatermark 0 -> the rule returns []. compactionOccurred is passed in (reuses the anchor
+// derivation, no double read).
+function deriveCompactState(ledgerDir, compactionOccurred) {
+  if (!ledgerDir) return undefined
+  const COMPACT_DEFAULT = 200000
+  const env = (typeof process === 'object' && process && process.env && process.env.AUTOPROMPT_COMPACT_AT) || ''
+  const parsedEnv = parseInt(env, 10)
+  const threshold = Number.isFinite(parsedEnv) && parsedEnv > 0 ? parsedEnv : COMPACT_DEFAULT
+  let peakWatermark = 0
+  const watermark = readIfExists(ledgerDir, '.context-watermark')
+  if (watermark != null) {
+    const m = /(\d+)/.exec(watermark)
+    if (m) { const n = parseInt(m[1], 10); if (Number.isFinite(n)) peakWatermark = n }
+  }
+  const supervisorAttached = readIfExists(ledgerDir, 'RUN-ENDED') != null
+  return { peakWatermark, threshold, compactionOccurred: compactionOccurred === true, supervisorAttached }
+}
+
+// collectLiveSignals (PLAN-liveness-reconcile): the THREE ground-truth signal sets that
+// can back a "running" claim - fresh non-terminated on-disk sub-*.jsonl ids, AGENTS.md
+// ids, and LIVE (non-sealed) FRONTIER ids+labels. All reads try/catch -> empty set on
+// failure (fail-closed: an absent signal never fabricates liveness).
+function collectLiveSignals(transcriptDir, artifactDir) {
+  const freshTranscriptIds = new Set()
+  const agentsMdIds = new Set()
+  const frontierIds = new Set()
+  const frontierLabels = new Set()
+  const addIds = (text, set) => { for (const m of String(text).matchAll(AGENT_ID_RE)) set.add(m[1].toLowerCase()) }
+  if (transcriptDir) {
+    let entries = []
+    try { entries = fs.readdirSync(transcriptDir) } catch (e) { entries = [] }
+    for (const name of entries) {
+      if (!/^sub-.*\.jsonl$/.test(name)) continue
+      const full = path.join(transcriptDir, name)
+      try {
+        const stat = fs.statSync(full)
+        if (Date.now() - stat.mtimeMs > LIVENESS_FRESH_WINDOW_MS) continue
+        const text = fs.readFileSync(full, 'utf8')
+        if (TRANSCRIPT_DONE_RE.test(text.slice(-2000))) continue
+        const m = name.match(/sub-([a-z0-9-]+)/i)
+        if (m) freshTranscriptIds.add(m[1].toLowerCase())
+        addIds(name, freshTranscriptIds)
+      } catch (e) { continue }
+    }
+  }
+  for (const dir of [transcriptDir, artifactDir]) {
+    if (!dir) continue
+    let entries = []
+    try { entries = fs.readdirSync(dir) } catch (e) { entries = [] }
+    for (const name of entries) {
+      if (/^AGENTS\.md$/i.test(name)) {
+        try { addIds(fs.readFileSync(path.join(dir, name), 'utf8'), agentsMdIds) } catch (e) { /* fail-closed */ }
+      }
+      if (/ANCHOR\.md$/i.test(name) || /frontier.*\.md$/i.test(name)) {
+        let text = ''
+        try { text = fs.readFileSync(path.join(dir, name), 'utf8') } catch (e) { continue }
+        for (const line of text.split('\n')) {
+          if (!FRONTIER_LIVE_RE.test(line) || FRONTIER_DEAD_RE.test(line)) continue
+          addIds(line, frontierIds)
+          for (const m of line.matchAll(FEATURE_LABEL_RE)) frontierLabels.add(m[1].toUpperCase())
+        }
+      }
+    }
+  }
+  return { freshTranscriptIds, agentsMdIds, frontierIds, frontierLabels }
+}
+
+// Scan a transcript dir of sub-*.jsonl files into the {path, feature, persona,
+// isConductor, ...flags} shape the F5-18 rule + the five FX-HIERARCHY rules read.
+// Absent dir -> [] (the rules then yield nothing - a non-benchmark run is never
+// false-FAILed). The feature id + persona are best-effort parsed from the filename
+// (the run names transcripts sub-<persona>-NN.jsonl); a persona-less name yields
+// persona '' (fail-closed - a rule keyed on a specific persona never fires) and a
+// 00-conductor* filename (or a cl-conductor persona) marks the conductor turn.
+function scanTranscriptDir(transcriptDir) {
+  if (!transcriptDir) return []
+  let entries
+  try { entries = fs.readdirSync(transcriptDir) } catch (e) { return [] }
+  const transcripts = []
+  for (const name of entries) {
+    if (!/\.jsonl$/.test(name)) continue
+    let text
+    try { text = fs.readFileSync(path.join(transcriptDir, name), 'utf8') } catch (e) { continue }
+    const scan = scanTranscript(text)
+    // FID matcher derives from the SAME FID_RE_SRC as FEATURE_DECL_RE (Change 3): the
+    // no-embedded-hyphen NAME body makes `sub-ap-manager-F-QUAL-01.jsonl` extract `F-QUAL`
+    // (NOT `F-QUAL-01`) - \b anchors and a persona token cannot match (no leading F/SPEC-).
+    const featureMatch = name.match(new RegExp(`\\b(${FID_RE_SRC})\\b`))
+    const personaMatch = name.match(/\b((?:ap|cl)-[a-z]+(?:-[a-z]+)*)\b/)
+    const persona = personaMatch ? personaMatch[1] : ''
+    const isConductor = persona === 'cl-conductor' || /(^|[\/\\])00-conductor/.test(name)
+    // SPEC-2: a conductor transcript is BILLIONAIRE when its filename carries the tag
+    // OR it actually spawned (totalSpawnCount >= 1). TOKENSAVER/unflagged -> false.
+    const isBillionaire = /billionaire|wide/i.test(name) || scan.totalSpawnCount >= 1
+    transcripts.push({
+      path: name,
+      feature: featureMatch ? featureMatch[1] : '',
+      persona,
+      isConductor,
+      hasProductionEditOrWrite: scan.hasProductionEditOrWrite,
+      hasVerifyOrGoalCheckPytest: scan.hasVerifyOrGoalCheckPytest,
+      hasBashEditWrite: scan.hasBashEditWrite,
+      hasWriteEditBashWebTool: scan.hasWriteEditBashWebTool,
+      hasNonAgentToolUse: scan.hasNonAgentToolUse,
+      wroteDoneSentinel: scan.wroteDoneSentinel,
+      wroteGoalCheck: scan.wroteGoalCheck,
+      spawnedTypes: scan.spawnedTypes,
+      editsProductionFile: scan.hasProductionEditOrWrite,
+      hasUserInterrupt: scan.hasUserInterrupt,
+      wroteAnchor: scan.wroteAnchor,
+      maxBatchedSpawns: scan.maxBatchedSpawns,
+      hadFoldOrDispatchAfterWave: scan.hadFoldOrDispatchAfterWave,
+      totalSpawnCount: scan.totalSpawnCount,
+      maxFeatureSupervisorWave: scan.maxFeatureSupervisorWave,
+      isBillionaire,
+      hasGitAddAll: scan.hasGitAddAll,
+      hasGitCommit: scan.hasGitCommit,
+      spawnedDescriptions: scan.spawnedDescriptions,
+      hasLeanAsIdleNarration: scan.hasLeanAsIdleNarration,
+      dispatchedAnyTrack: scan.dispatchedAnyTrack,
+      maxToolResultChars: scan.maxToolResultChars,
+      hasOversizedReport: scan.hasOversizedReport,
+      fleetTableTurns: scan.fleetTableTurns,
+      livenessTurns: scan.livenessTurns,
+      gateSpawnTurns: scan.gateSpawnTurns,
+      deadConclusionTurns: scan.deadConclusionTurns,
+      respawnTargets: scan.respawnTargets,
+      readsProductionFiles: scan.readsProductionFiles,
+      firstUserTurnText: scan.firstUserTurnText,
+      userTurnTexts: scan.userTurnTexts,
+      firstToolUseName: scan.firstToolUseName,
+    })
+  }
+  return transcripts
+}
+
+// parseArgs: minimal --flag value parser for the three dir flags.
+function parseArgs(argv) {
+  const out = {}
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--ledger-dir') out.ledgerDir = argv[++i]
+    else if (a === '--artifact-dir') out.artifactDir = argv[++i]
+    else if (a === '--transcript-dir') out.transcriptDir = argv[++i]
+    else if (a === '--terminal') out.terminal = true
+    else if (a === '--run-nonce') out.runNonce = argv[++i]
+    else if (a === '--resolve-prompt-dir') out.resolvePromptDir = true
+    else if (a === '--slug') out.slug = argv[++i]
+    else if (a === '--resume') out.resume = true
+    else if (a === '--verify-deployed') { out.verifyDeployed = true; out.deployInstalledDir = argv[++i]; out.deploySourceDir = argv[++i] }
+  }
+  return out
+}
+
+module.exports = {
+  parseLedgerLines,
+  parseRoadmapItems,
+  roadmapClosureFindings,
+  mixedLedgerFormatFindings,
+  reconcileProvenance,
+  selfReviewSignatureFindings,
+  managerExecFindings,
+  conductorToolUseFindings,
+  l1ChildrenFindings,
+  goalCheckJanitorFindings,
+  preflightEditFindings,
+  selfBlockYieldFindings,
+  anchorIntegrityFindings,
+  normalizeFrontier,
+  waveBarrierFindings,
+  isWaveBarrier,
+  parseModeFromBrief,
+  parseSerializationEnforcement,
+  commitCheckpointFindings,
+  parseGoalCheckRows,
+  parseCommitRows,
+  thinSprawlFindings,
+  conductorSpawnAllowlistFindings,
+  L0_LEGAL_SPAWN_TYPES,
+  leanIdleFindings,
+  artifactSubstanceFindings,
+  artifactSubstantiationReasons,
+  countSubstantiveCaptures,
+  parentFleetSynthesisFindings,
+  toolResults,
+  VERDICT_BUDGET_CHARS,
+  FLEET_TABLE_TURN_MIN,
+  FLEET_ROW_RE,
+  DIFF_RE,
+  midRunCancelCheckpointFindings,
+  deriveSteerCancels,
+  proportionalGatesFindings,
+  deriveFeatureTargets,
+  PROPORTIONAL_SIBLING_FLOOR,
+  livenessReconcileFindings,
+  isLivenessGap,
+  falseNegativeLivenessFindings,
+  isFalseNegativeLivenessGap,
+  toolResultForUse,
+  serialGateFindings,
+  serialFeatureFindings,
+  serialDispatchFindings,
+  SERIAL_DISPATCH_FLOOR,
+  spawnSplitFindings,
+  briefSplitReasons,
+  verifyDeployedMatchesSource,
+  listDeployKeyFiles,
+  hashContent,
+  managerWorkerStarvationFindings,
+  splittableConcreteParts,
+  L3_EXECUTORS,
+  FID_RE_SRC,
+  deriveFeatureDecomposition,
+  deriveFeatureDispatches,
+  disjointOwns,
+  SERIAL_FEATURE_FLOOR,
+  DISPATCH_RE,
+  supervisorWaveCountFindings,
+  SUPERVISOR_WAVE_FLOOR,
+  compactThresholdFindings,
+  frameworkFallthroughFindings,
+  tierProportionalityFindings,
+  deriveFeatureMeta,
+  deriveCeremonyRows,
+  evidencePackFindings,
+  frameworkTierFindings,
+  depthLockFindings,
+  DEPTHLOCK_D3_RE,
+  DEPTHLOCK_FIXLAYER_RE,
+  DEPTHLOCK_D4_RED_RE,
+  assistantText,
+  leafTierConsistent,
+  rowHasSubstantiveEvidence,
+  parseJsonObject,
+  resolveLaunchBinding,
+  ensureLedgerGitignore,
+  collectLiveSignals,
+  countOpenInFlightTracks,
+  anyArbiterDeferral,
+  detectCompaction,
+  detectDoneSentinel,
+  idleFinishFindings,
+  parseAnchorFrontier,
+  deriveGatelogFrontier,
+  scanTranscript,
+  scanTranscriptDir,
+  isProductionPath,
+  nextSessionName,
+  nextPromptName,
+  parseMarker,
+  decideSession,
+  pickPromptDir,
+  resolvePromptDir,
+  RULE_REGISTRY,
+  runLedgerCheck,
+  parseArgs,
+  resolvePromptDirCli,
+  verifyDeployedCli,
+  ledgerCheckCli,
+  runCli,
+  writeCliOutput,
+  GATE_EXPECTED_PERSONA,
+  REAL_RUNNER_RE,
+  L1_PERSONAS,
+  firstUserText,
+  allUserTexts,
+  parsePromptsTxt,
+  missionFidelityFindings,
+  missionSourceOfTruthFindings,
+  selfWrittenCaptureFindings,
+  openFlawFindings,
+  startupHandshakeFindings,
+  parseUnattendedFromBrief,
+  parseE2EAxis,
+  parseOpenBlockers,
+  collectGoalCheckArtifacts,
+  MISSION_BLOCK_LABEL,
+  MISSION_POINTER_LABEL,
+  PRIOR_STEERS_BLOCK_LABEL,
+}
+
+function resolvePromptDirCli(opts, environment = process.env) {
+  try {
+    const promptDir = resolvePromptDir({
+      ledgerRoot: opts.ledgerDir,
+      slug: opts.slug,
+      isResume: opts.resume === true,
+      token: environment.AUTOPROMPT_SESSION_TOKEN || '',
+    })
+    return { exitCode: 0, stdout: `${promptDir}\n`, stderr: '' }
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error)
+    return { exitCode: 1, stdout: '', stderr: `RESOLVE-PROMPT-DIR FAILED: ${message}\n` }
+  }
+}
+
+function verifyDeployedCli(opts) {
+  if (!opts.deployInstalledDir || !opts.deploySourceDir) {
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'VERIFY-DEPLOYED FAILED: usage is --verify-deployed <installedDir> <sourceDir> (both required)\n',
+    }
+  }
+  const { ok, checked, mismatched, missingInDeployed, missingInSource } =
+    verifyDeployedMatchesSource({
+      installedDir: opts.deployInstalledDir,
+      sourceDir: opts.deploySourceDir,
+    })
+  if (ok) {
+    return {
+      exitCode: 0,
+      stdout: `DEPLOYED==SOURCE OK: ${checked} key file(s) byte-identical (${opts.deployInstalledDir} == ${opts.deploySourceDir}).\n`,
+      stderr: '',
+    }
+  }
+  const stale = [
+    ...mismatched.map(file => `DIFFERS ${file}`),
+    ...missingInDeployed.map(file => `MISSING-IN-DEPLOYED ${file}`),
+    ...missingInSource.map(file => `MISSING-IN-SOURCE ${file}`),
+  ]
+  return {
+    exitCode: 1,
+    stdout: '',
+    stderr:
+      `DEPLOYED!=SOURCE MISMATCH: ${stale.length} of ${checked} key file(s) stale - ` +
+      'the installed skill does NOT match source. Re-deploy before shipping (F-11):\n' +
+      stale.map(line => `  ${line}`).join('\n') + '\n',
+  }
+}
+
+function ledgerCheckCli(opts) {
+  const { ok, findings, info } = runLedgerCheck(opts)
+  const stdout = [
+    ...info.map(note => `INFO: ${note}`),
+    ...findings.map(finding => `${finding.severity} [${finding.rule}] ${finding.title}`),
+  ]
+  if (ok) {
+    stdout.push('LEDGER-CHECK PASSED: every claimed gate is backed by a distinct spawn + artifact; no self-review signature.')
+    return { exitCode: 0, stdout: `${stdout.join('\n')}\n`, stderr: '' }
+  }
+  return {
+    exitCode: 1,
+    stdout: `${stdout.join('\n')}\n`,
+    stderr: `LEDGER-CHECK FAILED: ${findings.filter(finding => finding.severity === 'P0').length} P0 provenance finding(s).\n`,
+  }
+}
+
+function runCli(argv, environment = process.env) {
+  const opts = parseArgs(argv)
+  if (opts.resolvePromptDir === true) return resolvePromptDirCli(opts, environment)
+  if (opts.verifyDeployed === true) return verifyDeployedCli(opts)
+  return ledgerCheckCli(opts)
+}
+
+function writeCliOutput(output) {
+  process.stdout.write(output.stdout)
+  process.stderr.write(output.stderr)
+  process.exitCode = output.exitCode
+}
+
+if (require.main === module) {
+  writeCliOutput(runCli(process.argv.slice(2)))
+}

--- a/agents/omp/workflow/model-casting.js
+++ b/agents/omp/workflow/model-casting.js
@@ -1,0 +1,523 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+// omp (oh-my-pi) model casting. Contributes the resolved per-tier model
+// selectors for a run; the supervisor hands the serialized result to the child
+// session via AUTOPROMPT_CASTING, and the conductor applies it as run-scoped
+// task.agentModelOverrides project settings. With agents=off no selectors are
+// emitted and every worker inherits the parent's active model.
+
+const TIER_BY_ALIAS = Object.freeze({
+  R1: 'R1',
+  R2: 'R2',
+  R3: 'R3',
+  R4: 'R4',
+  R5: 'R5',
+})
+
+const TIER_ROLES = Object.freeze({
+  R1: 'coordinator',
+  R2: 'planning',
+  R3: 'implementation',
+  R4: 'review',
+  R5: 'mechanical',
+})
+
+const EFFORT_BY_TIER = Object.freeze({
+  R1: 'xhigh',
+  R2: 'xhigh',
+  R3: 'high',
+  R4: 'medium',
+  R5: 'low',
+})
+
+const MAXIMUM_EFFORT_PERSONAS = new Set([
+  'ap-scope-coordinator',
+  'ap-manager',
+  'ap-reviewer',
+  'ap-fresh-verifier',
+  'ap-verifier',
+  'ap-juror',
+  'ap-goal-checker',
+  'ap-depth-prober',
+  'ap-arbiter',
+  'ap-framework-validator',
+  'ap-re-anchor',
+  'ap-planner',
+  'ap-researcher',
+  'ap-scoper',
+  'ap-synthesizer',
+])
+
+const EFFORT_STATUSES = new Set([
+  'selectable',
+  'inherited-only',
+  'unsupported',
+  'unknown',
+])
+
+const UNKNOWN_EFFORT = Object.freeze({
+  status: 'unknown',
+  acceptedValues: [],
+  maximum: null,
+  source: 'unverified-provider-capability',
+})
+
+const INHERITED_EFFORT = Object.freeze({
+  status: 'inherited-only',
+  acceptedValues: [],
+  maximum: null,
+  source: 'session-inheritance',
+})
+
+const PERSONAS_BY_TIER = Object.freeze({
+  R1: [
+    'ap-scope-coordinator',
+    'ap-feature-coordinator',
+    'ap-sweep-coordinator',
+  ],
+  R2: [
+    'ap-manager',
+    'ap-scoper',
+    'ap-synthesizer',
+    'ap-planner',
+    'ap-execharness-resolver',
+    'ap-framework-generator',
+  ],
+  R3: [
+    'ap-implementer',
+    'ap-researcher',
+    'ap-intake',
+    'ap-preflight-probe',
+  ],
+  R4: [
+    'ap-reviewer',
+    'ap-verifier',
+    'ap-sweeper',
+    'ap-fresh-verifier',
+    'ap-framework-validator',
+    'ap-juror',
+  ],
+  R5: [
+    'ap-goal-checker',
+    'ap-arbiter',
+    'ap-re-anchor',
+    'ap-scribe',
+    'ap-janitor',
+    'ap-depth-prober',
+  ],
+})
+
+const EFFORT_WEIGHT = Object.freeze({ max: 0, high: 1, medium: 2, low: 3 })
+const REGISTRY_FIELDS = new Set(['name', 'provider', 'modelString', 'baseUrl', 'apiKeyEnv', 'effortHint'])
+const ENVIRONMENT_VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+function parseAgentsSelector(value) {
+  if (value == null || value === '') return { mode: 'off' }
+  if (value === 'off') return { mode: 'off' }
+  if (value === 'auto' || value.startsWith('auto:')) {
+    const models = value === 'auto' ? [] : value.slice(5).split(',').map((model) => model.trim()).filter(Boolean)
+    return { mode: 'auto-list', models }
+  }
+  const models = value.split(',').map((model) => model.trim()).filter(Boolean)
+  if (models.length === 0) return { mode: 'off' }
+  return { mode: 'list', models }
+}
+
+function parseModelList(value) {
+  if (value == null || value === '') return []
+  return value.split(',').map((model) => model.trim()).filter(Boolean)
+}
+
+function rankRegistry(registry) {
+  return registry
+    .map((entry, index) => ({ entry, index }))
+    .sort((left, right) => {
+      const leftWeight = EFFORT_WEIGHT[left.entry.effortHint] ?? EFFORT_WEIGHT.medium
+      const rightWeight = EFFORT_WEIGHT[right.entry.effortHint] ?? EFFORT_WEIGHT.medium
+      return leftWeight - rightWeight || left.index - right.index
+    })
+    .map(({ entry }) => entry)
+}
+
+// Map one to five model selectors onto the R1..R5 tiers. One selector fills
+// every tier (all workers use it); more selectors map strongest->R1 down to
+// weakest->R5. omp has no fixed alias pool, so selectors are used verbatim as
+// task.agentModelOverrides / modelRoles values.
+function mapModelsToTierSelectors(models) {
+  if (!Array.isArray(models) || models.length === 0) {
+    throw new Error('omp model casting requires at least one model')
+  }
+  if (models.length > 5) {
+    throw new Error('omp supports at most five tier selectors (R1..R5)')
+  }
+  if (new Set(models).size !== models.length) {
+    throw new Error('omp model casting requires unique provider model strings')
+  }
+
+  const tiers = Object.keys(TIER_BY_ALIAS)
+  const selectors = {}
+  for (let index = 0; index < tiers.length; index += 1) {
+    selectors[tiers[index]] = models[Math.min(index, models.length - 1)]
+  }
+  return selectors
+}
+
+function resolveOmpCasting(options = {}) {
+  const parsed = parseAgentsSelector(options.selector)
+  if (parsed.mode === 'off') return disabledCasting()
+
+  const providerCapability = options.providerCapabilityPath
+    ? readProviderCapability(options.providerCapabilityPath)
+    : options.providerCapability
+  const registryPath = resolveRegistryPath(options.registryPath, parsed.mode)
+  const registry = registryPath ? readRegistry(registryPath) : null
+  const selected = selectRegistryEntries(parsed, registry)
+  const ordered = parsed.mode === 'auto' || parsed.mode === 'auto-list'
+    ? rankRegistry(selected)
+    : selected
+  const names = ordered.map((entry) => entry.name)
+  const models = ordered.map((entry) => entry.modelString)
+
+  return {
+    enabled: true,
+    mode: parsed.mode,
+    names,
+    models,
+    selectors: mapModelsToTierSelectors(models),
+    tierRoles: { ...TIER_ROLES },
+    endpoint: resolveEndpoint(ordered),
+    effort: resolveProviderEffort(
+      providerCapability,
+      models,
+    ),
+  }
+}
+
+function readProviderCapability(configuredPath) {
+  const capabilityPath = expandHome(configuredPath)
+  let providerCapability
+
+  try {
+    providerCapability = JSON.parse(
+      fs.readFileSync(capabilityPath, 'utf8'),
+    )
+  } catch (error) {
+    throw new Error(
+      `Provider capability is not valid JSON: ` +
+      `${capabilityPath}: ${error.message}`,
+    )
+  }
+
+  return providerCapability
+}
+
+function resolveProviderEffort(providerCapability, models) {
+  if (providerCapability == null) return { ...INHERITED_EFFORT }
+  return validateProviderCapability(providerCapability, models)
+}
+
+function validateProviderCapability(providerCapability, models) {
+  if (typeof providerCapability !== 'object' || Array.isArray(providerCapability)) {
+    throw new Error('Provider capability must be an object')
+  }
+  const { effort, models: capabilityModels } = providerCapability
+  const validated = validateEffortCapability(effort)
+  if (models != null && capabilityModels != null) {
+    if (!Array.isArray(capabilityModels)) {
+      throw new Error('Provider capability models must be an array')
+    }
+    if (!sameStringArray(models, capabilityModels)) {
+      throw new Error('Provider capability models do not match the selected models')
+    }
+  }
+  return validated
+}
+
+function validateEffortCapability(effort) {
+  if (effort == null) return { ...INHERITED_EFFORT }
+  if (typeof effort !== 'object' || Array.isArray(effort)) {
+    throw new Error('Effort capability must be an object')
+  }
+  if (effort.status === 'inherited-only') return { ...INHERITED_EFFORT }
+  if (effort.status === 'unsupported') {
+    return { status: 'unsupported', acceptedValues: [], maximum: null, source: 'provider-capability' }
+  }
+  if (effort.status === 'unknown') return { ...UNKNOWN_EFFORT }
+  if (effort.status !== 'selectable') {
+    throw new Error(`Effort capability status must be selectable, inherited-only, unsupported, or unknown: ${effort.status}`)
+  }
+  const acceptedValues = [...(effort.acceptedValues ?? [])]
+  acceptedValues.forEach((value) => {
+    if (EFFORT_WEIGHT[value] == null) {
+      throw new Error(`Effort capability accepted value is not a valid effort: ${value}`)
+    }
+  })
+  const maximum = effort.maximum
+  if (EFFORT_WEIGHT[maximum] == null) {
+    throw new Error(`Effort capability maximum is not a valid effort: ${maximum}`)
+  }
+  return {
+    status: 'selectable',
+    acceptedValues,
+    maximum,
+    source: 'provider-capability',
+  }
+}
+
+function sameStringArray(actual, expected) {
+  if (actual.length !== expected.length) return false
+  for (let index = 0; index < actual.length; index += 1) {
+    if (actual[index] !== expected[index]) return false
+  }
+  return true
+}
+
+function copyEffort(effort) {
+  return { ...effort }
+}
+
+function disabledCasting() {
+  return {
+    enabled: false,
+    mode: 'off',
+    names: [],
+    models: [],
+    selectors: {},
+    tierRoles: {},
+    endpoint: {},
+    effort: { ...INHERITED_EFFORT },
+  }
+}
+
+// Default registry lives next to the omp agent config dir so the supervisor can
+// resolve `auto` without extra flags. PI_CODING_AGENT_DIR relocates that base.
+function ompAgentDir() {
+  const override = process.env.PI_CODING_AGENT_DIR || process.env.OMP_CODING_AGENT_DIR
+  if (override) return path.resolve(override)
+  return path.join(os.homedir(), '.omp', 'agent')
+}
+
+function resolveRegistryPath(configuredPath, mode) {
+  if (configuredPath) return expandHome(configuredPath)
+  if (mode !== 'auto' && mode !== 'auto-list') return null
+  return path.join(ompAgentDir(), 'autoprompt-models.json')
+}
+
+function expandHome(filePath) {
+  if (filePath === '~') return os.homedir()
+  if (filePath.startsWith('~/') || filePath.startsWith('~\\')) {
+    return path.join(os.homedir(), filePath.slice(2))
+  }
+  return path.resolve(filePath)
+}
+
+function readRegistry(registryPath) {
+  if (!fs.existsSync(registryPath)) {
+    throw new Error(`Autoprompt model registry file does not exist: ${registryPath}`)
+  }
+
+  let registry
+  try {
+    registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'))
+  } catch (error) {
+    throw new Error(`Autoprompt model registry is not valid JSON: ${registryPath}: ${error.message}`)
+  }
+  validateRegistry(registry)
+  return registry
+}
+
+function validateRegistry(registry) {
+  if (!Array.isArray(registry) || registry.length === 0) {
+    throw new Error('Autoprompt model registry must be a non-empty JSON array')
+  }
+
+  const names = new Set()
+  registry.forEach((entry, index) => {
+    validateRegistryEntry(entry, index)
+    if (names.has(entry.name)) throw new Error(`Autoprompt model registry has duplicate registry name: ${entry.name}`)
+    names.add(entry.name)
+  })
+}
+
+function validateRegistryEntry(entry, index) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error(`Autoprompt model registry entry ${index} must be an object`)
+  }
+  for (const field of Object.keys(entry)) {
+    if (!REGISTRY_FIELDS.has(field)) throw new Error(`Autoprompt model registry entry ${index} has unknown field: ${field}`)
+  }
+  for (const field of ['name', 'provider', 'modelString']) {
+    if (typeof entry[field] !== 'string' || entry[field].trim() === '') {
+      throw new Error(`Autoprompt model registry entry ${index} ${field} must be a non-empty string`)
+    }
+  }
+  for (const field of ['baseUrl', 'apiKeyEnv', 'effortHint']) {
+    if (entry[field] != null && (typeof entry[field] !== 'string' || entry[field].trim() === '')) {
+      throw new Error(`Autoprompt model registry entry ${index} ${field} must be a non-empty string when provided`)
+    }
+  }
+  if (entry.baseUrl != null) validateBaseUrl(entry.baseUrl, index)
+  if (entry.apiKeyEnv != null && !ENVIRONMENT_VARIABLE_NAME.test(entry.apiKeyEnv)) {
+    throw new Error(`Autoprompt model registry entry ${index} apiKeyEnv must be an environment variable name`)
+  }
+  if (entry.effortHint != null && !Object.hasOwn(EFFORT_WEIGHT, entry.effortHint)) {
+    throw new Error(`Autoprompt model registry entry ${index} effortHint must be max, high, medium, or low`)
+  }
+}
+
+function validateBaseUrl(baseUrl, index) {
+  let parsed
+  try {
+    parsed = new URL(baseUrl)
+  } catch {
+    throw new Error(`Autoprompt model registry entry ${index} baseUrl must be an absolute HTTP URL`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Autoprompt model registry entry ${index} baseUrl must be an absolute HTTP URL`)
+  }
+}
+
+function selectRegistryEntries(parsed, registry) {
+  if (!registry) {
+    return parsed.models.map((model) => ({ name: model, provider: 'inherited', modelString: model }))
+  }
+  if (parsed.mode === 'auto' || parsed.mode === 'auto-list') {
+    if (parsed.models.length === 0) return [...registry]
+    const byName = new Map(registry.map((entry) => [entry.name, entry]))
+    return parsed.models.map((name) => {
+      const entry = byName.get(name)
+      if (!entry) throw new Error(`Model ${name} is not present in the registry`)
+      return entry
+    })
+  }
+
+  const byName = new Map(registry.map((entry) => [entry.name, entry]))
+  return parsed.models.map((name) => {
+    const entry = byName.get(name)
+    if (!entry) throw new Error(`Model ${name} is not present in the registry`)
+    return entry
+  })
+}
+
+function resolveEndpoint(entries) {
+  const baseUrls = new Set(entries.map((entry) => entry.baseUrl ?? null))
+  const apiKeyEnvironments = new Set(entries.map((entry) => entry.apiKeyEnv ?? null))
+  if (baseUrls.size > 1 || apiKeyEnvironments.size > 1) {
+    throw new Error('omp custom models must form one endpoint-compatible pool with one credential source')
+  }
+
+  const endpoint = {}
+  const [baseUrl] = baseUrls
+  const [apiKeyEnv] = apiKeyEnvironments
+  if (baseUrl) endpoint.baseUrl = baseUrl
+  if (apiKeyEnv) endpoint.apiKeyEnv = apiKeyEnv
+  return endpoint
+}
+
+function resolvePersonaCasting(persona, casting) {
+  if (!casting || !casting.enabled) return null
+  const tier = Object.keys(PERSONAS_BY_TIER)
+    .find(candidate => PERSONAS_BY_TIER[candidate].includes(persona))
+  if (!tier) {
+    throw new Error(`Persona ${persona} has no model-casting tier`)
+  }
+
+  const resolved = { tier, model: casting.selectors[tier] ?? null }
+  if (casting.effort.status !== 'selectable') return resolved
+
+  const requestedEffort = MAXIMUM_EFFORT_PERSONAS.has(persona)
+    ? casting.effort.maximum
+    : EFFORT_BY_TIER[tier]
+  resolved.effort = resolveAcceptedEffort(
+    requestedEffort,
+    casting.effort,
+  )
+  return resolved
+}
+
+function resolveAcceptedEffort(requestedEffort, capability) {
+  if (capability.acceptedValues.includes(requestedEffort)) {
+    return requestedEffort
+  }
+  return capability.acceptedValues.reduce((closest, candidate) => {
+    const closestDistance = Math.abs(
+      effortRank(closest) - effortRank(requestedEffort),
+    )
+    const candidateDistance = Math.abs(
+      effortRank(candidate) - effortRank(requestedEffort),
+    )
+    return candidateDistance < closestDistance
+      ? candidate
+      : closest
+  }, capability.maximum)
+}
+
+function effortRank(effort) {
+  return ['low', 'medium', 'high', 'xhigh'].indexOf(effort)
+}
+
+function serializeLaunchCasting(casting) {
+  return JSON.stringify(casting)
+}
+
+function runCli(argv) {
+  const options = parseCliArguments(argv)
+  const casting = resolveOmpCasting(options)
+  process.stdout.write(`${serializeLaunchCasting(casting)}\n`)
+}
+
+function parseCliArguments(argv) {
+  const options = {}
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--selector') {
+      options.selector = requireCliValue(argv, ++index, argument)
+    } else if (argument === '--registry') {
+      options.registryPath = requireCliValue(argv, ++index, argument)
+    } else if (argument === '--provider-capability') {
+      options.providerCapabilityPath = requireCliValue(
+        argv,
+        ++index,
+        argument,
+      )
+    } else {
+      throw new Error(`Unknown model-casting argument: ${argument}`)
+    }
+  }
+  return options
+}
+
+function requireCliValue(argv, index, argument) {
+  const value = argv[index]
+  if (value == null || value === '') throw new Error(`${argument} requires a value`)
+  return value
+}
+
+if (require.main === module) {
+  try {
+    runCli(process.argv.slice(2))
+  } catch (error) {
+    process.stderr.write(`model-casting: ${error.message}\n`)
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  TIER_BY_ALIAS,
+  TIER_ROLES,
+  EFFORT_BY_TIER,
+  MAXIMUM_EFFORT_PERSONAS,
+  PERSONAS_BY_TIER,
+  mapModelsToTierSelectors,
+  parseAgentsSelector,
+  parseCliArguments,
+  rankRegistry,
+  resolveOmpCasting,
+  resolvePersonaCasting,
+  runCli,
+  serializeLaunchCasting,
+}

--- a/agents/omp/workflow/phase-budget.js
+++ b/agents/omp/workflow/phase-budget.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// F-SPEED (steer 2) B3 - PHASE WALL-CLOCK BUDGET verdict + CLI.
+//
+// Steer 2: "scope supervisor often takes 30min or more. come on this is like holy
+// over engineering ... it does work but its hella time consuming." IDLE_TIMEOUT
+// (supervisor.sh:74) only fires on frontier STALENESS; a scope phase that keeps
+// writing ROADMAP.md and retained roadmap-scout artifacts is advancing, so it resets the idle clock every
+// tick and is never bounded. This module is the pure decision the supervisor
+// heartbeat consults once per tick to bound the SCOPE phase by WALL-CLOCK, anchored
+// to scope-phase entry and NOT reset by frontier growth - the exact hole IDLE_TIMEOUT
+// leaves. It is require()-able (pure fn, unit-testable to 100% branches) AND a CLI so
+// the /bin/sh + PowerShell heartbeat can branch on a distinct exit code per action,
+// mirroring autoprompt-ledger-check.js (both require-able and a --resolver CLI).
+//
+// INVARIANT: the action token is NEVER 'fake'/'fabricate'; the residual is ALWAYS the
+// honest landed-angle list the caller passed (never invented). A budget breach seals
+// and surfaces the landed set for an honest converge - it never manufactures coverage.
+'use strict'
+
+const SCOPE_SOFT_SEC = 60     // ordinary bounded scope should converge within one minute
+const SCOPE_HARD_SEC = 300    // ordinary multi-surface scope has a five-minute ceiling
+const SCOPE_GRACE_SEC = 60    // one minute to honor a converge request
+const MAX_FORCED_RESETS = 1   // budget-forced scope resets before escalation
+
+// Coerce to a non-negative integer, or fall back to `fallback` on non-numeric/negative.
+// Mirrors the supervisor COMPACT_AT validation: an absurd value never disables the
+// guard and never becomes a zero-budget trap.
+function clampNonNegInt(value, fallback) {
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n) || n < 0) return fallback
+  return Math.floor(n)
+}
+
+// phaseBudgetVerdict(state) -> { verdict, action, residual, escalate }
+//   state: { phase, elapsedSec, softSec, hardSec, convergeRequestAgeSec, graceSec,
+//            priorForcedResets, maxForcedResets, landedAngles:[] }
+// Decision (in order):
+//   phase !== 'scope' OR elapsed < soft            -> ok       / continue
+//   soft <= elapsed < hard AND grace NOT elapsed   -> converge / request-converge
+//   elapsed >= hard OR convergeRequestAge >= grace  -> seal:
+//       priorForcedResets >= maxForcedResets ?  escalate  :  force-reset
+function phaseBudgetVerdict(state) {
+  const s = state || {}
+  const elapsed = clampNonNegInt(s.elapsedSec, 0)
+  const soft = clampNonNegInt(s.softSec, SCOPE_SOFT_SEC)
+  const hard = clampNonNegInt(s.hardSec, SCOPE_HARD_SEC)
+  const requestAge = clampNonNegInt(s.convergeRequestAgeSec, 0)
+  const grace = clampNonNegInt(s.graceSec, SCOPE_GRACE_SEC)
+  const priorResets = clampNonNegInt(s.priorForcedResets, 0)
+  const maxResets = clampNonNegInt(s.maxForcedResets, MAX_FORCED_RESETS)
+  const landed = Array.isArray(s.landedAngles) ? s.landedAngles.slice() : []
+
+  const ok = () => ({ verdict: 'ok', action: 'continue', residual: [], escalate: false })
+
+  if (s.phase !== 'scope' || elapsed < soft) return ok()
+
+  // Past soft. A hard breach OR an unhonored converge request past grace seals the phase.
+  const graceElapsed = requestAge >= grace
+  const hardBreach = elapsed >= hard
+  if (hardBreach || graceElapsed) {
+    if (priorResets >= maxResets) {
+      return { verdict: 'seal', action: 'escalate', residual: landed, escalate: true }
+    }
+    return { verdict: 'seal', action: 'force-reset', residual: landed, escalate: false }
+  }
+
+  // Soft breach, converge not yet unhonored-past-grace: request a converge, keep running.
+  return { verdict: 'converge', action: 'request-converge', residual: [], escalate: false }
+}
+
+// Exit codes let the shell branch WITHOUT parsing stdout; stdout still carries the
+// action token and (on seal) the honest residual list.
+const EXIT_CODE = {
+  'continue': 0,
+  'request-converge': 10,
+  'force-reset': 20,
+  'escalate': 30,
+}
+
+// Parse `--flag value` pairs from argv into a plain object keyed by flag name.
+function parseArgs(argv) {
+  const out = {}
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]
+    if (token.slice(0, 2) !== '--') continue
+    const key = token.slice(2)
+    const next = argv[i + 1]
+    if (next === undefined || next.slice(0, 2) === '--') { out[key] = true; continue }
+    out[key] = next
+    i++
+  }
+  return out
+}
+
+// CLI: node phase-budget.js --verdict --phase scope --elapsed E --soft S --hard H \
+//        --request-age R --grace G --prior-resets P --max-resets M --landed a,b
+function runCli(argv) {
+  const args = parseArgs(argv)
+  const landed = typeof args.landed === 'string' && args.landed.length > 0
+    ? args.landed.split(',').filter((a) => a.length > 0)
+    : []
+  const verdict = phaseBudgetVerdict({
+    phase: args.phase,
+    elapsedSec: args.elapsed,
+    softSec: args.soft,
+    hardSec: args.hard,
+    convergeRequestAgeSec: args['request-age'],
+    graceSec: args.grace,
+    priorForcedResets: args['prior-resets'],
+    maxForcedResets: args['max-resets'],
+    landedAngles: landed,
+  })
+  const residual = verdict.residual.join(',')
+  process.stdout.write(`${verdict.action} landed=${residual}\n`)
+  return EXIT_CODE[verdict.action]
+}
+
+if (require.main === module) {
+  const argv = process.argv.slice(2)
+  if (argv.includes('--verdict')) {
+    process.exit(runCli(argv.filter((a) => a !== '--verdict')))
+  }
+  process.stderr.write('usage: node phase-budget.js --verdict --phase scope --elapsed E ...\n')
+  process.exit(2)
+}
+
+module.exports = {
+  phaseBudgetVerdict,
+  clampNonNegInt,
+  SCOPE_SOFT_SEC,
+  SCOPE_HARD_SEC,
+  SCOPE_GRACE_SEC,
+  MAX_FORCED_RESETS,
+}

--- a/agents/omp/workflow/supervisor.ps1
+++ b/agents/omp/workflow/supervisor.ps1
@@ -1,0 +1,1574 @@
+<#
+.SYNOPSIS
+  autoprompt supervisor (Windows PowerShell 5.1 port of supervisor.sh) --
+  external auto-relaunch for a one-sitting unattended run.
+
+.DESCRIPTION
+  This is a STANDALONE OS PROCESS, NOT a Claude Code hook. It touches no
+  settings.json, registers no hook, and is launched by the operator. It honors
+  the global no-hooks rule.
+
+  It relaunches the autoprompt CLI with RESUME on any unexpected exit, loops
+  until the JANITOR has written the DONE-sentinel (autoprompt/DONE-<nonce>),
+  and has a crash-loop/poison-restart guard that distinguishes:
+    - a FINISHED run     (sentinel present)      -> clean halt (exit 0)
+    - a HEALTHY-LONG run (frontier advances)     -> keep relaunching, no escalation
+    - a TRULY-STUCK run  (no frontier progress)  -> escalate, stop relaunching (exit 1)
+
+  Behavior-faithful to agents/claude/workflow/supervisor.sh: identical sentinel glob
+  (autoprompt/DONE-*), identical "done": true check, identical env var names
+  (AUTOPROMPT_RESUME / AUTOPROMPT_UNATTENDED), identical --launcher selection,
+  identical backoff schedule and poison guard.
+
+.PARAMETER Launcher
+  apidemo | codexdemo (or any launcher command on PATH). Defaults to
+  $env:AUTOPROMPT_LAUNCHER. Exec'd as a bare command name.
+
+.PARAMETER Cmd
+  Verbatim launch command (e.g. "omp -p --auto-approve"),
+  word-split with the mission appended. Overrides -Launcher. Defaults to
+  $env:AUTOPROMPT_LAUNCH_CMD. A fresh user with no apidemo/codexdemo alias
+  uses --cmd with their real CLI.
+
+.PARAMETER Mission
+  The mission text passed through to the launch command.
+
+.EXAMPLE
+  powershell -File supervisor.ps1 --launcher apidemo "<mission>"
+
+.EXAMPLE
+  powershell -File supervisor.ps1 --cmd "omp -p --auto-approve" "<mission>"
+
+.EXAMPLE
+  powershell -File supervisor.ps1 --agents "auto:strong,cheap" --model-registry "$HOME\.omp\agent\autoprompt-models.json" --cmd "omp -p --auto-approve" "<mission>"
+
+.NOTES
+  Env (all optional), mirroring supervisor.sh:
+    AUTOPROMPT_LAUNCH_CMD  verbatim launch command (overrides --launcher)
+    AUTOPROMPT_LAUNCHER  default launcher label if --launcher is omitted
+    AUTOPROMPT_AGENTS     off | auto | <list> | auto:<list> (default off)
+    AUTOPROMPT_MODEL_REGISTRY  optional registry path; defaults to ~/.omp/agent/autoprompt-models.json for auto modes
+    LEDGER_DIR            default "autoprompt"
+    SENTINEL              explicit sentinel glob (default <LEDGER_DIR>/DONE-*).
+                          Passed to Get-ChildItem -Path as ONE pattern (no word-
+                          split), so a single dir-wildcard like 'autoprompt/*/DONE-*'
+                          works but a space-separated MULTI-pattern (a .sh-only escape
+                          hatch) does not -- use one wildcard on PowerShell. When UNSET
+                          (the default -- every real run) the glob is <LEDGER_DIR>/DONE-*
+                          as one quoted path, so a LEDGER_DIR containing spaces (a
+                          Windows path) still matches its own DONE-* sentinel.
+    MAX_RESTARTS          rapid restarts allowed in WINDOW without progress (default 5)
+    WINDOW               rolling window seconds for the poison guard (default 600)
+    RETRY_BASE           base backoff seconds between relaunches (default 5; 0 in tests)
+    RETRY_CAP            max backoff seconds (default 300)
+    AUTOPROMPT_AGENT_CASTING    when casting is enabled, the serialized casting
+                          JSON (selectors + effort) is exported to the child
+                          session; the conductor applies it as run-scoped
+                          task.agentModelOverrides project settings. With
+                          agents=off no casting is exported and every worker
+                          inherits the parent's active model.
+    AUTOPROMPT_MODE      tokensaver | wide | billionaire | custom (default tokensaver).
+                          WIDE and BILLIONAIRE share wide semantics. CUSTOM requires a
+                          positive numeric AUTOPROMPT_MAX_CONCURRENT value, floors it
+                          to a whole-agent ceiling, and passes both values through.
+
+  The 5-level topology (L0 conductor -> L1 coordinators -> L2 managers -> L3
+  executors -> L4 leaves) lives in the harness; rule 68 (L1 never executes) and
+  rule 67 (single-block spawns) are enforced there. This OS-level supervisor only
+  relaunches the L0 entry process and passes the mode through; it spawns no agents.
+  Test hooks (only honored with --dry-run):
+    FAKE_EXITS           space-separated exit codes the fake launcher returns in turn
+    FAKE_SENTINEL_AFTER  write the sentinel before the launch with this 1-based index
+    FAKE_POISON          1 => fake never advances the frontier and always exits non-zero
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-EnvOrDefault {
+    param([string]$Name, $Default)
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrEmpty($value)) { return $Default }
+    return $value
+}
+
+function Get-RequiredArgumentValue {
+    param([string]$Flag, [int]$Index, [string[]]$Arguments)
+    if ($Index -lt $Arguments.Count) { return $Arguments[$Index] }
+    [Console]::Error.WriteLine("supervisor: $Flag requires a value")
+    return $null
+}
+
+function ConvertTo-NativeArgument {
+    param([AllowEmptyString()][string]$Value)
+
+    if ($Value.Length -gt 0 -and $Value -notmatch '[\s"]') { return $Value }
+
+    $builder = New-Object Text.StringBuilder
+    $backslash = [char]92
+    $quote = [char]34
+    $backslashCount = 0
+    [void]$builder.Append($quote)
+    foreach ($character in $Value.ToCharArray()) {
+        if ($character -eq $backslash) {
+            $backslashCount += 1
+            continue
+        }
+        if ($character -eq $quote) {
+            for ($index = 0; $index -lt (($backslashCount * 2) + 1); $index += 1) {
+                [void]$builder.Append($backslash)
+            }
+            [void]$builder.Append($quote)
+            $backslashCount = 0
+            continue
+        }
+        for ($index = 0; $index -lt $backslashCount; $index += 1) {
+            [void]$builder.Append($backslash)
+        }
+        $backslashCount = 0
+        [void]$builder.Append($character)
+    }
+    for ($index = 0; $index -lt ($backslashCount * 2); $index += 1) {
+        [void]$builder.Append($backslash)
+    }
+    [void]$builder.Append($quote)
+    return $builder.ToString()
+}
+
+function Join-NativeArguments {
+    param([string[]]$Arguments)
+    return (($Arguments | ForEach-Object { ConvertTo-NativeArgument -Value $_ }) -join ' ')
+}
+
+function Get-AgentDefinitionsHash {
+    param([string]$ModelCastingPath, [string]$AgentsDirectory)
+
+    if (-not (Test-Path -LiteralPath $ModelCastingPath -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $AgentsDirectory -PathType Container)) {
+        return 'unknown'
+    }
+
+    $files = @($ModelCastingPath) + @(
+        Get-ChildItem -LiteralPath $AgentsDirectory -File -Filter 'ap-*.md' |
+            Sort-Object Name |
+            ForEach-Object { $_.FullName }
+    )
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        foreach ($file in $files) {
+            $label = [IO.Path]::GetFileName($file)
+            $labelBytes = [Text.Encoding]::UTF8.GetBytes($label)
+            $lengthBytes = [Text.Encoding]::UTF8.GetBytes(([string]$labelBytes.Length) + ':')
+            $null = $sha.TransformBlock($lengthBytes, 0, $lengthBytes.Length, $lengthBytes, 0)
+            $null = $sha.TransformBlock($labelBytes, 0, $labelBytes.Length, $labelBytes, 0)
+            $content = [IO.File]::ReadAllBytes($file)
+            $contentLength = [Text.Encoding]::UTF8.GetBytes(([string]$content.Length) + ':')
+            $null = $sha.TransformBlock($contentLength, 0, $contentLength.Length, $contentLength, 0)
+            $null = $sha.TransformBlock($content, 0, $content.Length, $content, 0)
+        }
+        $null = $sha.TransformFinalBlock([byte[]]@(), 0, 0)
+        return 'sha256:' + ([BitConverter]::ToString($sha.Hash) -replace '-', '').ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+}
+
+function Invoke-Supervisor {
+    param([string[]]$Argv)
+
+    function Test-CapabilityAttestation {
+        param([string]$Raw, [string[]]$Expected)
+
+        try {
+            $attestation = $Raw | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            return $false
+        }
+
+        $bindings = @(
+            'provider', 'cliVersion', 'permissionProfile', 'agentSelector',
+            'agentDefinitionsHash', 'castingHash', 'effortStatus', 'effortSource'
+        )
+        for ($index = 0; $index -lt $bindings.Count; $index += 1) {
+            $property = $attestation.PSObject.Properties[$bindings[$index]]
+            if ($null -eq $property -or
+                $property.Value -isnot [string] -or
+                $property.Value -cne $Expected[$index]) {
+                return $false
+            }
+        }
+
+        $schemaVersion = $attestation.PSObject.Properties['schemaVersion']
+        $proofKind = $attestation.PSObject.Properties['proofKind']
+        $proofHash = $attestation.PSObject.Properties['proofHash']
+        $proofBytes = $attestation.PSObject.Properties['proofBytes']
+        if ($null -eq $schemaVersion -or
+            $schemaVersion.Value -isnot [int] -or
+            $schemaVersion.Value -ne 4 -or
+            $null -eq $proofKind -or
+            $proofKind.Value -isnot [string] -or
+            $proofKind.Value -cne 'disposable-scratch' -or
+            $null -eq $proofHash -or
+            $proofHash.Value -isnot [string] -or
+            $proofHash.Value -cnotmatch '^sha256:[a-f0-9]{64}$') {
+            return $false
+        }
+        # The proof hash must recompute from the inspectable scratch bytes the
+        # attestation carries; a bare well-formed hash string proves nothing.
+        if ($null -eq $proofBytes -or
+            $proofBytes.Value -isnot [string] -or
+            $proofBytes.Value.Length -eq 0 -or
+            $proofBytes.Value.Length -gt 4096) {
+            return $false
+        }
+        $sha = [Security.Cryptography.SHA256]::Create()
+        try {
+            $recomputed = 'sha256:' + ([BitConverter]::ToString(
+                $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes($proofBytes.Value))
+            ) -replace '-', '').ToLowerInvariant()
+        } finally {
+            $sha.Dispose()
+        }
+        if ($recomputed -cne $proofHash.Value) {
+            return $false
+        }
+
+        foreach ($name in @('run', 'read', 'write')) {
+            $property = $attestation.PSObject.Properties[$name]
+            if ($null -eq $property -or
+                $property.Value -isnot [bool] -or
+                $property.Value -ne $true) {
+                return $false
+            }
+        }
+        return $true
+    }
+
+    $launcher   = Get-EnvOrDefault 'AUTOPROMPT_LAUNCHER' ''
+    $launchCmd  = Get-EnvOrDefault 'AUTOPROMPT_LAUNCH_CMD' ''
+    $agentsSelector = Get-EnvOrDefault 'AUTOPROMPT_AGENTS' 'off'
+    $modelRegistry = Get-EnvOrDefault 'AUTOPROMPT_MODEL_REGISTRY' ''
+    $providerCapability = Get-EnvOrDefault 'AUTOPROMPT_PROVIDER_CAPABILITY' ''
+    $ledgerDir  = Get-EnvOrDefault 'LEDGER_DIR' 'autoprompt'
+    $maxRestarts = [int](Get-EnvOrDefault 'MAX_RESTARTS' 5)
+    $window      = [int](Get-EnvOrDefault 'WINDOW' 600)
+    $retryBase   = [int](Get-EnvOrDefault 'RETRY_BASE' 5)
+    $retryCap    = [int](Get-EnvOrDefault 'RETRY_CAP' 300)
+    # P1 (PLAN-idle-watchdog) - heartbeat env defaults, IDENTICAL to supervisor.sh.
+    # IDLE_TIMEOUT defaults to 1800s (30 min) so a long-but-progressing build/test does
+    # NOT trip the heartbeat (the frontier count grows on ANY artifact write and resets
+    # the timer); operators with long atomic steps raise AUTOPROMPT_IDLE_TIMEOUT.
+    $idleTimeout = [int](Get-EnvOrDefault 'AUTOPROMPT_IDLE_TIMEOUT' 1800)
+    $heartbeatInterval = [int](Get-EnvOrDefault 'AUTOPROMPT_HEARTBEAT_INTERVAL' 60)
+    # PLAN-auto-compact-threshold: proactive, SUPERVISOR-FIRED compaction below the
+    # harness ~400k ceiling. IDENTICAL semantics + knobs to supervisor.sh. The supervisor
+    # observes the parent's context size from OUTSIDE (parent session transcript;
+    # watermark/ledger-byte fallbacks) and, on crossing $compactAt, writes COMPACT-REQUEST,
+    # then on grace timeout fires the kill->RESUME (the parent cannot /compact itself).
+    $compactAt = Get-EnvOrDefault 'AUTOPROMPT_COMPACT_AT' '200000'
+    $parsedCompactAt = 0
+    if (-not [int]::TryParse([string]$compactAt, [ref]$parsedCompactAt) -or $parsedCompactAt -le 0 -or $parsedCompactAt -ge 10000000) {
+        $parsedCompactAt = 200000   # absurd/non-numeric -> default (never disables the guard, never fires every tick)
+    }
+    $compactAt = $parsedCompactAt
+    $bytesPerToken = [int](Get-EnvOrDefault 'AUTOPROMPT_BYTES_PER_TOKEN' 4)
+    if ($bytesPerToken -le 0) { $bytesPerToken = 4 }
+    $compactCooldown = [int](Get-EnvOrDefault 'AUTOPROMPT_COMPACT_COOLDOWN' 120)
+    $compactGrace = [int](Get-EnvOrDefault 'AUTOPROMPT_COMPACT_GRACE' 180)
+    $externalCompactDelta = [int](Get-EnvOrDefault 'AUTOPROMPT_EXTERNAL_COMPACT_DELTA' 50000)
+    # Execution mode selects the 5-level topology's wave cap. Unknown modes retain
+    # the safe tokensaver fallback. CUSTOM is an explicit request for a caller-supplied
+    # ceiling, so a missing or invalid value fails closed.
+    $autopromptMode = Get-EnvOrDefault 'AUTOPROMPT_MODE' 'tokensaver'
+    switch -CaseSensitive ($autopromptMode) {
+        'tokensaver'  { $fanout = 'up to 6 live per wave'; $l3Tracks = 'parallel' }
+        'wide'        { $fanout = 'wide up to the runtime ceiling'; $l3Tracks = 'parallel' }
+        'billionaire' { $fanout = 'wide up to the runtime ceiling'; $l3Tracks = 'parallel' }
+        'custom'      {
+            $rawCustomMax = Get-EnvOrDefault 'AUTOPROMPT_MAX_CONCURRENT' ''
+            [double]$parsedCustomMax = 0
+            $validCustomMax = [double]::TryParse(
+                [string]$rawCustomMax,
+                [Globalization.NumberStyles]::Float,
+                [Globalization.CultureInfo]::InvariantCulture,
+                [ref]$parsedCustomMax
+            )
+            if (-not $validCustomMax -or [double]::IsNaN($parsedCustomMax) -or
+                [double]::IsInfinity($parsedCustomMax) -or $parsedCustomMax -lt 1) {
+                [Console]::Error.WriteLine('supervisor: custom mode requires a positive numeric AUTOPROMPT_MAX_CONCURRENT')
+                return 2
+            }
+            $customMax = [Math]::Floor($parsedCustomMax)
+            $env:AUTOPROMPT_MAX_CONCURRENT = [string]$customMax
+            $fanout = "up to $customMax live per wave (AUTOPROMPT_MAX_CONCURRENT)"
+            $l3Tracks = 'parallel'
+        }
+        default       { $autopromptMode = 'tokensaver'; $fanout = 'up to 6 live per wave'; $l3Tracks = 'parallel' }
+    }
+    # Scope wall-clock budget, with semantics matching supervisor.sh. A slow scope can
+    # keep producing ROADMAP.md and roadmap-scout-*.md checkpoints, resetting the idle
+    # clock while never converging. This budget is anchored to scope entry, not frontier
+    # growth. Each knob is validated with [int]::TryParse (like $compactAt): an absurd or
+    # non-numeric value falls back to the default (never disables the guard).
+    $scopeSoftSec = 60
+    if (-not [int]::TryParse([string](Get-EnvOrDefault 'AUTOPROMPT_SCOPE_SOFT_SEC' '60'), [ref]$scopeSoftSec) -or $scopeSoftSec -le 0) { $scopeSoftSec = 60 }
+    $scopeHardSec = 300
+    if (-not [int]::TryParse([string](Get-EnvOrDefault 'AUTOPROMPT_SCOPE_HARD_SEC' '300'), [ref]$scopeHardSec) -or $scopeHardSec -le 0) { $scopeHardSec = 300 }
+    $scopeGraceSec = 60
+    if (-not [int]::TryParse([string](Get-EnvOrDefault 'AUTOPROMPT_SCOPE_GRACE' '60'), [ref]$scopeGraceSec) -or $scopeGraceSec -lt 0) { $scopeGraceSec = 60 }
+    $maxScopeResets = 1
+    if (-not [int]::TryParse([string](Get-EnvOrDefault 'AUTOPROMPT_MAX_SCOPE_RESETS' '1'), [ref]$maxScopeResets) -or $maxScopeResets -lt 0) { $maxScopeResets = 1 }
+    $dryRun      = $false
+    $mission     = ''
+
+    # EDIT 23a: the supervisor sits in .../workflow/ next to autoprompt-ledger-check.js,
+    # so derive that resolver's absolute path from its own location and export it to the
+    # child (gate.js EDIT 4a reads AUTOPROMPT_LEDGER_CHECK; the SCRIBE/JANITOR briefs
+    # interpolate it). An operator override wins; else the script-dir sibling is used.
+    # $PSCommandPath is the .ps1's own full path (this script), the analog of the .sh $0.
+    $scriptDir = Split-Path -Parent $PSCommandPath
+    $ledgerCheckPath = if ($env:AUTOPROMPT_LEDGER_CHECK) { $env:AUTOPROMPT_LEDGER_CHECK } else { Join-Path $scriptDir 'autoprompt-ledger-check.js' }
+    $modelCastingPath = if ($env:AUTOPROMPT_MODEL_CASTING) { $env:AUTOPROMPT_MODEL_CASTING } else { Join-Path $scriptDir 'model-casting.js' }
+    $agentDefinitionsPath = if ($env:AUTOPROMPT_AGENT_DEFINITIONS_DIR) { $env:AUTOPROMPT_AGENT_DEFINITIONS_DIR } else { Join-Path (Split-Path -Parent $scriptDir) 'agents' }
+    $agentDefinitionsCli = if ($env:AUTOPROMPT_AGENT_DEFINITIONS_CLI) { $env:AUTOPROMPT_AGENT_DEFINITIONS_CLI } else { Join-Path $scriptDir 'agent-definitions-cli.js' }
+    # F-SPEED steer-2 B3: the phase-budget verdict CLI sits next to the ledger-check.
+    # An operator override wins; the Test-Path guard at the call site fail-opens if
+    # node/module are absent (same posture as the ledger-check).
+    $phaseBudgetPath = if ($env:AUTOPROMPT_PHASE_BUDGET) { $env:AUTOPROMPT_PHASE_BUDGET } else { Join-Path $scriptDir 'phase-budget.js' }
+    # EDIT 23: per-conversation session token. The supervisor is the durable producer
+    # across relaunches of one conversation: seed it (env > file > empty) before the
+    # loop, re-export the held token to each child, and HARVEST the resolver-minted
+    # marker token after each launch so a 2nd prompt rejoins the same session_NN.
+    $sessionToken = Get-EnvOrDefault 'AUTOPROMPT_SESSION_TOKEN' ''
+    $initialResume = (Get-EnvOrDefault 'AUTOPROMPT_RESUME' '').Trim().ToLowerInvariant() -in @('1', 'true', 'yes')
+    $runNonce = Get-EnvOrDefault 'AUTOPROMPT_RUN_NONCE' ''
+    $legacySentinel = (Get-EnvOrDefault 'AUTOPROMPT_LEGACY_SENTINEL' '0') -eq '1'
+
+    # --- arg parse (mirrors the .sh case loop) ----------------------------------
+    $i = 0
+    while ($i -lt $Argv.Count) {
+        $arg = $Argv[$i]
+        switch -CaseSensitive ($arg) {
+            '--launcher'   {
+                $value = Get-RequiredArgumentValue -Flag $arg -Index ($i + 1) -Arguments $Argv
+                if ($null -eq $value) { return 2 }
+                $launcher = $value; $i += 2; continue
+            }
+            '--cmd'        {
+                $value = Get-RequiredArgumentValue -Flag $arg -Index ($i + 1) -Arguments $Argv
+                if ($null -eq $value) { return 2 }
+                $launchCmd = $value; $i += 2; continue
+            }
+            '--agents'     {
+                $value = Get-RequiredArgumentValue -Flag $arg -Index ($i + 1) -Arguments $Argv
+                if ($null -eq $value) { return 2 }
+                $agentsSelector = $value; $i += 2; continue
+            }
+            '--model-registry' {
+                $value = Get-RequiredArgumentValue -Flag $arg -Index ($i + 1) -Arguments $Argv
+                if ($null -eq $value) { return 2 }
+                $modelRegistry = $value; $i += 2; continue
+            }
+            '--provider-capability' {
+                $value = Get-RequiredArgumentValue -Flag $arg -Index ($i + 1) -Arguments $Argv
+                if ($null -eq $value) { return 2 }
+                $providerCapability = $value; $i += 2; continue
+            }
+            '--dry-run'    { $dryRun = $true; $i += 1; continue }
+            '--ledger-dir' {
+                $value = Get-RequiredArgumentValue -Flag $arg -Index ($i + 1) -Arguments $Argv
+                if ($null -eq $value) { return 2 }
+                $ledgerDir = $value; $i += 2; continue
+            }
+            '--'           {
+                # A trailing bare '--' with no following tokens yields an EMPTY
+                # mission (matches supervisor.sh `shift; MISSION="$*"`). Only build
+                # the slice when there is at least one token after '--', else the
+                # range reverses (e.g. 2..1) and throws "index out of range".
+                if (($i + 1) -lt $Argv.Count) {
+                    $mission = ($Argv[($i + 1)..($Argv.Count - 1)] -join ' ')
+                } else {
+                    $mission = ''
+                }
+                $i = $Argv.Count; continue
+            }
+            default {
+                if ($arg -like '-*') {
+                    [Console]::Error.WriteLine("supervisor: unknown flag $arg")
+                    return 2
+                }
+                $mission = $arg; $i += 1; continue
+            }
+        }
+    }
+
+    $missionBytes = [Text.Encoding]::UTF8.GetBytes($mission)
+    $missionSha = [Security.Cryptography.SHA256]::Create()
+    try {
+        $scopeMissionBinding = 'sha256:' + ([BitConverter]::ToString($missionSha.ComputeHash($missionBytes)) -replace '-', '').ToLowerInvariant()
+    } finally {
+        $missionSha.Dispose()
+    }
+    if (-not $legacySentinel) {
+        if ([string]::IsNullOrEmpty($runNonce)) {
+            $nonceBytes = New-Object byte[] 16
+            $generator = [Security.Cryptography.RandomNumberGenerator]::Create()
+            try { $generator.GetBytes($nonceBytes) } finally { $generator.Dispose() }
+            $runNonce = 'NONCE-' + ([BitConverter]::ToString($nonceBytes) -replace '-', '').ToLowerInvariant()
+        } elseif ($runNonce -cnotmatch '^NONCE-[A-Za-z0-9_-]+$') {
+            [Console]::Error.WriteLine('supervisor: AUTOPROMPT_RUN_NONCE is malformed')
+            return 2
+        }
+    }
+
+    $casting = $null
+    $castingJson = ''
+    $castingEnabled = $false
+    $capabilityProvider = 'omp'
+    $capabilityCliVersion = 'unknown'
+    $capabilityPermissionProfile = 'default'
+    $capabilityAgentDefinitionsHash = 'unknown'
+    $capabilityCastingHash = 'none'
+    $capabilityEffortStatus = 'inherited-only'
+    $capabilityEffortSource = 'session-inheritance'
+    $suppliedCapabilityAttestation = Get-EnvOrDefault 'AUTOPROMPT_CAPABILITY_ATTESTATION' ''
+    $capabilityAttestation = $null
+    $selectorControl = $agentsSelector.Trim().ToLowerInvariant()
+    if (-not [string]::IsNullOrEmpty($selectorControl) -and $selectorControl -ne 'off') {
+        if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+            [Console]::Error.WriteLine('supervisor: model casting requires node on PATH')
+            return 2
+        }
+        if (-not (Test-Path -LiteralPath $modelCastingPath -PathType Leaf)) {
+            [Console]::Error.WriteLine("supervisor: model casting resolver is not readable: $modelCastingPath")
+            return 2
+        }
+
+        $nodeArgs = @($modelCastingPath, '--selector', $agentsSelector)
+        if (-not [string]::IsNullOrEmpty($modelRegistry)) {
+            $nodeArgs += @('--registry', $modelRegistry)
+        }
+        if (-not [string]::IsNullOrEmpty($providerCapability)) {
+            $nodeArgs += @('--provider-capability', $providerCapability)
+        }
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            $castingOutput = @(& node @nodeArgs 2>&1)
+            $castingExitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        $castingJson = ($castingOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+        if ($castingExitCode -ne 0) {
+            [Console]::Error.WriteLine($castingJson.Trim())
+            return 2
+        }
+        try {
+            $casting = $castingJson | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            [Console]::Error.WriteLine("supervisor: model casting resolver returned invalid JSON: $($_.Exception.Message)")
+            return 2
+        }
+
+        $castingEnabled = [bool]$casting.enabled
+        if ($castingEnabled) {
+            # omp has no fixed alias pool: verify every tier selector resolved
+            # to a non-empty selector; the serialized casting travels to the
+            # child session as AUTOPROMPT_AGENT_CASTING.
+            foreach ($tier in @('R1','R2','R3','R4','R5')) {
+                $sel = $casting.selectors.$tier
+                if ($null -eq $sel -or [string]::IsNullOrEmpty([string]$sel)) {
+                    [Console]::Error.WriteLine("supervisor: model casting resolved an empty $tier selector")
+                    return 2
+                }
+            }
+        }
+    }
+
+    if (Get-Command node -ErrorAction SilentlyContinue) {
+        $configuredVersion = Get-EnvOrDefault 'AUTOPROMPT_CLI_VERSION' ''
+        if (-not [string]::IsNullOrEmpty($configuredVersion)) {
+            $capabilityCliVersion = $configuredVersion
+        } else {
+            $cliCommand = if (-not [string]::IsNullOrEmpty($launchCmd)) { ($launchCmd -split '\s+')[0] } else { $launcher }
+            if (-not [string]::IsNullOrEmpty($cliCommand) -and (Get-Command $cliCommand -ErrorAction SilentlyContinue)) {
+                try { $capabilityCliVersion = [string]((& $cliCommand --version 2>$null | Select-Object -First 1)) } catch {}
+            }
+        }
+        if ($launchCmd -match '(?:^|\s)--dangerously-skip-permissions(?:\s|$)') {
+            $capabilityPermissionProfile = 'bypass-permissions'
+        } else {
+            $capabilityPermissionProfile = Get-EnvOrDefault 'AUTOPROMPT_PERMISSION_PROFILE' 'default'
+        }
+        $capabilityAgentDefinitionsHash = Get-AgentDefinitionsHash `
+            -ModelCastingPath $modelCastingPath `
+            -AgentsDirectory $agentDefinitionsPath
+        if ($castingEnabled) {
+            $bytes = [Text.Encoding]::UTF8.GetBytes($castingJson)
+            $sha = [Security.Cryptography.SHA256]::Create()
+            try { $capabilityCastingHash = 'sha256:' + ([BitConverter]::ToString($sha.ComputeHash($bytes)) -replace '-', '').ToLowerInvariant() }
+            finally { $sha.Dispose() }
+            $capabilityEffortStatus = [string]$casting.effort.status
+            $capabilityEffortSource = [string]$casting.effort.source
+        }
+        if ($capabilityCliVersion -ne 'unknown' -and
+            $capabilityAgentDefinitionsHash -ne 'unknown' -and
+            -not [string]::IsNullOrEmpty($suppliedCapabilityAttestation)) {
+            $expectedBindings = @(
+                $capabilityProvider,
+                $capabilityCliVersion,
+                $capabilityPermissionProfile,
+                $agentsSelector,
+                $capabilityAgentDefinitionsHash,
+                $capabilityCastingHash,
+                $capabilityEffortStatus,
+                $capabilityEffortSource
+            )
+            if (Test-CapabilityAttestation `
+                -Raw $suppliedCapabilityAttestation `
+                -Expected $expectedBindings) {
+                $capabilityAttestation = $suppliedCapabilityAttestation
+            }
+        }
+    }
+
+    $agentDefinitionsJson = ''
+    if (-not $dryRun) {
+        if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+            [Console]::Error.WriteLine('supervisor: activation-scoped agents require node on PATH')
+            return 2
+        }
+        if (-not (Test-Path -LiteralPath $agentDefinitionsCli -PathType Leaf)) {
+            [Console]::Error.WriteLine("supervisor: agent-definition converter is not readable: $agentDefinitionsCli")
+            return 2
+        }
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = 'Continue'
+            $agentDefinitionsOutput = @(
+                & node $agentDefinitionsCli $agentDefinitionsPath 2>&1
+            )
+            $agentDefinitionsExitCode = $LASTEXITCODE
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
+        if ($agentDefinitionsExitCode -ne 0) {
+            [Console]::Error.WriteLine(($agentDefinitionsOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine)
+            return 2
+        }
+        $agentDefinitionsJson = $agentDefinitionsOutput -join [Environment]::NewLine
+        if ([string]::IsNullOrEmpty($agentDefinitionsJson)) {
+            [Console]::Error.WriteLine('supervisor: agent-definition converter returned an empty cast')
+            return 2
+        }
+    }
+
+    $sentinelGlob = Get-EnvOrDefault 'SENTINEL' (Join-Path $ledgerDir 'DONE-*')
+    $escalateFile = Join-Path $ledgerDir 'SUPERVISOR-ESCALATE'
+    $snapshotFile = Join-Path $ledgerDir '.sentinel-snapshot'
+    # EDIT 23: durable session-token store under the ledger dir, surviving across
+    # relaunches of one conversation. Seeded before the loop, harvested after launches.
+    $sessionTokenFile = Join-Path $ledgerDir '.session-token'
+    # PLAN-auto-compact-threshold path vars. Discovery is CWD-AGNOSTIC and slug-free: it
+    # matches the supervisor's own run cwd against each transcript's embedded "cwd" after
+    # normalization -- NO slug derivation, NO launcher edit. Identical to supervisor.sh.
+    $runCwd = (Get-EnvOrDefault 'RUN_CWD' (Get-Location).Path)
+    $parentTranscript = Get-EnvOrDefault 'AUTOPROMPT_PARENT_TRANSCRIPT' ''
+    $watermarkFile = Join-Path $ledgerDir '.context-watermark'
+    $compactRequestFile = Join-Path $ledgerDir 'COMPACT-REQUEST'
+    $compactStateFile = Join-Path $ledgerDir '.compaction-state'
+    # Scope-budget state survives relaunches. The start epoch does not reset on
+    # frontier growth; the reset counter clears once build evidence lands.
+    $scopePhaseStartFile = Join-Path $ledgerDir '.scope-phase-start'
+    $scopeResetsFile = Join-Path $ledgerDir '.scope-forced-resets'
+    if (-not (Test-Path -LiteralPath $ledgerDir)) {
+        New-Item -ItemType Directory -Path $ledgerDir -Force | Out-Null
+    }
+
+    # Supervisor start time (captured BEFORE the first launch). It is no longer part
+    # of the stale-sentinel guarantee (see below) -- it is kept only to name the
+    # quarantine target (superseded-<epoch>-...). Get-Date cannot fail here.
+    $startTime = Get-Date
+
+    # THE stale-sentinel guarantee is a LIVE STARTUP SNAPSHOT, not LastWriteTime.
+    # Before the first launch we record every pre-existing DONE-* PATH into
+    # $snapshotFile. Test-SentinelPresent REFUSES any DONE-* whose path is in that
+    # snapshot -- regardless of LastWriteTime. As quarantine SUCCESSFULLY renames each
+    # stale occupant aside it PRUNES that path from the snapshot, so a path is vetoed
+    # IFF its stale occupant still physically exists. A DONE-* counts as THIS run's
+    # completion if its path was NOT present at startup OR was present but has since
+    # been cleared by a successful quarantine (the launcher then wrote a FRESH one
+    # there -- the same-activation DONE-<nonce> case). A failed quarantine
+    # rename leaves the path vetoed -> RELAUNCH, never a false halt. The
+    # LastWriteTime>=start belt is gone -- it could not backstop the same-second
+    # class, which is the whole reason this defense exists. FAIL-SAFE: if the snapshot
+    # cannot be written or read, ALL DONE-* are treated as suspect -> relaunch.
+    $script:state = @{
+        DryRun        = $dryRun
+        LedgerDir     = $ledgerDir
+        SentinelGlob  = $sentinelGlob
+        LaunchIndex   = 0
+        StartTime     = $startTime
+        SnapshotFile  = $snapshotFile
+        SnapshotOk    = $false
+        SnapshotPaths = @{}
+        ScopeEscalate = $false
+        ScopeTerminal = $false
+    }
+
+    function Write-SupLog {
+        param([string]$Message)
+        $ts = (Get-Date).ToString('yyyy-MM-ddTHH:mm:ss')
+        Write-Host "[supervisor $ts] $Message"
+    }
+
+    # Take the startup snapshot of pre-existing DONE-* PATHS, BEFORE the first
+    # launch and BEFORE any sentinel check or quarantine. Each path is written on
+    # its own line to $snapshotFile and held in a hashtable for O(1) lookup.
+    # SnapshotOk=$true marks a trustworthy snapshot; if writing fails we leave it
+    # $false, and Test-SentinelPresent then treats EVERY DONE-* as suspect
+    # (relaunch), the fail-safe direction.
+    function Save-PreExistingSentinels {
+        $script:state.SnapshotOk = $false
+        $script:state.SnapshotPaths = @{}
+        try {
+            $found = @(Get-ChildItem -Path $script:state.SentinelGlob -ErrorAction SilentlyContinue)
+            $lines = New-Object System.Collections.Generic.List[string]
+            foreach ($file in $found) {
+                $lines.Add($file.FullName)
+                $script:state.SnapshotPaths[$file.FullName] = $true
+            }
+            Set-Content -LiteralPath $script:state.SnapshotFile -Value $lines -Encoding ascii -ErrorAction Stop
+            $script:state.SnapshotOk = $true
+        } catch {
+            $script:state.SnapshotOk = $false
+        }
+    }
+
+    # Is $Path one of the paths recorded in the startup snapshot? If the snapshot is
+    # not trustworthy (SnapshotOk=$false) we answer YES for every path -> every
+    # DONE-* is treated as pre-existing -> never halts -> relaunch. That is the
+    # deliberate fail-safe: a missing/unreadable snapshot must never permit a halt.
+    function Test-PathInSnapshot {
+        param([string]$Path)
+        if (-not $script:state.SnapshotOk) { return $true }
+        return $script:state.SnapshotPaths.ContainsKey($Path)
+    }
+
+    # Drop one path from the live snapshot so a genuinely-fresh sentinel can later
+    # reclaim it. Called by quarantine ONLY after a SUCCESSFUL rename: once the stale
+    # occupant has been moved aside, the path is empty, so the ONLY thing that can
+    # appear there is a fresh sentinel written by THIS run. The activation nonce is
+    # minted once (CSPRNG) and re-exported unchanged to every relaunched child (no
+    # clock), so a re-launch of
+    # the SAME activation writes the SAME path the snapshot recorded -- if the snapshot
+    # kept vetoing it, that fresh sentinel would be refused forever and the supervisor
+    # would relaunch without end (the livelock). We drop it from the in-memory set AND
+    # rewrite $SnapshotFile so a mid-run re-read agrees. If the rewrite fails we KEEP
+    # the path in memory (over-veto = relaunch, never a false halt). A path whose
+    # rename FAILED is never pruned, so it stays vetoed while its occupant still exists.
+    function Remove-PathFromSnapshot {
+        param([string]$Path)
+        if (-not $script:state.SnapshotOk) { return }
+        $script:state.SnapshotPaths.Remove($Path) | Out-Null
+        try {
+            $lines = New-Object System.Collections.Generic.List[string]
+            foreach ($key in $script:state.SnapshotPaths.Keys) { $lines.Add($key) }
+            Set-Content -LiteralPath $script:state.SnapshotFile -Value $lines -Encoding ascii -ErrorAction Stop
+        } catch {
+            # Rewrite failed: the in-memory set already dropped the path (the source of
+            # truth for this process); the on-disk copy is only for a mid-run re-read,
+            # which this port does not do. Leaving it stale cannot cause a false halt.
+        }
+    }
+
+    # A DONE-sentinel counts as THIS run's completion iff it exists, carries the
+    # done marker, AND its path is NOT in the LIVE startup snapshot. The snapshot
+    # starts as every pre-existing DONE-* path and is pruned as quarantine clears
+    # each one, so a path is vetoed IFF its stale occupant still physically exists;
+    # a fresh sentinel at a cleared path is honored. Mirrors the .sh for-loop glob +
+    # grep '"done"\s*:\s*true'.
+    function Test-SentinelPresent {
+        if (-not $legacySentinel) {
+            $sentinelPath = Join-Path $script:state.LedgerDir "DONE-$runNonce"
+            if (-not (Test-Path -LiteralPath $sentinelPath -PathType Leaf) -or
+                (Test-PathInSnapshot $sentinelPath)) {
+                return $false
+            }
+            try {
+                $sentinel = Get-Content -LiteralPath $sentinelPath -Raw -ErrorAction Stop |
+                    ConvertFrom-Json -ErrorAction Stop
+                $done = $sentinel.PSObject.Properties['done']
+                $nonce = $sentinel.PSObject.Properties['nonce']
+                return $null -ne $done -and $done.Value -is [bool] -and $done.Value -eq $true -and
+                    $null -ne $nonce -and $nonce.Value -is [string] -and $nonce.Value -ceq $runNonce
+            } catch {
+                return $false
+            }
+        }
+        $found = @(Get-ChildItem -Path $script:state.SentinelGlob -File -ErrorAction SilentlyContinue)
+        foreach ($file in $found) {
+            $content = Get-Content -LiteralPath $file.FullName -Raw -ErrorAction SilentlyContinue
+            if ($null -ne $content -and $content -match '"done"\s*:\s*true') {
+                if (-not (Test-PathInSnapshot $file.FullName)) {
+                    return $true
+                }
+            }
+        }
+        return $false
+    }
+
+    # At startup, BEFORE the first launch, QUARANTINE every pre-existing done:true
+    # DONE-* sentinel: rename it aside to <dir>\superseded-<start-epoch>-<name> so
+    # the new name no longer starts with DONE- and thus no longer matches the live
+    # DONE-* glob -- it cannot halt this fresh mission. (Prefixing, NOT suffixing: a
+    # DONE-X.superseded-N name would STILL match DONE-* and re-trip the same-second
+    # halt, so the leading DONE- must be displaced.) This is the PRIMARY fix for the
+    # whole stale-sentinel class -- after quarantine there is no leftover sentinel
+    # left to race, so a same-second / sub-second LastWriteTime collision is moot.
+    # We RENAME, never delete (deleting artifacts is the JANITOR's job; never
+    # silently remove operator files) and log a loud line naming each quarantined
+    # file. On a SUCCESSFUL rename the path is pruned from the live snapshot so a
+    # genuine fresh same-activation DONE-<nonce> (the minted nonce is re-exported to
+    # every relaunched child, no clock) can reclaim it -- else the snapshot would veto
+    # that fresh sentinel forever and the supervisor would relaunch without end
+    # (livelock). If a rename FAILS (read-only dir / permissions / clobber) the
+    # leftover DONE-* still matches the live glob, its path is NOT pruned, and
+    # Test-SentinelPresent unconditionally refuses it. A failed rename degrades to
+    # RELAUNCH, never a halt. Net invariant: the snapshot vetoes a path IFF its stale
+    # occupant still exists.
+    function Move-StaleSentinelAside {
+        $startEpoch = [int64][Math]::Floor(([DateTimeOffset]$script:state.StartTime).ToUnixTimeSeconds())
+        $found = @(Get-ChildItem -Path $script:state.SentinelGlob -File -ErrorAction SilentlyContinue)
+        foreach ($file in $found) {
+            $content = Get-Content -LiteralPath $file.FullName -Raw -ErrorAction SilentlyContinue
+            if ($null -ne $content -and $content -match '"done"\s*:\s*true') {
+                $quarantined = Join-Path $file.DirectoryName "superseded-$startEpoch-$($file.Name)"
+                try {
+                    Move-Item -LiteralPath $file.FullName -Destination $quarantined -Force -ErrorAction Stop
+                    # The stale occupant is gone, so this path can no longer hold
+                    # anything but a FRESH this-run sentinel. Drop it from the live
+                    # snapshot so the same-activation DONE-<nonce> is
+                    # reclaimable -- otherwise the snapshot would veto the genuine
+                    # fresh sentinel forever (the livelock).
+                    Remove-PathFromSnapshot $file.FullName
+                    Write-SupLog "QUARANTINE: pre-existing DONE-sentinel '$($file.FullName)' (from a prior run) renamed to '$quarantined' so it cannot halt this fresh mission. It is preserved, not deleted."
+                } catch {
+                    Write-SupLog "WARNING: could not quarantine pre-existing DONE-sentinel '$($file.FullName)' -- it is IGNORED for halting by the startup snapshot and will not stop this mission. Remove it if it is no longer relevant."
+                }
+            }
+        }
+    }
+
+    # The frontier marker is a monotonic forward-progress counter, not a success
+    # counter. In real runs it counts roadmap/scout, plan, build, assurance, sweep,
+    # arbitration, and goal-check artifacts. Versioned, per-feature, retained-scout,
+    # and per-round files multiply as work proceeds, so an advancing pre-build scope
+    # that writes roadmap and retained scout evidence long
+    # before any plan-final -- bumps the count every relaunch and resets the
+    # poison window; a run writing nothing new stays flat and still trips poison.
+    function Get-FrontierCount {
+        if ($script:state.DryRun) {
+            if ((Get-EnvOrDefault 'FAKE_POISON' '0') -eq '1') { return 0 }
+            $counterFile = Join-Path $script:state.LedgerDir '.fake-frontier'
+            if (Test-Path -LiteralPath $counterFile) {
+                return [int]((Get-Content -LiteralPath $counterFile -Raw).Trim())
+            }
+            return 0
+        }
+        $count = 0
+        # Three artifact layouts must ALL be counted, or a run driven by one of them
+        # is invisible to the frontier and a healthy-long run trips POISON:
+        #   prose/agent (SKILL.md/GATES.md): autoprompt/prompt-NNN-<slug>/artifacts/
+        #   harness (autoprompt-gate.js ARTIFACT_DIR): autoprompt/.artifacts/<run-tag>/
+        #   session ledger (SPEC-1 SCRIBE): autoprompt/session_NN/prompt_NN-<slug>/ and
+        #     its optional artifacts/ subdir. The per-prompt ledger .md files
+        #     (BRIEF/GATELOG/COVERAGE...) count as forward progress (monotonic; same
+        #     rationale as the multiplying-artifacts globs), so a run advancing ONLY in
+        #     the new layout is never falsely poisoned.
+        # The leading-dot harness dir is not matched by the prose "*" wildcard and its
+        # nesting differs, so it needs its own glob -- which also stops the prose glob
+        # from double-counting it. Ledger-root prose files (BRIEF/PLAN/GATELOG...) live
+        # one level above artifacts/ so they are not counted by the first two globs; the
+        # session-ledger glob counts them at their nested depth. The DONE sentinel lives
+        # at the ledger root, not under any artifacts/ dir.
+        $proseArtifacts   = Join-Path (Join-Path $script:state.LedgerDir '*') 'artifacts'
+        $harnessArtifacts = Join-Path (Join-Path $script:state.LedgerDir '.artifacts') '*'
+        $artifactGlobs = @(
+            (Join-Path $proseArtifacts   '*.md')
+            (Join-Path $harnessArtifacts '*.md')
+            (Join-Path (Join-Path (Join-Path $script:state.LedgerDir 'session_*') 'prompt_*') (Join-Path 'artifacts' '*.md'))
+            (Join-Path (Join-Path (Join-Path $script:state.LedgerDir 'session_*') 'prompt_*') '*.md')
+        )
+        $count += @(Get-ChildItem -Path $artifactGlobs -File -ErrorAction SilentlyContinue).Count
+        return $count
+    }
+
+    # Scope wall-clock budget starts at launch, before the author can emit an artifact,
+    # and goes dormant only when build evidence lands.
+    function Get-ScopePhaseElapsed {
+        if ($script:state.DryRun) {
+            $fse = Get-EnvOrDefault 'FAKE_SCOPE_ELAPSED' ''
+            if (-not [string]::IsNullOrEmpty($fse)) { return [int]$fse }
+            return $null
+        }
+        $ld = $script:state.LedgerDir
+        $buildGlobs = @(
+            (Join-Path (Join-Path (Join-Path $ld '.artifacts') '*') '*-impl-v*.md')
+            (Join-Path (Join-Path (Join-Path $ld '*') 'artifacts') '*-impl-v*.md')
+            (Join-Path (Join-Path (Join-Path (Join-Path $ld 'session_*') 'prompt_*') 'artifacts') '*-impl-v*.md')
+        )
+        if (@(Get-ChildItem -Path $buildGlobs -File -ErrorAction SilentlyContinue).Count -gt 0) {
+            Remove-Item -LiteralPath $scopePhaseStartFile -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $scopeResetsFile -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $ld 'SCOPE-CONVERGE-REQUEST') -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $ld 'SCOPE-BUDGET-BREACH') -Force -ErrorAction SilentlyContinue
+            return $null
+        }
+        $nowS = [int64][Math]::Floor(([DateTimeOffset](Get-Date)).ToUnixTimeSeconds())
+        $startS = 0
+        $storedBinding = ''
+        if (Test-Path -LiteralPath $scopePhaseStartFile) {
+            try {
+                $first = (Get-Content -LiteralPath $scopePhaseStartFile -First 1 -ErrorAction Stop)
+                if ($null -ne $first) {
+                    $fields = ([string]$first).Trim() -split '\s+'
+                    if ($fields.Count -ge 1) { [void][int64]::TryParse($fields[0], [ref]$startS) }
+                    if ($fields.Count -ge 2) { $storedBinding = $fields[1] }
+                }
+            } catch { $startS = 0; $storedBinding = '' }
+        }
+        if ($storedBinding -cne $scopeMissionBinding) {
+            $startS = 0
+            Remove-Item -LiteralPath (Join-Path $ld 'SCOPE-CONVERGE-REQUEST') -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $ld 'SCOPE-BUDGET-BREACH') -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $scopeResetsFile -Force -ErrorAction SilentlyContinue
+        }
+        if ($startS -le 0) {
+            $startS = $nowS
+            try {
+                $tmp = "$scopePhaseStartFile.tmp"
+                "$startS $scopeMissionBinding" | Set-Content -LiteralPath $tmp -Encoding ascii
+                Move-Item -LiteralPath $tmp -Destination $scopePhaseStartFile -Force
+            } catch { }
+        }
+        $elapsed = $nowS - $startS
+        if ($elapsed -lt 0) { $elapsed = 0 }
+        return [int]$elapsed
+    }
+
+    # Honest retained scope evidence: roadmap-scout-N on new runs, scope-<key> on
+    # legacy resumes. Missing evidence stays missing rather than being invented.
+    function Get-ScopeLandedAngles {
+        if ($script:state.DryRun) { return (Get-EnvOrDefault 'FAKE_SCOPE_LANDED' '') }
+        $ld = $script:state.LedgerDir
+        $scopeGlobs = @(
+            (Join-Path (Join-Path (Join-Path $ld '.artifacts') '*') 'roadmap-scout-*.md')
+            (Join-Path (Join-Path (Join-Path $ld '*') 'artifacts') 'roadmap-scout-*.md')
+            (Join-Path (Join-Path (Join-Path (Join-Path $ld 'session_*') 'prompt_*') 'artifacts') 'roadmap-scout-*.md')
+            (Join-Path (Join-Path (Join-Path $ld '.artifacts') '*') 'scope-*.md')
+            (Join-Path (Join-Path (Join-Path $ld '*') 'artifacts') 'scope-*.md')
+            (Join-Path (Join-Path (Join-Path (Join-Path $ld 'session_*') 'prompt_*') 'artifacts') 'scope-*.md')
+        )
+        $keys = New-Object System.Collections.Generic.List[string]
+        foreach ($file in @(Get-ChildItem -Path $scopeGlobs -File -ErrorAction SilentlyContinue)) {
+            $key = if ($file.Name -like 'roadmap-scout-*.md') {
+                $file.Name -replace '\.md$', ''
+            } else {
+                $file.Name -replace '^scope-', '' -replace '-v[0-9]+\.md$', '' -replace '\.md$', ''
+            }
+            if (-not [string]::IsNullOrEmpty($key) -and -not $keys.Contains($key)) { $keys.Add($key) }
+        }
+        return ($keys -join ',')
+    }
+
+    # Age (seconds) of the pending SCOPE-CONVERGE-REQUEST, or 0 when none exists.
+    function Get-ScopeConvergeRequestAge {
+        $req = Join-Path $script:state.LedgerDir 'SCOPE-CONVERGE-REQUEST'
+        if (-not (Test-Path -LiteralPath $req)) { return 0 }
+        $nowS = [int64][Math]::Floor(([DateTimeOffset](Get-Date)).ToUnixTimeSeconds())
+        $reqTs = 0
+        try {
+            $first = (Get-Content -LiteralPath $req -First 1 -ErrorAction Stop)
+            if ($null -ne $first) { $f = ([string]$first).Trim() -split '\s+'; if ($f.Count -ge 1) { [void][int64]::TryParse($f[0], [ref]$reqTs) } }
+        } catch { $reqTs = 0 }
+        $age = $nowS - $reqTs
+        if ($age -lt 0) { $age = 0 }
+        return [int]$age
+    }
+
+    # === PLAN-auto-compact-threshold: proactive supervisor-fired compaction ==========
+    # The PowerShell port of canon_path / find_parent_transcript / read_context_estimate
+    # / note_external_compaction / maybe_request_compaction / kill_tree. The slug-free
+    # discovery rule (single-level glob + embedded-cwd match + newest-since-launch) is
+    # BYTE-FOR-BYTE the same decision as supervisor.sh -- there is no slug to diverge on.
+
+    # Canonicalize a path for cross-platform cwd comparison (win32 AND posix): lowercase;
+    # collapse \ and / runs to a single /; map a leading "<drive>:" to "/<drive>".
+    function Get-CanonPath {
+        param([string]$Path)
+        if ($null -eq $Path) { return '' }
+        $p = $Path.ToLowerInvariant() -replace '\\', '/'
+        $p = $p -replace '/+', '/'
+        $p = $p -replace '^([a-z]):', '/$1'
+        return $p
+    }
+
+    # Find the live parent session .jsonl. Slug-free: matches $runCwd against each
+    # transcript's embedded "cwd" after canonicalization. Single-level glob excludes
+    # nested subagent/tool-result transcripts. Returns the path or $null.
+    function Find-ParentTranscript {
+        param([long]$LaunchEpoch)
+        if (-not [string]::IsNullOrEmpty($parentTranscript) -and (Test-Path -LiteralPath $parentTranscript)) {
+            return $parentTranscript
+        }
+        $cfg = Get-EnvOrDefault 'PI_CODING_AGENT_DIR' (Join-Path $HOME '.omp\agent')
+        $want = Get-CanonPath $runCwd
+        $glob = Join-Path (Join-Path $cfg 'sessions') (Join-Path '*' '*.jsonl')
+        $newest = $null; $newestMt = [long]0
+        foreach ($f in @(Get-ChildItem -Path $glob -File -ErrorAction SilentlyContinue)) {
+            $mt = [int64][Math]::Floor(([DateTimeOffset]$f.LastWriteTimeUtc).ToUnixTimeSeconds())
+            if ($mt -lt $LaunchEpoch) { continue }   # stale prior session
+            $tcwd = $null
+            try {
+                foreach ($line in [System.IO.File]::ReadLines($f.FullName)) {
+                    $m = [regex]::Match($line, '"cwd":"([^"]*)"')
+                    if ($m.Success) { $tcwd = $m.Groups[1].Value; break }
+                }
+            } catch { $tcwd = $null }
+            if ([string]::IsNullOrEmpty($tcwd)) { continue }
+            $tcwd = $tcwd -replace '\\\\', '\'   # un-escape JSON doubled backslashes
+            if ((Get-CanonPath $tcwd) -ne $want) { continue }
+            if ($mt -gt $newestMt) { $newest = $f.FullName; $newestMt = $mt }
+        }
+        return $newest
+    }
+
+    # Read the PARENT's context size in three tiers; returns an integer (0 = unavailable).
+    # TIER 1 parse transcript usage (byte proxy on parse failure); TIER 2 watermark
+    # (stale-rejected); TIER 3 coarse ledger-byte proxy. Honors FAKE_WATERMARK in dry-run.
+    function Read-ContextEstimate {
+        param([long]$LaunchEpoch)
+        if ($script:state.DryRun) {
+            $fw = Get-EnvOrDefault 'FAKE_WATERMARK' ''
+            if (-not [string]::IsNullOrEmpty($fw)) { return [int]$fw }
+            return 0
+        }
+        $tx = Find-ParentTranscript -LaunchEpoch $LaunchEpoch
+        if (-not [string]::IsNullOrEmpty($tx) -and (Test-Path -LiteralPath $tx)) {
+            $lastUsage = $null
+            try {
+                foreach ($line in [System.IO.File]::ReadLines($tx)) {
+                    if ($line -notmatch '"usage"') { continue }
+                    try {
+                        $obj = $line | ConvertFrom-Json
+                        if ($obj.message -and $obj.message.usage) { $lastUsage = $obj.message.usage }
+                    } catch { }
+                }
+            } catch { $lastUsage = $null }
+            if ($null -ne $lastUsage) {
+                $sum = 0
+                foreach ($k in @('input_tokens', 'cache_read_input_tokens', 'cache_creation_input_tokens')) {
+                    $v = $lastUsage.$k
+                    if ($null -ne $v) { $sum += [int]$v }
+                }
+                if ($sum -gt 0) { return $sum }
+            }
+            try {
+                $sz = (Get-Item -LiteralPath $tx).Length
+                if ($sz -gt 0) { return [int]([math]::Floor($sz / $bytesPerToken)) }
+            } catch { }
+        }
+        if (Test-Path -LiteralPath $watermarkFile) {
+            try {
+                $first = (Get-Content -LiteralPath $watermarkFile -First 1 -ErrorAction Stop)
+                if ($null -ne $first) {
+                    $fields = ([string]$first).Trim() -split '\s+'
+                    $wmTok = 0
+                    if ($fields.Count -ge 1 -and [int]::TryParse($fields[0], [ref]$wmTok)) {
+                        $wmTs = $null
+                        if ($fields.Count -ge 2) { $parsedTs = [long]0; if ([long]::TryParse($fields[1], [ref]$parsedTs)) { $wmTs = $parsedTs } }
+                        if ($null -eq $wmTs -or $wmTs -ge $LaunchEpoch) { return $wmTok }
+                    }
+                }
+            } catch { }
+        }
+        $bytes = [long]0
+        $ledgerGlobs = @(
+            (Join-Path (Join-Path (Join-Path $script:state.LedgerDir 'session_*') 'prompt_*') '*.md')
+            (Join-Path (Join-Path (Join-Path $script:state.LedgerDir 'session_*') 'prompt_*') (Join-Path 'artifacts' '*.md'))
+            (Join-Path (Join-Path $script:state.LedgerDir '*') (Join-Path 'artifacts' '*.md'))
+        )
+        foreach ($g in $ledgerGlobs) {
+            foreach ($f in @(Get-ChildItem -Path $g -File -ErrorAction SilentlyContinue)) { $bytes += $f.Length }
+        }
+        return [int]([math]::Floor($bytes / $bytesPerToken))
+    }
+
+    # Detect a harness-fired compaction (a sharp estimate DROP across ticks): arm the
+    # cooldown and clear any pending request so the supervisor does NOT double-fire.
+    # Returns $true when an external compaction was detected.
+    function Note-ExternalCompaction {
+        param([long]$Now, [int]$CurrentEst)
+        $prevEst = 0; $lastCompact = 0
+        if (Test-Path -LiteralPath $compactStateFile) {
+            try {
+                $first = (Get-Content -LiteralPath $compactStateFile -First 1 -ErrorAction Stop)
+                if ($null -ne $first) {
+                    $f = ([string]$first).Trim() -split '\s+'
+                    if ($f.Count -ge 1) { [void][int]::TryParse($f[0], [ref]$lastCompact) }
+                    if ($f.Count -ge 2) { [void][int]::TryParse($f[1], [ref]$prevEst) }
+                }
+            } catch { }
+        }
+        if ($prevEst -gt 0 -and (($prevEst - $CurrentEst) -ge $externalCompactDelta)) {
+            try {
+                $tmp = "$compactStateFile.tmp"
+                "$Now $CurrentEst external_compaction" | Set-Content -LiteralPath $tmp -Encoding ascii
+                Move-Item -LiteralPath $tmp -Destination $compactStateFile -Force
+            } catch { }
+            if (Test-Path -LiteralPath $compactRequestFile) { Remove-Item -LiteralPath $compactRequestFile -Force -ErrorAction SilentlyContinue }
+            Write-SupLog "EXTERNAL COMPACTION detected: context estimate dropped $prevEst->$CurrentEst (>=$externalCompactDelta) -- arming cooldown and clearing any pending COMPACT-REQUEST (no double-fire)."
+            return $true
+        }
+        try {
+            $tmp = "$compactStateFile.tmp"
+            "$lastCompact $CurrentEst" | Set-Content -LiteralPath $tmp -Encoding ascii
+            Move-Item -LiteralPath $tmp -Destination $compactStateFile -Force
+        } catch { }
+        return $false
+    }
+
+    # Decide whether to request/force a compaction. Returns @{Requested=$bool; Force=$bool}.
+    # Guards: cooldown, in-flight request, external-compaction detection.
+    function Request-CompactionIfNeeded {
+        param([long]$LaunchEpoch, [long]$Now)
+        $result = @{ Requested = $false; Force = $false }
+        $est = Read-ContextEstimate -LaunchEpoch $LaunchEpoch
+        if (Note-ExternalCompaction -Now $Now -CurrentEst $est) { return $result }
+        $lastCompact = 0
+        if (Test-Path -LiteralPath $compactStateFile) {
+            try {
+                $first = (Get-Content -LiteralPath $compactStateFile -First 1 -ErrorAction Stop)
+                if ($null -ne $first) { $f = ([string]$first).Trim() -split '\s+'; if ($f.Count -ge 1) { [void][int]::TryParse($f[0], [ref]$lastCompact) } }
+            } catch { }
+        }
+        if ($lastCompact -gt 0 -and (($Now - $lastCompact) -lt $compactCooldown)) { return $result }
+        if (Test-Path -LiteralPath $compactRequestFile) {
+            $reqTs = 0
+            try {
+                $first = (Get-Content -LiteralPath $compactRequestFile -First 1 -ErrorAction Stop)
+                if ($null -ne $first) { $f = ([string]$first).Trim() -split '\s+'; if ($f.Count -ge 1) { [void][int]::TryParse($f[0], [ref]$reqTs) } }
+            } catch { }
+            if (($Now - $reqTs) -ge $compactGrace) { $result.Force = $true; $result.Requested = $true }
+            return $result
+        }
+        if ($est -ge $compactAt) {
+            try {
+                $tmp = "$compactRequestFile.tmp"
+                "$Now proactive est=$est threshold=$compactAt" | Set-Content -LiteralPath $tmp -Encoding ascii
+                Move-Item -LiteralPath $tmp -Destination $compactRequestFile -Force
+                Write-SupLog "COMPACT-REQUEST written: context est=$est tokens >= AUTOPROMPT_COMPACT_AT=$compactAt. Parent will checkpoint+compact at its next gate boundary (not a wipe, not a stop)."
+            } catch { }
+            $result.Requested = $true
+        }
+        return $result
+    }
+
+    # Kill the child process AND every descendant so a wedged parent leaves NO orphaned
+    # subagent (the ps1 analog of the .sh process-group kill_tree). Walks Win32_Process
+    # ParentProcessId, killing leaves-first, then the root.
+    function Stop-ProcessTree {
+        param($Proc)
+        if ($null -eq $Proc) { return }
+        $rootId = $null
+        try { $rootId = $Proc.Id } catch { $rootId = $null }
+        if ($null -ne $rootId) {
+            try {
+                & taskkill.exe /T /F /PID $rootId 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) { return }
+            } catch { }
+            # Fallback: manual descendant walk if taskkill is unavailable or fails.
+            try {
+                $all = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue
+                $toKill = New-Object System.Collections.Generic.List[int]
+                $queue = New-Object System.Collections.Generic.Queue[int]
+                $queue.Enqueue([int]$rootId)
+                while ($queue.Count -gt 0) {
+                    $procId = $queue.Dequeue(); $toKill.Add($procId)
+                    foreach ($c in @($all | Where-Object { $_.ParentProcessId -eq $procId })) { $queue.Enqueue([int]$c.ProcessId) }
+                }
+                foreach ($victim in ($toKill.ToArray() | Sort-Object -Descending)) {
+                    try { Stop-Process -Id $victim -Force -ErrorAction SilentlyContinue } catch { }
+                }
+            } catch { }
+        }
+        try { $Proc.Kill() } catch { }
+    }
+
+    # Run the real or fake launcher once; return its exit code.
+    #
+    # HEARTBEAT (PLAN-idle-watchdog P3, behavior-parallel to supervisor.sh V3): the
+    # child is launched in the BACKGROUND on BOTH the real exec AND the dry-run fake
+    # path (via Start-Process -PassThru), so a SINGLE poll loop watches liveness +
+    # frontier-COUNT staleness regardless of path (blocker 2: the poll loop is genuinely
+    # exercised under --dry-run against a real process handle). While the child is alive,
+    # if Get-FrontierCount has NOT grown beyond last-seen within $idleTimeout and no
+    # sentinel exists, the run is ALIVE-BUT-IDLE -> Stop-Process so the outer relaunch
+    # loop RESUMEs it (the automatic CONTINUE). DISTINCT from the EXIT-keyed poison guard
+    # and FEEDS it: a heartbeat kill that produced no count growth is a no-progress
+    # restart for the outer loop, so a wedged child still trips POISON after MAX_RESTARTS
+    # (anti-thrash). The model-pin / session-token save -> set -> restore-in-finally
+    # quartet wraps the Start-Process so the child inherits the neutralized env and this
+    # supervisor's own env is restored after the child fully exits.
+    function Invoke-Launcher {
+        $script:state.LaunchIndex += 1
+        $idx = $script:state.LaunchIndex
+        $childLaunchEpoch = [int64][Math]::Floor(([DateTimeOffset](Get-Date)).ToUnixTimeSeconds())
+        if (-not $script:state.DryRun) {
+            $storedBinding = ''
+            if (Test-Path -LiteralPath $scopePhaseStartFile) {
+                try {
+                    $first = Get-Content -LiteralPath $scopePhaseStartFile -First 1 -ErrorAction Stop
+                    if ($null -ne $first) {
+                        $fields = ([string]$first).Trim() -split '\s+'
+                        if ($fields.Count -ge 2) { $storedBinding = $fields[1] }
+                    }
+                } catch { $storedBinding = '' }
+            }
+            if ($storedBinding -cne $scopeMissionBinding) {
+                Remove-Item -LiteralPath (Join-Path $ledgerDir 'SCOPE-CONVERGE-REQUEST') -Force -ErrorAction SilentlyContinue
+                Remove-Item -LiteralPath (Join-Path $ledgerDir 'SCOPE-BUDGET-BREACH') -Force -ErrorAction SilentlyContinue
+                Remove-Item -LiteralPath $scopeResetsFile -Force -ErrorAction SilentlyContinue
+                try {
+                    $tmp = "$scopePhaseStartFile.tmp"
+                    "$childLaunchEpoch $scopeMissionBinding" | Set-Content -LiteralPath $tmp -Encoding ascii
+                    Move-Item -LiteralPath $tmp -Destination $scopePhaseStartFile -Force
+                } catch {}
+            }
+        }
+        $absLedger = $script:state.LedgerDir
+        if (-not [System.IO.Path]::IsPathRooted($absLedger)) {
+            $absLedger = Join-Path (Get-Location).Path $absLedger
+        }
+        if ($script:state.DryRun) {
+            # Compute everything in the PARENT (idx-indexed), then background a generated
+            # fake-child script via Start-Process so the poll loop has a real handle. The
+            # fake writes the sentinel / advances the frontier / optionally stays alive
+            # (FAKE_CHILD_ALIVE seconds) then exits with the popped code - exactly the
+            # work the old synchronous fake did, now in a real backgrounded process.
+            $sentinelAfter = Get-EnvOrDefault 'FAKE_SENTINEL_AFTER' ''
+            $writeSentinel = (-not [string]::IsNullOrEmpty($sentinelAfter) -and $idx -ge [int]$sentinelAfter)
+            $advance = ((Get-EnvOrDefault 'FAKE_POISON' '0') -ne '1')
+            $alive = [int](Get-EnvOrDefault 'FAKE_CHILD_ALIVE' 0)
+            $fakeExits = (Get-EnvOrDefault 'FAKE_EXITS' '0').Trim()
+            $codes = @($fakeExits -split '\s+' | Where-Object { $_ -ne '' })
+            $code = 0
+            if ($idx -ge 1 -and $idx -le $codes.Count) { $code = [int]$codes[$idx - 1] }
+            $fakeChild = Join-Path $absLedger '.fake-child.ps1'
+            @(
+                'param($Ledger,$WriteSentinel,$Advance,$Alive,$Code)'
+                'if ($WriteSentinel -eq "1") {'
+                '  $done = Join-Path $Ledger "DONE-FAKE"'
+                '  $tmp = "$done.tmp"'
+                '  ''{"done": true, "nonce": "FAKE", "verdict": "fake done", "ts": "now"}'' | Set-Content -LiteralPath $tmp -Encoding ascii -NoNewline'
+                '  Move-Item -LiteralPath $tmp -Destination $done -Force'
+                '}'
+                'if ($Advance -eq "1") {'
+                '  $cf = Join-Path $Ledger ".fake-frontier"'
+                '  $cur = 0; if (Test-Path -LiteralPath $cf) { $cur = [int]((Get-Content -LiteralPath $cf -Raw).Trim()) }'
+                '  ($cur + 1) | Set-Content -LiteralPath $cf -Encoding ascii -NoNewline'
+                '}'
+                'if ($Alive -gt 0) { Start-Sleep -Seconds $Alive }'
+                'exit $Code'
+            ) -join "`n" | Set-Content -LiteralPath $fakeChild -Encoding ascii
+            $wsArg = if ($writeSentinel) { '1' } else { '0' }
+            $advArg = if ($advance) { '1' } else { '0' }
+            $proc = Start-Process -FilePath 'powershell' `
+                -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $fakeChild, $absLedger, $wsArg, $advArg, "$alive", "$code") `
+                -PassThru -NoNewWindow -WorkingDirectory (Get-Location).Path
+            return (Wait-ChildWithHeartbeat -Proc $proc)
+        }
+        # Launch one is fresh unless the operator explicitly requested resume.
+        # Relaunches always export AUTOPROMPT_RESUME=1.
+        # When $launchCmd is set it is used VERBATIM (word-split into command +
+        # args, mission appended) so a fresh user can pass their real CLI;
+        # otherwise the bare $launcher label is exec'd as before.
+        # Neutralize nothing: omp has no subagent model pin environment variable.
+        # The resolved casting (selectors + effort) travels to the child session
+        # as AUTOPROMPT_AGENT_CASTING; agents=off exports nothing and every
+        # worker inherits the child session's active model. PowerShell env is
+        # process-scoped, so prior values are saved and restored in `finally`.
+        $previousUnattended = $env:AUTOPROMPT_UNATTENDED
+        $previousResume = $env:AUTOPROMPT_RESUME
+        $previousMode = $env:AUTOPROMPT_MODE
+        $previousRunNonce = $env:AUTOPROMPT_RUN_NONCE
+        $previousLedgerCheck = $env:AUTOPROMPT_LEDGER_CHECK
+        $previousSessionToken = $env:AUTOPROMPT_SESSION_TOKEN
+        $previousAgents = $env:AUTOPROMPT_AGENTS
+        $previousAgentCasting = $env:AUTOPROMPT_AGENT_CASTING
+        $previousCapabilityAttestation = $env:AUTOPROMPT_CAPABILITY_ATTESTATION
+        $previousProvider = $env:AUTOPROMPT_PROVIDER
+        $previousCliVersion = $env:AUTOPROMPT_CLI_VERSION
+        $previousPermissionProfile = $env:AUTOPROMPT_PERMISSION_PROFILE
+        $previousAgentDefinitionsHash = $env:AUTOPROMPT_AGENT_DEFINITIONS_HASH
+        $previousCastingHash = $env:AUTOPROMPT_CASTING_HASH
+
+        $env:AUTOPROMPT_UNATTENDED = '1'
+        if ($idx -gt 1 -or $initialResume) {
+            $env:AUTOPROMPT_RESUME = '1'
+        } else {
+            $env:AUTOPROMPT_RESUME = $null
+        }
+        $env:AUTOPROMPT_MODE = $autopromptMode
+        if (-not $legacySentinel) { $env:AUTOPROMPT_RUN_NONCE = $runNonce }
+        $env:AUTOPROMPT_LEDGER_CHECK = $ledgerCheckPath
+        if (-not [string]::IsNullOrEmpty($sessionToken)) {
+            $env:AUTOPROMPT_SESSION_TOKEN = $sessionToken
+        } else {
+            $env:AUTOPROMPT_SESSION_TOKEN = $null
+        }
+        $env:AUTOPROMPT_AGENTS = $agentsSelector
+        $env:AUTOPROMPT_PROVIDER = $capabilityProvider
+        $env:AUTOPROMPT_CLI_VERSION = $capabilityCliVersion
+        $env:AUTOPROMPT_PERMISSION_PROFILE = $capabilityPermissionProfile
+        $env:AUTOPROMPT_AGENT_DEFINITIONS_HASH = $capabilityAgentDefinitionsHash
+        $env:AUTOPROMPT_CASTING_HASH = $capabilityCastingHash
+        $env:AUTOPROMPT_CAPABILITY_ATTESTATION = $capabilityAttestation
+        if ($castingEnabled) {
+            $env:AUTOPROMPT_AGENT_CASTING = $castingJson
+        }
+        try {
+            $launchWorkingDirectory = (Get-Location).Path
+            if (-not [string]::IsNullOrEmpty($launchCmd)) {
+                $parts = @($launchCmd -split '\s+' | Where-Object { $_ -ne '' })
+                $exe = $parts[0]
+                $rest = @($parts | Select-Object -Skip 1)
+                $procArgs = @($rest + @('--agents', $agentDefinitionsJson, $mission))
+            } else {
+                $exe = $launcher
+                $procArgs = @('--agents', $agentDefinitionsJson, $mission)
+            }
+            $nativeArguments = Join-NativeArguments -Arguments $procArgs
+            $proc = Start-Process -FilePath $exe `
+                -ArgumentList $nativeArguments -PassThru -NoNewWindow `
+                -WorkingDirectory $launchWorkingDirectory
+            return (Wait-ChildWithHeartbeat -Proc $proc)
+        } catch {
+            # A launcher that cannot be executed (a bad --cmd/--launcher: user typo
+            # or missing alias) throws a TERMINATING error under 'Stop'. Mirror the
+            # bash exit 127 so it feeds the SAME poison-guard/relaunch path instead
+            # of unwinding the loop and crashing the supervisor with a stack trace.
+            Write-SupLog "launch failed: $($_.Exception.Message)"
+            return 127
+        } finally {
+            $env:AUTOPROMPT_UNATTENDED = $previousUnattended
+            $env:AUTOPROMPT_RESUME = $previousResume
+            $env:AUTOPROMPT_MODE = $previousMode
+            $env:AUTOPROMPT_RUN_NONCE = $previousRunNonce
+            $env:AUTOPROMPT_LEDGER_CHECK = $previousLedgerCheck
+            $env:AUTOPROMPT_SESSION_TOKEN = $previousSessionToken
+            $env:AUTOPROMPT_AGENTS = $previousAgents
+            $env:AUTOPROMPT_AGENT_CASTING = $previousAgentCasting
+            $env:AUTOPROMPT_CAPABILITY_ATTESTATION = $previousCapabilityAttestation
+            $env:AUTOPROMPT_PROVIDER = $previousProvider
+            $env:AUTOPROMPT_CLI_VERSION = $previousCliVersion
+            $env:AUTOPROMPT_PERMISSION_PROFILE = $previousPermissionProfile
+            $env:AUTOPROMPT_AGENT_DEFINITIONS_HASH = $previousAgentDefinitionsHash
+            $env:AUTOPROMPT_CASTING_HASH = $previousCastingHash
+            if ($castingEnabled) { Write-SupLog 'model-casting environment restored' }
+        }
+    }
+
+    # Wait-ChildWithHeartbeat: poll a backgrounded child process for liveness +
+    # frontier-COUNT staleness, killing it on an idle-timeout so the outer relaunch
+    # loop RESUMEs it. Behavior-parallel to the supervisor.sh poll loop. Returns the
+    # child's exit code (or 0 if a heartbeat kill pre-empted a clean exit code - the
+    # outer loop then sees no count growth and treats it as a no-progress restart).
+    # The poll wakes on a RESPONSIVE 200ms slice so a fast-exiting child is detected
+    # promptly; the staleness evaluation runs only once per $heartbeatInterval of
+    # elapsed wall-clock, preserving the exact heartbeat cadence.
+    function Wait-ChildWithHeartbeat {
+        param($Proc)
+        $handle = $Proc.Handle   # cache the OS handle so .ExitCode populates on exit
+        $nowEpoch = { [int64][Math]::Floor(([DateTimeOffset](Get-Date)).ToUnixTimeSeconds()) }
+        $childLaunchEpoch = & $nowEpoch
+        $lastProgress = & $nowEpoch
+        $lastEval = $lastProgress
+        $lastSeenCount = Get-FrontierCount
+        while (-not $Proc.HasExited) {
+            Start-Sleep -Milliseconds 200
+            if (Test-SentinelPresent) { break }
+            $now = & $nowEpoch
+            if (($now - $lastEval) -lt $heartbeatInterval) { continue }
+            $lastEval = $now
+            $curCount = Get-FrontierCount
+            if ($curCount -gt $lastSeenCount) {
+                $lastSeenCount = $curCount; $lastProgress = $now
+            } elseif (($now - $lastProgress) -ge $idleTimeout) {
+                Write-SupLog "HEARTBEAT: no frontier progress for >=${idleTimeout}s while alive and no sentinel -- killing to relaunch with RESUME (auto-continue an idle agent)."
+                Stop-ProcessTree -Proc $Proc
+                break
+            }
+            # PLAN-auto-compact-threshold: proactive supervisor-fired compaction check.
+            $compact = Request-CompactionIfNeeded -LaunchEpoch $childLaunchEpoch -Now $now
+            if ($compact.Force) {
+                Write-SupLog "COMPACT FALLBACK: request unhonored for >=${compactGrace}s (parent likely wedged) -- recording a .forced-reset marker, then killing the WHOLE child process tree so no subagent is orphaned; the outer loop RESUMEs from the SCRIBE-refreshed ANCHOR.md."
+                try {
+                    $tmp = (Join-Path $ledgerDir '.forced-reset.tmp')
+                    "$now forced est_unhonored grace=$compactGrace" | Set-Content -LiteralPath $tmp -Encoding ascii
+                    Move-Item -LiteralPath $tmp -Destination (Join-Path $ledgerDir '.forced-reset') -Force
+                } catch { }
+                try {
+                    $tmp2 = "$compactStateFile.tmp"
+                    "$now forced" | Set-Content -LiteralPath $tmp2 -Encoding ascii
+                    Move-Item -LiteralPath $tmp2 -Destination $compactStateFile -Force
+                } catch { }
+                if (Test-Path -LiteralPath $compactRequestFile) { Remove-Item -LiteralPath $compactRequestFile -Force -ErrorAction SilentlyContinue }
+                Stop-ProcessTree -Proc $Proc
+                break
+            }
+            # F-SPEED steer-2 B3: PHASE WALL-CLOCK BUDGET check. Once per tick, when the
+            # SCOPE phase is active, consult phase-budget.js. Anchored to scope ENTRY, NOT
+            # reset by frontier growth. Fail-open: an absent node/module skips the block.
+            $scopeEl = Get-ScopePhaseElapsed
+            if ($null -ne $scopeEl -and (Test-Path -LiteralPath $phaseBudgetPath)) {
+                $reqAge = Get-ScopeConvergeRequestAge
+                $prior = 0
+                if (Test-Path -LiteralPath $scopeResetsFile) {
+                    try {
+                        $pf = (Get-Content -LiteralPath $scopeResetsFile -First 1 -ErrorAction Stop)
+                        if ($null -ne $pf) { [void][int]::TryParse(([string]$pf).Trim(), [ref]$prior) }
+                    } catch { $prior = 0 }
+                }
+                $landed = Get-ScopeLandedAngles
+                & node $phaseBudgetPath --verdict --phase scope --elapsed $scopeEl `
+                    --soft $scopeSoftSec --hard $scopeHardSec --request-age $reqAge `
+                    --grace $scopeGraceSec --prior-resets $prior --max-resets $maxScopeResets `
+                    --landed $landed *> $null
+                $verdictCode = $LASTEXITCODE
+                $convergeReqFile = Join-Path $ledgerDir 'SCOPE-CONVERGE-REQUEST'
+                if ($verdictCode -eq 10) {
+                    # SOFT breach: write the converge heads-up ONCE (idempotent), keep running.
+                    if (-not (Test-Path -LiteralPath $convergeReqFile)) {
+                        try {
+                            $tmp = "$convergeReqFile.tmp"
+                            "$now soft scope budget: mission=$scopeMissionBinding elapsed=${scopeEl}s soft=${scopeSoftSec}s landed=$landed -- converge on the landed angles; do NOT fabricate unscoped ones." | Set-Content -LiteralPath $tmp -Encoding ascii
+                            Move-Item -LiteralPath $tmp -Destination $convergeReqFile -Force
+                        } catch { }
+                        Write-SupLog "SCOPE BUDGET soft breach at ${scopeEl}s (>= ${scopeSoftSec}s, frontier advancing) -- wrote SCOPE-CONVERGE-REQUEST (converge on landed=$landed); child NOT killed."
+                    }
+                } elseif ($verdictCode -eq 20) {
+                    # HARD/grace breach: durable marker (honest landed residual), bump counter, kill->RESUME.
+                    try {
+                        $breachFile = Join-Path $ledgerDir 'SCOPE-BUDGET-BREACH'
+                        $tmp = "$breachFile.tmp"
+                        "$now hard scope budget breach: mission=$scopeMissionBinding elapsed=${scopeEl}s hard=${scopeHardSec}s landed=$landed residual=$landed -- converge on landed, surface any unscoped angle; DO NOT fabricate." | Set-Content -LiteralPath $tmp -Encoding ascii
+                        Move-Item -LiteralPath $tmp -Destination $breachFile -Force
+                    } catch { }
+                    try {
+                        $tmpR = "$scopeResetsFile.tmp"
+                        "$($prior + 1)" | Set-Content -LiteralPath $tmpR -Encoding ascii
+                        Move-Item -LiteralPath $tmpR -Destination $scopeResetsFile -Force
+                    } catch { }
+                    Write-SupLog "SCOPE BUDGET hard breach at ${scopeEl}s (frontier was advancing) -- wrote SCOPE-BUDGET-BREACH (residual=$landed); killing the process tree and terminating this supervisor run."
+                    $script:state.ScopeTerminal = $true
+                    Stop-ProcessTree -Proc $Proc
+                    break
+                } elseif ($verdictCode -eq 30) {
+                    # RE-BREACH past the reset cap: escalate honestly, never fake a roadmap.
+                    try {
+                        $lines = @(
+                            "supervisor escalation: scope budget breached past MAX_SCOPE_RESETS=$maxScopeResets"
+                            "scope_elapsed=$scopeEl hard=$scopeHardSec prior_resets=$prior landed=$landed"
+                            'converge unreachable -- landed angles surfaced as the honest residual; NO fabricated roadmap'
+                            "ts=$((Get-Date).ToString())"
+                        )
+                        $lines -join [Environment]::NewLine | Set-Content -LiteralPath $escalateFile -Encoding ascii
+                    } catch { }
+                    Write-SupLog "SCOPE BUDGET escalation at ${scopeEl}s -- breached past MAX_SCOPE_RESETS=$maxScopeResets; landed=$landed surfaced as residual; killing and exiting 1."
+                    $script:state.ScopeEscalate = $true
+                    Stop-ProcessTree -Proc $Proc
+                    break
+                }
+            }
+        }
+        try { $Proc.WaitForExit() } catch {}
+        $exit = 0
+        try { if ($Proc.HasExited) { $exit = $Proc.ExitCode } } catch { $exit = 0 }
+        if ($null -eq $exit) { $exit = 0 }
+        return $exit
+    }
+
+    # Legacy broad DONE-* matching is a DOWNGRADE honored only for a verified
+    # legacy resume: the operator opted in explicitly AND the ledger directory
+    # carries physical evidence of a pre-nonce run (legacy governance files a
+    # three-file new-format run never creates). A fresh or new-format directory
+    # fails closed so the downgrade can never weaken a current-format run.
+    if ($legacySentinel) {
+        $legacyEvidence = $false
+        foreach ($marker in @('BRIEF.md', 'AGENTS.md', 'bucketlist.md', 'ANCHOR.md')) {
+            if (Test-Path -LiteralPath (Join-Path $ledgerDir $marker) -PathType Leaf) {
+                $legacyEvidence = $true
+                break
+            }
+        }
+        if (-not $legacyEvidence) {
+            [Console]::Error.WriteLine("supervisor: AUTOPROMPT_LEGACY_SENTINEL=1 requires a verified legacy resume (legacy governance files under $ledgerDir); unset it for new runs")
+            return 2
+        }
+    }
+
+    if ([string]::IsNullOrEmpty($launcher) -and [string]::IsNullOrEmpty($launchCmd) -and -not $dryRun) {
+        [Console]::Error.WriteLine('supervisor: no launch command (use --cmd "<your CLI>" / AUTOPROMPT_LAUNCH_CMD, or --launcher apidemo|codexdemo / AUTOPROMPT_LAUNCHER)')
+        return 2
+    }
+
+    $launcherLabel =
+        if (-not [string]::IsNullOrEmpty($launchCmd)) { $launchCmd }
+        elseif (-not [string]::IsNullOrEmpty($launcher)) { $launcher }
+        else { '<dry-run>' }
+    Write-SupLog "starting: launcher=$launcherLabel ledger=$ledgerDir mission=`"$mission`""
+    Write-SupLog "topology: 5-level L0->L4; mode=$autopromptMode; per-L3 fan-out=$fanout; L3 tracks=$l3Tracks; L1 never executes (rule 68); single-block spawns (rule 67) -- enforced in the harness."
+    # Snapshot pre-existing DONE-* PATHS FIRST, THEN quarantine. Order matters: the
+    # snapshot must see the dir as it was before any rename, so a failed rename still
+    # leaves the path recorded (and vetoed). Quarantine prunes each SUCCESSFULLY
+    # renamed path back out of the snapshot, so the net invariant after this pair is:
+    # a path is vetoed IFF its stale occupant still physically exists.
+    Save-PreExistingSentinels
+    Move-StaleSentinelAside
+
+    # EDIT 23: seed the per-conversation session token ONCE, before the relaunch loop.
+    # An env-supplied token (operator or a prior same-conversation export) wins and is
+    # persisted to the durable file; else a previously-harvested token is read back;
+    # else the token stays empty and the first SCRIBE-run resolver MINTS one. Fail-soft:
+    # an unwritable/unreadable token file never aborts the run.
+    if (-not [string]::IsNullOrEmpty($sessionToken)) {
+        try { Set-Content -LiteralPath $sessionTokenFile -Value $sessionToken -Encoding ascii -ErrorAction Stop } catch {}
+    } elseif (Test-Path -LiteralPath $sessionTokenFile) {
+        try {
+            $fileToken = (Get-Content -LiteralPath $sessionTokenFile -First 1 -ErrorAction Stop)
+            if ($null -ne $fileToken) { $sessionToken = ([string]$fileToken).Trim() }
+        } catch {}
+    }
+
+    [long[]]$restartTimes = @()   # epoch seconds of recent restarts (no progress)
+    $lastFrontier = Get-FrontierCount
+    $backoff = $retryBase
+
+    while ($true) {
+        if (Test-SentinelPresent) {
+            Write-SupLog 'DONE-sentinel present -- run complete, halting cleanly.'
+            return 0
+        }
+
+        $exitCode = Invoke-Launcher
+
+        # Scope budget termination is checked before sentinels so a breach cannot be
+        # masked by output written during the same tick or poison-relaunch the mission.
+        if ($script:state.ScopeEscalate) {
+            return 1
+        }
+        if ($script:state.ScopeTerminal) {
+            Write-SupLog 'SCOPE BUDGET terminal stop -- no same-mission relaunch will consume another worker.'
+            return 124
+        }
+
+        if (Test-SentinelPresent) {
+            Write-SupLog "DONE-sentinel present after launch (exit $exitCode) -- run complete, halting cleanly."
+            return 0
+        }
+
+        # P4 (MANDATORY terminal caller, behavior-parallel to supervisor.sh V5): the
+        # child EXITED with no DONE-sentinel -- a TERMINAL boundary for that child. Write
+        # the RUN-ENDED marker so a ledger audit treats this as run-ended, then (real-run
+        # only) run a best-effort terminal IDLE-FINISH audit. RUN-ENDED is the marker
+        # autoprompt-ledger-check.js reads to set runEnded=true. Written every exit-
+        # without-sentinel; idempotent (overwritten each exit). The clean-DONE path
+        # short-circuits at the sentinel checks above, so RUN-ENDED is only ever written
+        # when the run is genuinely not done.
+        try {
+            "run-ended exit=$exitCode ts=$(Get-Date)" | Set-Content -LiteralPath (Join-Path $ledgerDir 'RUN-ENDED') -Encoding ascii
+        } catch {}
+        if (-not $dryRun -and (Test-Path -LiteralPath $ledgerCheckPath)) {
+            # Best-effort loud-log: the marker alone is sufficient for the rule to fire on
+            # the NEXT audit, so this node call's non-zero exit is informational; the
+            # relaunch happens regardless.
+            try {
+                & node $ledgerCheckPath --ledger-dir $ledgerDir --transcript-dir $ledgerDir --terminal *> $null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-SupLog 'IDLE-FINISH terminal audit flagged a P0 (run ended with open work, no live agent) -- relaunching with RESUME to re-drive.'
+                }
+            } catch {}
+        }
+
+        $now = [int64][Math]::Floor(([DateTimeOffset](Get-Date)).ToUnixTimeSeconds())
+        $curFrontier = Get-FrontierCount
+        # EDIT 23: HARVEST the resolver-minted session token after a launch when the
+        # supervisor holds none yet. The SCRIBE-run --resolve-prompt-dir CLI writes the
+        # marker "<LedgerDir>/.session-current" as "session_NN  <token>" (two
+        # whitespace-separated fields -- the EDIT 7 contract). Read the 2nd field and
+        # persist it so the NEXT launch re-exports the SAME token and a 2nd prompt
+        # rejoins the same session_NN. Fail-soft: an absent/corrupt marker (no 2nd
+        # field) leaves the token empty and the next launch mints again.
+        if ([string]::IsNullOrEmpty($sessionToken)) {
+            $markerPath = Join-Path $ledgerDir '.session-current'
+            if (Test-Path -LiteralPath $markerPath) {
+                try {
+                    $markerLine = (Get-Content -LiteralPath $markerPath -First 1 -ErrorAction Stop)
+                    if ($null -ne $markerLine) {
+                        $fields = ([string]$markerLine).Trim() -split '\s+'
+                        if ($fields.Count -ge 2 -and -not [string]::IsNullOrEmpty($fields[1])) {
+                            $sessionToken = $fields[1]
+                            try { Set-Content -LiteralPath $sessionTokenFile -Value $sessionToken -Encoding ascii -ErrorAction Stop } catch {}
+                        }
+                    }
+                } catch {}
+            }
+        }
+        Write-SupLog "launcher exited ($exitCode); frontier $lastFrontier -> $curFrontier; no sentinel -- relaunching with RESUME."
+
+        if ($curFrontier -gt $lastFrontier) {
+            # Healthy-long: progress was made. Reset the poison window and backoff.
+            $restartTimes = @()
+            $backoff = $retryBase
+            $lastFrontier = $curFrontier
+        } else {
+            # No progress since the last launch. Record this restart in the rolling
+            # window and check the poison guard.
+            $newTimes = New-Object System.Collections.Generic.List[long]
+            $rapid = 1
+            foreach ($t in $restartTimes) {
+                if (($now - $t) -lt $window) {
+                    $newTimes.Add($t)
+                    $rapid += 1
+                }
+            }
+            $newTimes.Add($now)
+            $restartTimes = $newTimes.ToArray()
+            if ($rapid -ge $maxRestarts) {
+                Write-SupLog "POISON: $rapid restarts within ${window}s with NO frontier progress -- escalating, not relaunching."
+                $escalateTs = (Get-Date).ToString()
+                $lines = @(
+                    'supervisor escalation: crash-loop with no frontier progress'
+                    "restarts_in_window=$rapid window_s=$window last_exit=$exitCode frontier=$curFrontier"
+                    "ts=$escalateTs"
+                )
+                $lines -join [Environment]::NewLine | Set-Content -LiteralPath $escalateFile -Encoding ascii
+                return 1
+            }
+            # Exponential backoff, capped, between unproductive relaunches.
+            if ($backoff -gt 0) { Start-Sleep -Seconds $backoff }
+            $next = $backoff * 2
+            if ($next -gt $retryCap) { $next = $retryCap }
+            $backoff = $next
+        }
+    }
+}
+
+# Only auto-run when invoked as a script, not when dot-sourced by the test suite.
+if ($MyInvocation.InvocationName -ne '.') {
+    $exit = Invoke-Supervisor -Argv $args
+    exit $exit
+}

--- a/agents/omp/workflow/supervisor.sh
+++ b/agents/omp/workflow/supervisor.sh
@@ -1,0 +1,1251 @@
+#!/bin/sh
+# autoprompt supervisor - external auto-relaunch for a one-sitting unattended run.
+#
+# This is a STANDALONE OS PROCESS, NOT a Claude Code hook. It touches no
+# settings.json, registers no hook, and is launched by the operator (or a
+# tmux/nohup line). It honors the global no-hooks rule.
+#
+# It relaunches the autoprompt CLI with RESUME on any unexpected exit, loops
+# until the JANITOR has written the DONE-sentinel (autoprompt/DONE-<nonce>),
+# and has a crash-loop/poison-restart guard that distinguishes:
+#   - a FINISHED run (sentinel present)        -> clean halt
+#   - a HEALTHY-LONG run (frontier advances)   -> keep relaunching, no escalation
+#   - a TRULY-STUCK run (no frontier progress) -> escalate, stop relaunching
+#
+# Usage:
+#   supervisor.sh --launcher apidemo|codexdemo "<mission>"
+#   supervisor.sh --cmd "omp -p --auto-approve" "<mission>"
+#   supervisor.sh --agents "auto:strong,cheap" --model-registry ~/.omp/agent/autoprompt-models.json --cmd "omp -p --auto-approve" "<mission>"
+#
+# The launch command is resolved in this precedence:
+#   1. --cmd "<command>" / AUTOPROMPT_LAUNCH_CMD  (used VERBATIM, word-split,
+#      with the mission appended) -- the explicit, copy-pasteable escape hatch.
+#   2. --launcher <label> / AUTOPROMPT_LAUNCHER   (the bare command name, e.g.
+#      apidemo|codexdemo, exec'd directly -- requires that name to be on PATH).
+# A fresh user with no apidemo/codexdemo alias uses --cmd with their real CLI.
+# Env (all optional):
+#   AUTOPROMPT_LAUNCH_CMD  verbatim launch command (overrides --launcher)
+#   AUTOPROMPT_LAUNCHER   default launcher label if --launcher is omitted
+#   AUTOPROMPT_AGENTS      off | auto | <list> | auto:<list> (default off)
+#   AUTOPROMPT_MODEL_REGISTRY  optional registry path; defaults to ~/.omp/agent/autoprompt-models.json for auto modes
+#   LEDGER_DIR             default "autoprompt"
+#   SENTINEL               explicit sentinel glob/patterns (default <LEDGER_DIR>/DONE-*).
+#                          When SET, the value is WORD-SPLIT into one-or-more shell
+#                          globs (an explicit multi-pattern escape hatch) and so MUST
+#                          NOT contain spaces in any single path. When UNSET (the
+#                          default -- every real run) the glob is "$LEDGER_DIR"/DONE-*
+#                          with the DIR QUOTED and only the * unquoted, so a LEDGER_DIR
+#                          containing spaces (e.g. a Windows path) still matches its
+#                          DONE-* sentinel. NOTE: the .ps1 port passes an explicit
+#                          SENTINEL as ONE Get-ChildItem -Path pattern (no word-split),
+#                          so a space-separated multi-pattern SENTINEL is a .sh-only
+#                          feature; on PowerShell use a single dir-wildcard instead.
+#   MAX_RESTARTS           rapid restarts allowed in WINDOW without progress (default 5)
+#   WINDOW                 rolling window seconds for the poison guard (default 600)
+#   RETRY_BASE             base backoff seconds between relaunches (default 5; 0 in tests)
+#   RETRY_CAP              max backoff seconds (default 300)
+#   AUTOPROMPT_AGENT_CASTING    when casting is enabled, the serialized casting
+#                          JSON (selectors + effort) is exported to the child
+#                          session; the conductor applies it as run-scoped
+#                          task.agentModelOverrides project settings. With
+#                          agents=off no casting is exported and every worker
+#                          inherits the parent's active model.
+#   AUTOPROMPT_MODE       tokensaver | wide | billionaire | custom (default
+#                          tokensaver). WIDE and BILLIONAIRE share wide semantics.
+#                          CUSTOM requires a positive numeric
+#                          AUTOPROMPT_MAX_CONCURRENT value, floors it to a whole-agent
+#                          ceiling, and passes both values through to the harness.
+# The 5-level topology (L0 conductor -> L1 coordinators -> L2 managers -> L3
+# executors -> L4 leaves) lives in the harness; rule 68 (L1 never executes) and
+# rule 67 (single-block spawns) are enforced there. This OS-level supervisor only
+# relaunches the L0 entry process and passes the mode through; it spawns no agents.
+# Test hooks (only honored with --dry-run):
+#   FAKE_EXITS             space-separated exit codes the fake launcher returns in turn
+#   FAKE_SENTINEL_AFTER    write the sentinel before the launch with this 1-based index
+#   FAKE_POISON            1 => fake never advances the frontier and always exits non-zero
+set -u
+
+LAUNCHER="${AUTOPROMPT_LAUNCHER:-}"
+LAUNCH_CMD="${AUTOPROMPT_LAUNCH_CMD:-}"
+AGENTS_SELECTOR="${AUTOPROMPT_AGENTS:-off}"
+MODEL_REGISTRY="${AUTOPROMPT_MODEL_REGISTRY:-}"
+PROVIDER_CAPABILITY="${AUTOPROMPT_PROVIDER_CAPABILITY:-}"
+LEDGER_DIR="${LEDGER_DIR:-autoprompt}"
+MAX_RESTARTS="${MAX_RESTARTS:-5}"
+WINDOW="${WINDOW:-600}"
+RETRY_BASE="${RETRY_BASE:-5}"
+RETRY_CAP="${RETRY_CAP:-300}"
+IDLE_TIMEOUT="${AUTOPROMPT_IDLE_TIMEOUT:-1800}"      # seconds of frontier-count staleness while alive -> kill -> relaunch (continue)
+HEARTBEAT_INTERVAL="${AUTOPROMPT_HEARTBEAT_INTERVAL:-60}"  # poll cadence while the child is alive
+# V4 (long-tool-call guard): IDLE_TIMEOUT defaults to 1800s (30 min) precisely so a
+# long-but-progressing build/test does NOT trip the heartbeat - the frontier count
+# grows when ANY artifact is written, so a progressing run resets the timer well before
+# 30 min. Operators with long single atomic steps raise AUTOPROMPT_IDLE_TIMEOUT.
+# PLAN-auto-compact-threshold: proactive, SUPERVISOR-FIRED compaction below the harness
+# ~400k ceiling. The supervisor observes the parent's context size from OUTSIDE (it
+# parses the parent's own Claude Code session transcript; watermark/ledger-byte
+# fallbacks) and, when it crosses COMPACT_AT, writes COMPACT-REQUEST (a heads-up so the
+# parent checkpoints + STOPS its subagents at the next gate boundary) and, on grace
+# timeout, fires the kill->RESUME itself (the parent cannot /compact itself).
+COMPACT_AT="${AUTOPROMPT_COMPACT_AT:-200000}"          # proactive compaction watermark (tokens); below the harness ~400k ceiling
+BYTES_PER_TOKEN="${AUTOPROMPT_BYTES_PER_TOKEN:-4}"     # bytes->tokens divisor for the fallback proxies
+COMPACT_COOLDOWN="${AUTOPROMPT_COMPACT_COOLDOWN:-120}" # seconds after a compaction before another may be requested
+COMPACT_GRACE="${AUTOPROMPT_COMPACT_GRACE:-180}"       # seconds to let the parent honor a request before the forced fallback
+EXTERNAL_COMPACT_DELTA="${AUTOPROMPT_EXTERNAL_COMPACT_DELTA:-50000}"  # an estimate DROP >= this across ticks = a harness-fired compaction
+# Validate COMPACT_AT to a positive integer; an absurd/non-numeric value falls back to
+# the default (never disables the guard, never fires every tick -- the zero-threshold trap).
+case "$COMPACT_AT" in (*[!0-9]*|"") COMPACT_AT=200000 ;; esac
+[ "$COMPACT_AT" -gt 0 ] 2>/dev/null || COMPACT_AT=200000
+[ "$COMPACT_AT" -lt 10000000 ] 2>/dev/null || COMPACT_AT=200000
+case "$BYTES_PER_TOKEN" in (*[!0-9]*|""|0) BYTES_PER_TOKEN=4 ;; esac
+# F-SPEED steer-2 B3: PHASE WALL-CLOCK BUDGET for the SCOPE phase. IDLE_TIMEOUT
+# (above) fires only on frontier STALENESS; a slow scope can keep producing
+# ROADMAP.md and roadmap-scout-*.md checkpoints, resetting the idle clock while never
+# bounded. This budget is anchored to scope-phase ENTRY and NOT reset by frontier
+# growth - the exact hole IDLE_TIMEOUT leaves. Soft => a converge REQUEST; hard (or an
+# unhonored converge past grace) => a durable breach marker + REAL kill->RESUME on the
+# honest landed set; a re-breach past the reset cap => SUPERVISOR-ESCALATE. It NEVER
+# fabricates a roadmap. Each knob is validated with the SAME positive-integer idiom as
+# COMPACT_AT: an absurd/non-numeric value falls back to the default (never disables the
+# guard, never a zero-budget trap that fires every tick).
+SCOPE_SOFT_SEC="${AUTOPROMPT_SCOPE_SOFT_SEC:-60}"      # bounded scope target
+SCOPE_HARD_SEC="${AUTOPROMPT_SCOPE_HARD_SEC:-300}"     # ordinary multi-surface ceiling
+SCOPE_GRACE_SEC="${AUTOPROMPT_SCOPE_GRACE:-60}"        # converge-request grace
+MAX_SCOPE_RESETS="${AUTOPROMPT_MAX_SCOPE_RESETS:-1}"  # budget-forced scope resets before escalation
+case "$SCOPE_SOFT_SEC" in (*[!0-9]*|"") SCOPE_SOFT_SEC=60 ;; esac
+[ "$SCOPE_SOFT_SEC" -gt 0 ] 2>/dev/null || SCOPE_SOFT_SEC=60
+case "$SCOPE_HARD_SEC" in (*[!0-9]*|"") SCOPE_HARD_SEC=300 ;; esac
+[ "$SCOPE_HARD_SEC" -gt 0 ] 2>/dev/null || SCOPE_HARD_SEC=300
+case "$SCOPE_GRACE_SEC" in (*[!0-9]*|"") SCOPE_GRACE_SEC=60 ;; esac
+[ "$SCOPE_GRACE_SEC" -ge 0 ] 2>/dev/null || SCOPE_GRACE_SEC=60
+case "$MAX_SCOPE_RESETS" in (*[!0-9]*|"") MAX_SCOPE_RESETS=1 ;; esac
+[ "$MAX_SCOPE_RESETS" -ge 0 ] 2>/dev/null || MAX_SCOPE_RESETS=1
+# Execution mode selects the 5-level topology's wave cap. Unknown modes retain the
+# safe tokensaver fallback. CUSTOM is different: it is an explicit request for a
+# caller-supplied ceiling, so a missing or invalid ceiling fails closed.
+AUTOPROMPT_MODE="${AUTOPROMPT_MODE:-tokensaver}"
+case "$AUTOPROMPT_MODE" in
+  tokensaver) FANOUT="up to 6 live per wave"; L3_TRACKS="parallel" ;;
+  wide|billionaire) FANOUT="wide up to the runtime ceiling"; L3_TRACKS="parallel" ;;
+  custom)
+    CUSTOM_MAX=$(awk -v raw="${AUTOPROMPT_MAX_CONCURRENT:-}" 'BEGIN {
+      if (raw ~ /^[+]?[0-9]+([.][0-9]+)?$/ && (raw + 0) >= 1) printf "%d", int(raw + 0)
+    }')
+    if [ -z "$CUSTOM_MAX" ]; then
+      echo "supervisor: custom mode requires a positive numeric AUTOPROMPT_MAX_CONCURRENT" >&2
+      exit 2
+    fi
+    AUTOPROMPT_MAX_CONCURRENT="$CUSTOM_MAX"
+    export AUTOPROMPT_MAX_CONCURRENT
+    FANOUT="up to $CUSTOM_MAX live per wave (AUTOPROMPT_MAX_CONCURRENT)"
+    L3_TRACKS="parallel"
+    ;;
+  *) AUTOPROMPT_MODE="tokensaver"; FANOUT="up to 6 live per wave"; L3_TRACKS="parallel" ;;
+esac
+# EDIT 23a: the supervisor sits in .../workflow/ next to autoprompt-ledger-check.js,
+# so it derives that resolver's ABSOLUTE path from its own location and exports it to
+# the child (gate.js EDIT 4a reads AUTOPROMPT_LEDGER_CHECK; the SCRIBE/JANITOR briefs
+# interpolate it to RUN `node "$AUTOPROMPT_LEDGER_CHECK" --resolve-prompt-dir ...`).
+# An operator override wins; otherwise the script-dir sibling is used. CDPATH= guards
+# a hostile CDPATH from redirecting the cd, and -- ends option parsing for odd $0.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+LEDGER_CHECK_PATH="${AUTOPROMPT_LEDGER_CHECK:-$SCRIPT_DIR/autoprompt-ledger-check.js}"
+MODEL_CASTING_PATH="${AUTOPROMPT_MODEL_CASTING:-$SCRIPT_DIR/model-casting.js}"
+AGENT_DEFINITIONS_PATH="${AUTOPROMPT_AGENT_DEFINITIONS_DIR:-$SCRIPT_DIR/../agents}"
+AGENT_DEFINITIONS_CLI="${AUTOPROMPT_AGENT_DEFINITIONS_CLI:-$SCRIPT_DIR/agent-definitions-cli.js}"
+# F-SPEED steer-2 B3: the phase-budget verdict CLI sits next to the ledger-check in
+# .../workflow/. An operator override wins; otherwise the script-dir sibling is used.
+# Consulted once per heartbeat tick, scope-phase only, and guarded by [ -r ] so an
+# absent node/module fail-opens to IDLE_TIMEOUT alone (same posture as the ledger-check).
+PHASE_BUDGET_PATH="${AUTOPROMPT_PHASE_BUDGET:-$SCRIPT_DIR/phase-budget.js}"
+# EDIT 23: per-conversation session token, defaulted here for `set -u` safety. The
+# supervisor is the durable producer across relaunches of one conversation: it seeds
+# this token (env > file > empty) before the loop and HARVESTs the resolver-minted
+# marker token after each launch, re-exporting the SAME token so a 2nd prompt lands
+# in the SAME session_NN (SPEC-1 S2). RESUME is always same-session regardless.
+AUTOPROMPT_SESSION_TOKEN="${AUTOPROMPT_SESSION_TOKEN:-}"
+INITIAL_RESUME="${AUTOPROMPT_RESUME:-}"
+case "$(printf '%s' "$INITIAL_RESUME" | tr '[:upper:]' '[:lower:]')" in
+  1|true|yes) INITIAL_RESUME=1 ;;
+  *) INITIAL_RESUME=0 ;;
+esac
+SCOPE_MISSION_BINDING="unbound"
+RUN_NONCE="${AUTOPROMPT_RUN_NONCE:-}"
+LEGACY_SENTINEL="${AUTOPROMPT_LEGACY_SENTINEL:-0}"
+SCOPE_BUDGET_TERMINAL=0
+DRY_RUN=0
+MISSION=""
+
+require_flag_value() {
+  [ "$2" -ge 2 ] && return 0
+  echo "supervisor: $1 requires a value" >&2
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --launcher) require_flag_value "$1" "$#"; LAUNCHER="$2"; shift 2 ;;
+    --cmd) require_flag_value "$1" "$#"; LAUNCH_CMD="$2"; shift 2 ;;
+    --agents) require_flag_value "$1" "$#"; AGENTS_SELECTOR="$2"; shift 2 ;;
+    --model-registry) require_flag_value "$1" "$#"; MODEL_REGISTRY="$2"; shift 2 ;;
+    --provider-capability) require_flag_value "$1" "$#"; PROVIDER_CAPABILITY="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --ledger-dir) require_flag_value "$1" "$#"; LEDGER_DIR="$2"; shift 2 ;;
+    --) shift; MISSION="$*"; break ;;
+    -*) echo "supervisor: unknown flag $1" >&2; exit 2 ;;
+    *) MISSION="$1"; shift ;;
+  esac
+done
+
+if command -v node >/dev/null 2>&1; then
+  SCOPE_MISSION_BINDING=$(printf '%s' "$MISSION" | node -e '
+const crypto = require("crypto")
+let input = ""
+process.stdin.setEncoding("utf8")
+process.stdin.on("data", chunk => { input += chunk })
+process.stdin.on("end", () => process.stdout.write("sha256:" + crypto.createHash("sha256").update(input, "utf8").digest("hex")))
+' 2>/dev/null || echo unbound)
+fi
+
+if [ "$LEGACY_SENTINEL" != "1" ]; then
+  case "$RUN_NONCE" in
+    NONCE-[A-Za-z0-9_-]*) ;;
+    "")
+      if command -v node >/dev/null 2>&1; then
+        RUN_NONCE="NONCE-$(node -e 'process.stdout.write(require("crypto").randomBytes(16).toString("hex"))' 2>/dev/null || true)"
+      fi
+      case "$RUN_NONCE" in
+        NONCE-[A-Za-z0-9_-]*) ;;
+        *) echo "supervisor: could not mint a cryptographically strong activation nonce" >&2; exit 2 ;;
+      esac
+      ;;
+    *) echo "supervisor: AUTOPROMPT_RUN_NONCE is malformed" >&2; exit 2 ;;
+  esac
+fi
+
+# Sentinel matching has two modes. DEFAULT (SENTINEL unset -- every real run):
+# the glob is "$LEDGER_DIR"/DONE-* iterated with the DIR QUOTED and only the *
+# unquoted, so a LEDGER_DIR containing spaces (a Windows path) still matches its
+# own DONE-* sentinel. EXPLICIT (SENTINEL set): the value is word-split into one
+# or more shell globs -- an intentional multi-pattern escape hatch -- so no single
+# path in it may contain spaces. SENTINEL_SET records which mode is active; the
+# unquoted word-split is confined to the explicit case where the user opted in.
+if [ -n "${SENTINEL:-}" ]; then
+  SENTINEL_SET=1
+  SENTINEL_GLOB="$SENTINEL"
+else
+  SENTINEL_SET=0
+  SENTINEL_GLOB="$LEDGER_DIR/DONE-*"   # reference/logging only; never iterated unquoted
+fi
+ESCALATE_FILE="$LEDGER_DIR/SUPERVISOR-ESCALATE"
+SNAPSHOT_FILE="$LEDGER_DIR/.sentinel-snapshot"
+# EDIT 23: the durable session-token store, under the ledger dir so it survives across
+# relaunches of one conversation. Seeded before the loop, harvested after each launch.
+SESSION_TOKEN_FILE="$LEDGER_DIR/.session-token"
+# PLAN-auto-compact-threshold path vars. Discovery is CWD-AGNOSTIC and slug-free: it
+# matches the supervisor's own RUN_CWD (POSIX on gitbash) against each transcript's
+# embedded OS-native "cwd" after normalization -- NO slug derivation, NO launcher edit.
+RUN_CWD="${RUN_CWD:-$PWD}"                              # run cwd; matched against each transcript's embedded "cwd"
+PARENT_TRANSCRIPT="${AUTOPROMPT_PARENT_TRANSCRIPT:-}"  # OPTIONAL explicit override of the parent .jsonl path
+WATERMARK_FILE="$LEDGER_DIR/.context-watermark"        # FALLBACK: parent-emitted watermark (only when transcript unreadable)
+COMPACT_REQUEST_FILE="$LEDGER_DIR/COMPACT-REQUEST"
+COMPACT_STATE_FILE="$LEDGER_DIR/.compaction-state"     # holds: last_compact_epoch + last seen estimate (for cooldown + drop-detection)
+# Scope-budget state under the ledger dir, durable across relaunches. The start epoch
+# does not reset on frontier growth; the reset counter clears once build evidence lands.
+SCOPE_PHASE_START_FILE="$LEDGER_DIR/.scope-phase-start"
+SCOPE_RESETS_FILE="$LEDGER_DIR/.scope-forced-resets"
+SNAPSHOT_OK=0
+mkdir -p "$LEDGER_DIR" 2>/dev/null || true
+
+# Supervisor start epoch (captured BEFORE the first launch). It is no longer part
+# of the stale-sentinel guarantee (see below) -- it is kept only to name the
+# quarantine target (superseded-<epoch>-...) and is read fail-safe: if `date +%s`
+# fails we leave it EMPTY (not 0), so the quarantine name degrades to
+# superseded-unknown-... rather than colliding on a fixed "0".
+SUPERVISOR_START_EPOCH=$(date +%s 2>/dev/null || echo)
+
+# THE stale-sentinel guarantee is a STARTUP SNAPSHOT, not mtime. Before the first
+# launch we record every pre-existing DONE-* PATH into $SNAPSHOT_FILE.
+# sentinel_present then REFUSES any DONE-* whose path is still in that snapshot --
+# regardless of mtime. THE LIVE INVARIANT: a path stays in the snapshot IFF its
+# stale occupant still physically exists. Quarantine renames each pre-existing
+# done:true sentinel aside; on a SUCCESSFUL rename the path is now empty, so it is
+# PRUNED from the snapshot -- the only thing that can later appear there is a
+# genuinely fresh this-run sentinel, which must be honored (otherwise the
+# same-activation DONE-<nonce> - the supervisor-minted CSPRNG nonce re-exported
+# unchanged to every relaunched child, with NO clock - would be vetoed forever
+# and the supervisor would relaunch without end --
+# the livelock). A path whose rename FAILED is NOT pruned: its stale occupant is
+# still there, so it stays vetoed and a failed quarantine degrades to RELAUNCH,
+# never a false halt. The mtime `>=start` belt is gone -- it could not backstop
+# the same-second class, which is the whole reason this defense exists. FAIL-SAFE:
+# if the snapshot cannot be written or read, ALL DONE-* are treated as suspect ->
+# relaunch, never halt.
+
+log() { echo "[supervisor $(date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null)] $*"; }
+
+CASTING_ENABLED=0
+CASTING_JSON=""
+CASTING_OPUS=""
+CASTING_SONNET=""
+CASTING_HAIKU=""
+CASTING_BASE_URL=""
+CASTING_API_KEY_ENV=""
+CASTING_AUTH_TOKEN=""
+CAPABILITY_PROVIDER="omp"
+CAPABILITY_CLI_VERSION="unknown"
+CAPABILITY_PERMISSION_PROFILE="default"
+CAPABILITY_AGENT_DEFINITIONS_HASH="unknown"
+CAPABILITY_CASTING_HASH="unknown"
+CAPABILITY_EFFORT_STATUS="inherited-only"
+CAPABILITY_EFFORT_SOURCE="session-inheritance"
+AUTOPROMPT_CAPABILITY_ATTESTATION="${AUTOPROMPT_CAPABILITY_ATTESTATION:-}"
+
+casting_json_field() {
+  field="$1"
+  printf '%s' "$CASTING_JSON" | node -e '
+let input = ""
+process.stdin.setEncoding("utf8")
+process.stdin.on("data", chunk => { input += chunk })
+process.stdin.on("end", () => {
+  let value = JSON.parse(input)
+  for (const key of process.argv[1].split(".")) value = value == null ? undefined : value[key]
+  if (value != null) process.stdout.write(String(value))
+})
+' "$field"
+}
+
+resolve_model_casting() {
+  control=$(printf '%s' "$AGENTS_SELECTOR" | tr '[:upper:]' '[:lower:]')
+  [ -z "$control" ] || [ "$control" = "off" ] || {
+    command -v node >/dev/null 2>&1 || {
+      echo "supervisor: model casting requires node on PATH" >&2
+      return 2
+    }
+    [ -r "$MODEL_CASTING_PATH" ] || {
+      echo "supervisor: model casting resolver is not readable: $MODEL_CASTING_PATH" >&2
+      return 2
+    }
+
+    set -- "$MODEL_CASTING_PATH" --selector "$AGENTS_SELECTOR"
+    if [ -n "$MODEL_REGISTRY" ]; then
+      set -- "$@" --registry "$MODEL_REGISTRY"
+    fi
+    if [ -n "$PROVIDER_CAPABILITY" ]; then
+      set -- "$@" --provider-capability "$PROVIDER_CAPABILITY"
+    fi
+    CASTING_JSON=$(node "$@") || return 2
+
+    CASTING_ENABLED=$(casting_json_field enabled) || return 2
+    [ "$CASTING_ENABLED" = "true" ] || return 0
+    # omp has no fixed alias pool: verify every tier selector resolved to a
+    # non-empty selector and hand the serialized casting to the child session.
+    for tier in R1 R2 R3 R4 R5; do
+      selector=$(casting_json_field "selectors.$tier") || return 2
+      [ -n "$selector" ] || {
+        echo "supervisor: model casting resolved an empty $tier selector" >&2
+        return 2
+      }
+    done
+  }
+}
+
+sha256_file() {
+  file="$1"
+  node -e '
+const fs = require("fs")
+const crypto = require("crypto")
+const file = process.argv[1]
+process.stdout.write("sha256:" + crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex"))
+' "$file"
+}
+
+sha256_text() {
+  node -e '
+const crypto = require("crypto")
+process.stdin.setEncoding("utf8")
+let input = ""
+process.stdin.on("data", chunk => { input += chunk })
+process.stdin.on("end", () => process.stdout.write("sha256:" + crypto.createHash("sha256").update(input, "utf8").digest("hex")))
+'
+}
+
+hash_agent_definitions() {
+  agents_dir=$(CDPATH= cd -- "$AGENT_DEFINITIONS_PATH" 2>/dev/null && pwd) || return 1
+  node -e '
+const crypto = require("crypto")
+const fs = require("fs")
+const path = require("path")
+const [castingPath, agentsDir] = process.argv.slice(1)
+const files = [castingPath, ...fs.readdirSync(agentsDir)
+  .filter(name => /^ap-.*\.md$/.test(name))
+  .sort()
+  .map(name => path.join(agentsDir, name))]
+const hash = crypto.createHash("sha256")
+for (const file of files) {
+  const label = path.basename(file)
+  hash.update(String(Buffer.byteLength(label, "utf8"))).update(":").update(label)
+  const content = fs.readFileSync(file)
+  hash.update(String(content.length)).update(":").update(content)
+}
+process.stdout.write("sha256:" + hash.digest("hex"))
+' "$MODEL_CASTING_PATH" "$agents_dir"
+}
+
+resolve_agent_definitions_json() {
+  command -v node >/dev/null 2>&1 || {
+    echo "supervisor: activation-scoped agents require node on PATH" >&2
+    return 2
+  }
+  [ -r "$AGENT_DEFINITIONS_CLI" ] || {
+    echo "supervisor: agent-definition converter is not readable: $AGENT_DEFINITIONS_CLI" >&2
+    return 2
+  }
+  AGENT_DEFINITIONS_JSON=$(node "$AGENT_DEFINITIONS_CLI" "$AGENT_DEFINITIONS_PATH") || return 2
+  [ -n "$AGENT_DEFINITIONS_JSON" ] || {
+    echo "supervisor: agent-definition converter returned an empty cast" >&2
+    return 2
+  }
+}
+
+
+resolve_capability_binding() {
+  supplied_attestation="$AUTOPROMPT_CAPABILITY_ATTESTATION"
+  AUTOPROMPT_CAPABILITY_ATTESTATION=""
+  command -v node >/dev/null 2>&1 || return 0
+  CAPABILITY_CLI_VERSION="${AUTOPROMPT_CLI_VERSION:-}"
+  if [ -z "$CAPABILITY_CLI_VERSION" ]; then
+    cli_cmd="${LAUNCH_CMD%% *}"
+    [ -n "$cli_cmd" ] || cli_cmd="$LAUNCHER"
+    if [ -n "$cli_cmd" ] && command -v "$cli_cmd" >/dev/null 2>&1; then
+      CAPABILITY_CLI_VERSION=$($cli_cmd --version 2>/dev/null | head -n1 || true)
+    fi
+  fi
+  [ -n "$CAPABILITY_CLI_VERSION" ] || CAPABILITY_CLI_VERSION="unknown"
+  case " $LAUNCH_CMD " in
+    *" --dangerously-skip-permissions "*) CAPABILITY_PERMISSION_PROFILE="bypass-permissions" ;;
+    *) CAPABILITY_PERMISSION_PROFILE="${AUTOPROMPT_PERMISSION_PROFILE:-default}" ;;
+  esac
+  if [ -r "$MODEL_CASTING_PATH" ]; then
+    CAPABILITY_AGENT_DEFINITIONS_HASH=$(hash_agent_definitions 2>/dev/null || echo unknown)
+  fi
+  CAPABILITY_CASTING_HASH="none"
+  if [ "$CASTING_ENABLED" = "true" ]; then
+    CAPABILITY_CASTING_HASH=$(printf '%s' "$CASTING_JSON" | sha256_text) || return 2
+    CAPABILITY_EFFORT_STATUS=$(casting_json_field effort.status) || return 2
+    CAPABILITY_EFFORT_SOURCE=$(casting_json_field effort.source) || return 2
+  fi
+  if [ "$CAPABILITY_CLI_VERSION" = "unknown" ] || [ "$CAPABILITY_AGENT_DEFINITIONS_HASH" = "unknown" ] || [ -z "$supplied_attestation" ]; then
+    return 0
+  fi
+  AUTOPROMPT_CAPABILITY_ATTESTATION=$(node -e '
+const crypto = require("crypto")
+const raw = process.argv[1]
+const expected = process.argv.slice(2)
+let attestation
+try { attestation = JSON.parse(raw) } catch { process.exit(1) }
+const bindings = [
+  "provider", "cliVersion", "permissionProfile", "agentSelector",
+  "agentDefinitionsHash", "castingHash", "effortStatus", "effortSource",
+]
+const proofBytesOk = typeof attestation.proofBytes === "string" &&
+  attestation.proofBytes !== "" && attestation.proofBytes.length <= 4096
+const proofOk = proofBytesOk &&
+  "sha256:" + crypto.createHash("sha256").update(attestation.proofBytes, "utf8").digest("hex") === attestation.proofHash
+const valid = attestation && attestation.schemaVersion === 4 &&
+  attestation.run === true && attestation.read === true && attestation.write === true &&
+  attestation.proofKind === "disposable-scratch" &&
+  typeof attestation.proofHash === "string" && /^sha256:[a-f0-9]{64}$/.test(attestation.proofHash) &&
+  proofOk &&
+  bindings.every((field, index) => attestation[field] === expected[index])
+if (!valid) process.exit(1)
+process.stdout.write(JSON.stringify(attestation))
+' "$supplied_attestation" "$CAPABILITY_PROVIDER" "$CAPABILITY_CLI_VERSION" \
+  "$CAPABILITY_PERMISSION_PROFILE" "$AGENTS_SELECTOR" "$CAPABILITY_AGENT_DEFINITIONS_HASH" \
+  "$CAPABILITY_CASTING_HASH" "$CAPABILITY_EFFORT_STATUS" "$CAPABILITY_EFFORT_SOURCE" 2>/dev/null) || {
+    AUTOPROMPT_CAPABILITY_ATTESTATION=""
+    return 0
+  }
+}
+
+# Take the startup snapshot of pre-existing DONE-* PATHS, BEFORE the first launch
+# and BEFORE any sentinel check or quarantine. Each path is written on its own
+# line to $SNAPSHOT_FILE. SNAPSHOT_OK=1 marks a trustworthy snapshot; if writing
+# fails we leave it 0, and sentinel_present then treats EVERY DONE-* as suspect
+# (relaunch), the fail-safe direction. The snapshot is the authoritative record
+# of "what was already here", so it is taken from the live glob exactly once.
+snapshot_pre_existing_sentinels() {
+  SNAPSHOT_OK=0
+  # `:` is a POSIX SPECIAL builtin: under dash a redirection error on it aborts
+  # the whole non-interactive shell BEFORE `|| return` can run (bash only
+  # returns). Wrapping it in a subshell isolates the abort to the subshell, so
+  # an unwritable snapshot file degrades to RELAUNCH (fail-safe) under dash too.
+  ( : > "$SNAPSHOT_FILE" ) 2>/dev/null || return
+  if [ "$SENTINEL_SET" -eq 1 ]; then set -- $SENTINEL_GLOB; else set -- "$LEDGER_DIR"/DONE-*; fi
+  for f in "$@"; do
+    [ -e "$f" ] || continue
+    printf '%s\n' "$f" >> "$SNAPSHOT_FILE" 2>/dev/null || return
+  done
+  SNAPSHOT_OK=1
+}
+
+# Is $1 one of the paths recorded in the startup snapshot? Exact whole-line match.
+# If the snapshot is not trustworthy (SNAPSHOT_OK=0) we answer YES for every path
+# -> every DONE-* is treated as pre-existing -> never halts -> relaunch. That is
+# the deliberate fail-safe: a missing/unreadable snapshot must never permit a halt.
+path_in_snapshot() {
+  [ "$SNAPSHOT_OK" -eq 1 ] 2>/dev/null || return 0
+  # If the snapshot file became unreadable/removed after SNAPSHOT_OK was set, the
+  # read loop below would never run and we would fall through to `return 1` (= not
+  # snapshotted = halt ALLOWED) -- fail-OPEN. The header contract says a snapshot
+  # that cannot be READ makes every path suspect, so veto here too (return 0).
+  [ -r "$SNAPSHOT_FILE" ] || return 0
+  while IFS= read -r line; do
+    [ "$line" = "$1" ] && return 0
+  done < "$SNAPSHOT_FILE" 2>/dev/null
+  return 1
+}
+
+# Drop one path from the live snapshot (in $SNAPSHOT_FILE) so a genuinely-fresh
+# sentinel can later reclaim it. Called by quarantine ONLY after a SUCCESSFUL
+# rename: once the stale occupant has been moved aside, the path is empty, so the
+# ONLY thing that can appear there is a fresh sentinel written by THIS run. The
+# activation nonce is minted once (CSPRNG) and re-exported unchanged to every
+# relaunched child (no clock), so a re-launch of the SAME activation writes the
+# SAME path the snapshot recorded -- if
+# the snapshot kept vetoing it, that fresh sentinel would be refused forever and
+# the supervisor would relaunch without end (the livelock). Rewrite is atomic via
+# a temp file. If the rewrite itself fails we KEEP the path (over-veto = relaunch,
+# never a false halt) -- the safe direction. A path whose rename FAILED is never
+# pruned, so it stays vetoed while its stale occupant still physically exists.
+prune_path_from_snapshot() {
+  [ "$SNAPSHOT_OK" -eq 1 ] 2>/dev/null || return 0
+  pruned="$SNAPSHOT_FILE.prune"
+  ( : > "$pruned" ) 2>/dev/null || return 0
+  while IFS= read -r line; do
+    [ "$line" = "$1" ] && continue
+    printf '%s\n' "$line" >> "$pruned" 2>/dev/null || { rm -f "$pruned" 2>/dev/null; return 0; }
+  done < "$SNAPSHOT_FILE" 2>/dev/null
+  mv "$pruned" "$SNAPSHOT_FILE" 2>/dev/null || rm -f "$pruned" 2>/dev/null
+}
+
+sentinel_json_matches() {
+  file="$1"
+  expected_nonce="$2"
+  node -e '
+const fs = require("fs")
+let value
+try { value = JSON.parse(fs.readFileSync(process.argv[1], "utf8")) }
+catch { process.exit(1) }
+process.exit(value && value.done === true && value.nonce === process.argv[2] ? 0 : 1)
+' "$file" "$expected_nonce" >/dev/null 2>&1
+}
+
+sentinel_present() {
+  if [ "$LEGACY_SENTINEL" != "1" ]; then
+    f="$LEDGER_DIR/DONE-$RUN_NONCE"
+    [ -f "$f" ] || return 1
+    path_in_snapshot "$f" && return 1
+    sentinel_json_matches "$f" "$RUN_NONCE"
+    return $?
+  fi
+  if [ "$SENTINEL_SET" -eq 1 ]; then set -- $SENTINEL_GLOB; else set -- "$LEDGER_DIR"/DONE-*; fi
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    grep -q '"done"[[:space:]]*:[[:space:]]*true' "$f" 2>/dev/null || continue
+    path_in_snapshot "$f" && continue
+    return 0
+  done
+  return 1
+}
+
+# At startup, BEFORE the first launch, QUARANTINE every pre-existing done:true
+# DONE-* sentinel: rename it aside to <dir>/superseded-<start-epoch>-<name> so the
+# new name no longer starts with DONE- and thus no longer matches the live DONE-*
+# glob -- it cannot halt this fresh mission. (Prefixing, NOT suffixing: a
+# DONE-X.superseded-N name would STILL match DONE-* and re-trip the same-second
+# halt, so the leading DONE- must be displaced.) This is the PRIMARY fix for the
+# whole stale-sentinel class -- after quarantine there is no leftover sentinel
+# left to race, so a same-second / zero-epoch / sub-second mtime collision is
+# moot. We RENAME, never delete (deleting artifacts is the JANITOR's job; never
+# silently rm operator files) and log a loud line naming each quarantined file.
+# On a SUCCESSFUL rename the path is pruned from the live snapshot so a genuine
+# fresh same-activation DONE-<nonce> (the minted nonce is re-exported to every
+# relaunched child, no clock) can reclaim it -- else the snapshot would veto that
+# fresh sentinel forever and the supervisor would relaunch without end (livelock).
+# If a rename FAILS (read-only dir / permissions / clobber) the leftover DONE-*
+# still matches the live glob, its path is NOT pruned, and sentinel_present
+# unconditionally refuses it. A failed rename degrades to RELAUNCH, never a halt.
+# Net invariant: the snapshot vetoes a path IFF its stale occupant still exists.
+quarantine_stale_sentinels() {
+  if [ "$SENTINEL_SET" -eq 1 ]; then set -- $SENTINEL_GLOB; else set -- "$LEDGER_DIR"/DONE-*; fi
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    if grep -q '"done"[[:space:]]*:[[:space:]]*true' "$f" 2>/dev/null; then
+      dir=$(dirname "$f"); base=$(basename "$f")
+      quarantined="$dir/superseded-${SUPERVISOR_START_EPOCH:-unknown}-$base"
+      if mv "$f" "$quarantined" 2>/dev/null; then
+        # The stale occupant is gone, so this path can no longer hold anything
+        # but a FRESH this-run sentinel. Drop it from the live snapshot so the
+        # same-activation DONE-<nonce> is reclaimable -- otherwise the
+        # snapshot would veto the genuine fresh sentinel forever (the livelock).
+        prune_path_from_snapshot "$f"
+        log "QUARANTINE: pre-existing DONE-sentinel '$f' (from a prior run) renamed to '$quarantined' so it cannot halt this fresh mission. It is preserved, not deleted."
+      else
+        log "WARNING: could not quarantine pre-existing DONE-sentinel '$f' -- it is IGNORED for halting by the startup snapshot and will not stop this mission. Remove it if it is no longer relevant."
+      fi
+    fi
+  done
+}
+
+# The frontier marker: how much forward progress exists on disk. It is a
+# MONOTONIC progress counter, not a success counter - it counts EVERY gate
+# artifact across the whole lifecycle (roadmap/scouts, plan draft/review/
+# fresh-verify, plan-final, impl, impl-review, verify, signoff, sweep-round,
+# arbiter, goal-check). Versioned (-vN), per-feature (Fx-), retained-scout, and
+# per-round artifacts multiply as work proceeds, so a run that is advancing through
+# the pre-build scope phase, which writes roadmap and retained scout evidence
+# long before the first plan-final - bumps the count every relaunch and resets
+# the poison window. A run that relaunches writing NOTHING new keeps the count
+# flat and still trips poison. Counting only plan-final/verify (the old globs)
+# pinned the count at 0 for that whole early phase and KILLED healthy runs.
+frontier_count() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    # In dry-run, a poison fake never advances; a healthy fake bumps a counter file.
+    if [ "${FAKE_POISON:-0}" = "1" ]; then echo 0; return; fi
+    if [ -f "$LEDGER_DIR/.fake-frontier" ]; then cat "$LEDGER_DIR/.fake-frontier"; else echo 0; fi
+    return
+  fi
+  count=0
+  # Three artifact layouts must ALL be counted, or a run driven by one of them is
+  # invisible to the frontier and a healthy-long run trips POISON:
+  #   prose/agent (SKILL.md/GATES.md): autoprompt/prompt-NNN-<slug>/artifacts/
+  #   harness (autoprompt-gate.js ARTIFACT_DIR): autoprompt/.artifacts/<run-tag>/
+  #   session ledger (SPEC-1 SCRIBE): autoprompt/session_NN/prompt_NN-<slug>/ and
+  #     its optional artifacts/ subdir. The per-prompt ledger .md files (BRIEF/
+  #     GATELOG/COVERAGE...) count as forward progress (monotonic; same rationale as
+  #     the multiplying-artifacts globs), so a run advancing ONLY in the new layout
+  #     is never falsely poisoned.
+  # The leading-dot harness dir is NOT matched by "*" (POSIX glob skips dotfiles),
+  # and its nesting differs, so it needs its own glob - which also stops the prose
+  # glob from double-counting it. Ledger-root prose files (BRIEF/PLAN/GATELOG...)
+  # live ONE level above artifacts/ so they are not counted by the first two globs;
+  # the session-ledger glob counts them at their nested depth. The DONE sentinel
+  # lives at the ledger root, not under any artifacts/ dir. Plain shell `for` over an
+  # unmatched glob leaves the literal pattern (nullglob off); `[ -f ]` filters it.
+  for f in "$LEDGER_DIR"/*/artifacts/*.md \
+           "$LEDGER_DIR"/.artifacts/*/*.md \
+           "$LEDGER_DIR"/session_*/prompt_*/artifacts/*.md \
+           "$LEDGER_DIR"/session_*/prompt_*/*.md; do
+    [ -f "$f" ] && count=$((count + 1))
+  done
+  echo "$count"
+}
+
+# The durable pre-execution clock starts before the roadmap author and remains active
+# through every plan/review/fresh-verify revision. Only real G4 implementation evidence
+# proves execution started; planning artifacts are never execution progress.
+scope_phase_elapsed() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    [ -n "${FAKE_SCOPE_ELAPSED:-}" ] && echo "$FAKE_SCOPE_ELAPSED"
+    return
+  fi
+  for f in "$LEDGER_DIR"/.artifacts/*/*-impl-v*.md \
+           "$LEDGER_DIR"/*/artifacts/*-impl-v*.md \
+           "$LEDGER_DIR"/session_*/prompt_*/artifacts/*-impl-v*.md; do
+    [ -f "$f" ] && {
+      rm -f "$SCOPE_PHASE_START_FILE" "$SCOPE_RESETS_FILE" \
+        "$LEDGER_DIR/SCOPE-CONVERGE-REQUEST" \
+        "$LEDGER_DIR/SCOPE-BUDGET-BREACH" 2>/dev/null
+      return
+    }
+  done
+  now_s=$(date +%s 2>/dev/null || echo 0)
+  start_s=""
+  stored_binding=""
+  if [ -r "$SCOPE_PHASE_START_FILE" ]; then
+    start_s=$(awk 'NR==1{print $1; exit}' "$SCOPE_PHASE_START_FILE" 2>/dev/null || echo)
+    stored_binding=$(awk 'NR==1{print $2; exit}' "$SCOPE_PHASE_START_FILE" 2>/dev/null || echo)
+  fi
+  case "$start_s" in (*[!0-9]*|"") start_s="" ;; esac
+  if [ "$stored_binding" != "$SCOPE_MISSION_BINDING" ]; then
+    start_s=""
+    rm -f "$LEDGER_DIR/SCOPE-CONVERGE-REQUEST" \
+      "$LEDGER_DIR/SCOPE-BUDGET-BREACH" "$SCOPE_RESETS_FILE" 2>/dev/null
+  fi
+  if [ -z "$start_s" ] || [ "$start_s" -le 0 ] 2>/dev/null; then
+    start_s="$now_s"
+    printf '%s %s\n' "$start_s" "$SCOPE_MISSION_BINDING" \
+      > "$SCOPE_PHASE_START_FILE.tmp" 2>/dev/null \
+      && mv "$SCOPE_PHASE_START_FILE.tmp" "$SCOPE_PHASE_START_FILE" 2>/dev/null
+  fi
+  el=$((now_s - start_s))
+  [ "$el" -lt 0 ] 2>/dev/null && el=0
+  echo "$el"
+}
+
+# Honest retained scope evidence. New runs expose roadmap-scout-N; legacy resumes
+# expose scope-<key>. Missing evidence stays missing rather than being invented.
+scope_landed_angles() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "${FAKE_SCOPE_LANDED:-}"
+    return
+  fi
+  keys=""
+  for f in "$LEDGER_DIR"/.artifacts/*/roadmap-scout-*.md \
+           "$LEDGER_DIR"/*/artifacts/roadmap-scout-*.md \
+           "$LEDGER_DIR"/session_*/prompt_*/artifacts/roadmap-scout-*.md \
+           "$LEDGER_DIR"/.artifacts/*/scope-*.md \
+           "$LEDGER_DIR"/*/artifacts/scope-*.md \
+           "$LEDGER_DIR"/session_*/prompt_*/artifacts/scope-*.md; do
+    [ -f "$f" ] || continue
+    base=$(basename "$f")
+    case "$base" in
+      roadmap-scout-*.md) key=$(printf '%s' "$base" | sed -e 's/\.md$//') ;;
+      *) key=$(printf '%s' "$base" | sed -e 's/^scope-//' -e 's/-v[0-9]*\.md$//' -e 's/\.md$//') ;;
+    esac
+    [ -n "$key" ] || continue
+    case " $keys " in (*" $key "*) ;; (*) keys="$keys $key" ;; esac
+  done
+  printf '%s' "$keys" | sed -e 's/^ *//' -e 's/ *$//' -e 's/  */,/g'
+}
+
+# Age (seconds) of the pending SCOPE-CONVERGE-REQUEST, or 0 when none exists.
+scope_converge_request_age() {
+  req="$LEDGER_DIR/SCOPE-CONVERGE-REQUEST"
+  [ -r "$req" ] || { echo 0; return; }
+  now_s=$(date +%s 2>/dev/null || echo 0)
+  req_ts=$(awk 'NR==1{print $1+0; exit}' "$req" 2>/dev/null || echo 0)
+  case "$req_ts" in (*[!0-9]*|"") req_ts=0 ;; esac
+  age=$((now_s - req_ts))
+  [ "$age" -lt 0 ] 2>/dev/null && age=0
+  echo "$age"
+}
+
+# === PLAN-auto-compact-threshold: proactive supervisor-fired compaction ============
+# The supervisor cannot introspect the live CLI's RAM, and the parent cannot /compact
+# itself. So the supervisor OBSERVES the parent's context size from disk (the parent's
+# own session transcript; watermark/ledger-byte fallbacks) and, on crossing COMPACT_AT,
+# writes COMPACT-REQUEST then -- on grace timeout -- fires a process-group kill so the
+# outer relaunch loop RESUMEs a fresh, smaller context that re-reads ANCHOR.md.
+
+# Canonicalize a path for cross-platform cwd comparison (win32/gitbash AND posix):
+# lowercase; collapse \ and / runs to a single /; map a leading "<drive>:" to "/<drive>".
+# Worked: "/c/Users/x"->"/c/users/x"; "C:\\Users\\x"->"c:\\users\\x"->"c:/users/x"->"/c/users/x".
+canon_path() {  # $1 = raw path ; echoes canonical form
+  printf '%s' "$1" \
+    | tr 'A-Z\\' 'a-z/' \
+    | sed -e 's#//*#/#g' -e 's#^\([a-z]\):#/\1#'
+}
+
+# Find the live parent session .jsonl. Slug-free: matches RUN_CWD against each
+# transcript's embedded "cwd" after canonicalization. Single-level glob excludes nested
+# subagent/tool-result transcripts. Echoes the path of the newest cwd-matching transcript
+# whose mtime is >= the child launch epoch, or nothing.
+find_parent_transcript() {  # $1 = child_launch_epoch
+  if [ -n "$PARENT_TRANSCRIPT" ] && [ -r "$PARENT_TRANSCRIPT" ]; then echo "$PARENT_TRANSCRIPT"; return; fi
+  cfg="${PI_CODING_AGENT_DIR:-$HOME/.omp/agent}"
+  want=$(canon_path "$RUN_CWD")
+  newest=""; newest_mt=0
+  for f in "$cfg"/sessions/*/*.jsonl; do
+    [ -f "$f" ] || continue
+    mt=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
+    [ "$mt" -lt "${1:-0}" ] 2>/dev/null && continue          # stale prior session
+    tcwd=$(grep -o '"cwd":"[^"]*"' "$f" 2>/dev/null | head -n1 | sed 's/.*"cwd":"//; s/"$//')
+    [ -n "$tcwd" ] || continue
+    tcwd=$(printf '%s' "$tcwd" | sed 's/\\\\/\\/g')          # un-escape JSON doubled backslashes
+    [ "$(canon_path "$tcwd")" = "$want" ] || continue        # different project session -> skip
+    [ "$mt" -gt "$newest_mt" ] 2>/dev/null && { newest="$f"; newest_mt=$mt; }
+  done
+  [ -n "$newest" ] && echo "$newest"
+}
+
+# Read the PARENT's context size in three tiers; echoes an integer (0 = unavailable).
+#   TIER 1: parse the parent session .jsonl usage fields (real token accounting), with a
+#           same-source byte proxy of THAT .jsonl when usage is unparseable.
+#   TIER 2: parent-emitted .context-watermark (stale-rejected).
+#   TIER 3: coarse ledger-byte proxy (NOT parent context -- last resort).
+# Honors FAKE_WATERMARK in dry-run so the poll loop is testable.
+read_context_estimate() {  # $1 = child_launch_epoch (for staleness)
+  if [ "$DRY_RUN" -eq 1 ]; then
+    if [ -n "${FAKE_WATERMARK:-}" ]; then echo "$FAKE_WATERMARK"; else echo 0; fi
+    return
+  fi
+  tx=$(find_parent_transcript "${1:-0}")
+  if [ -n "$tx" ] && [ -r "$tx" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      est=$(jq -r 'select(.message.usage) | .message.usage
+                   | ((.input_tokens//0)+(.cache_read_input_tokens//0)+(.cache_creation_input_tokens//0))' \
+               "$tx" 2>/dev/null | awk 'NF{v=$1} END{if(v!="")print v}')
+    else
+      est=$(grep -o '"usage":[^}]*}' "$tx" 2>/dev/null | tail -n1 \
+            | grep -oE '"(input_tokens|cache_read_input_tokens|cache_creation_input_tokens)":[0-9]+' \
+            | awk -F: '{s+=$2} END{if(s>0)print s}')
+    fi
+    case "$est" in (*[0-9]*) [ "$est" -gt 0 ] 2>/dev/null && { echo "$est"; return; } ;; esac
+    sz=$(wc -c < "$tx" 2>/dev/null || echo 0)
+    [ "$sz" -gt 0 ] 2>/dev/null && { echo $((sz / BYTES_PER_TOKEN)); return; }
+  fi
+  if [ -r "$WATERMARK_FILE" ]; then
+    wm_tok=$(awk 'NR==1{print $1; exit}' "$WATERMARK_FILE" 2>/dev/null || echo)
+    wm_ts=$(awk 'NR==1{print $2; exit}'  "$WATERMARK_FILE" 2>/dev/null || echo)
+    case "$wm_tok" in (*[0-9]*) ;; (*) wm_tok="" ;; esac
+    if [ -n "$wm_tok" ] && { [ -z "$wm_ts" ] || [ "${wm_ts:-0}" -ge "${1:-0}" ] 2>/dev/null; }; then
+      echo "$wm_tok"; return
+    fi
+  fi
+  bytes=0
+  for f in "$LEDGER_DIR"/session_*/prompt_*/*.md "$LEDGER_DIR"/session_*/prompt_*/artifacts/*.md "$LEDGER_DIR"/*/artifacts/*.md; do
+    [ -f "$f" ] || continue
+    sz=$(wc -c < "$f" 2>/dev/null || echo 0); bytes=$((bytes + sz))
+  done
+  echo $((bytes / BYTES_PER_TOKEN))
+}
+
+# Detect a harness-fired (~400k) compaction so the supervisor does NOT then double-fire:
+# a sharp estimate DROP across ticks arms the cooldown and clears any pending request.
+# Records "<epoch> <est>" into COMPACT_STATE_FILE each tick. $1=now $2=current_est.
+note_external_compaction() {  # $1=now $2=current_est
+  prev_est=0
+  [ -r "$COMPACT_STATE_FILE" ] && prev_est=$(awk 'NR==1{print $2+0; exit}' "$COMPACT_STATE_FILE" 2>/dev/null || echo 0)
+  if [ "${prev_est:-0}" -gt 0 ] 2>/dev/null \
+     && [ $(( prev_est - ${2:-0} )) -ge "$EXTERNAL_COMPACT_DELTA" ] 2>/dev/null; then
+    printf '%s %s external_compaction\n' "$1" "${2:-0}" > "$COMPACT_STATE_FILE.tmp" 2>/dev/null \
+      && mv "$COMPACT_STATE_FILE.tmp" "$COMPACT_STATE_FILE" 2>/dev/null
+    rm -f "$COMPACT_REQUEST_FILE" 2>/dev/null || true
+    log "EXTERNAL COMPACTION detected: context estimate dropped ${prev_est}->${2:-0} (>=${EXTERNAL_COMPACT_DELTA}) - arming cooldown and clearing any pending COMPACT-REQUEST (no double-fire)."
+    return 0
+  fi
+  # record the current estimate for next tick's drop comparison (keep the last_compact epoch field 0 unless set)
+  last_compact=0; [ -r "$COMPACT_STATE_FILE" ] && last_compact=$(awk 'NR==1{print $1+0; exit}' "$COMPACT_STATE_FILE" 2>/dev/null || echo 0)
+  printf '%s %s\n' "$last_compact" "${2:-0}" > "$COMPACT_STATE_FILE.tmp" 2>/dev/null \
+    && mv "$COMPACT_STATE_FILE.tmp" "$COMPACT_STATE_FILE" 2>/dev/null
+  return 1
+}
+
+# Decide whether to request/force a compaction. Sets COMPACT_FORCE=1 when a written
+# request has gone unhonored past COMPACT_GRACE. Returns 0 when the caller should act
+# (request written OR force due), 1 otherwise. Guards: cooldown, in-flight request,
+# external-compaction detection -- so one context fill triggers at most one compaction.
+maybe_request_compaction() {  # $1=child_launch_epoch $2=now
+  COMPACT_FORCE=0
+  est=$(read_context_estimate "$1")
+  note_external_compaction "$2" "$est" && return 1   # harness already compacted -> nothing to do
+  last_compact=0; [ -r "$COMPACT_STATE_FILE" ] && last_compact=$(awk 'NR==1{print $1+0; exit}' "$COMPACT_STATE_FILE" 2>/dev/null || echo 0)
+  if [ "${last_compact:-0}" -gt 0 ] 2>/dev/null && [ $(( $2 - last_compact )) -lt "$COMPACT_COOLDOWN" ] 2>/dev/null; then
+    return 1
+  fi
+  if [ -f "$COMPACT_REQUEST_FILE" ]; then
+    req_ts=$(awk 'NR==1{print $1+0; exit}' "$COMPACT_REQUEST_FILE" 2>/dev/null || echo 0)
+    if [ $(( $2 - req_ts )) -ge "$COMPACT_GRACE" ] 2>/dev/null; then COMPACT_FORCE=1; return 0; fi
+    return 1
+  fi
+  if [ "$est" -ge "$COMPACT_AT" ] 2>/dev/null; then
+    printf '%s proactive est=%s threshold=%s\n' "$2" "$est" "$COMPACT_AT" > "$COMPACT_REQUEST_FILE.tmp" 2>/dev/null \
+      && mv "$COMPACT_REQUEST_FILE.tmp" "$COMPACT_REQUEST_FILE" 2>/dev/null \
+      && log "COMPACT-REQUEST written: context est=${est} tokens >= AUTOPROMPT_COMPACT_AT=${COMPACT_AT}. Parent will checkpoint+compact at its next gate boundary (not a wipe, not a stop)."
+    return 0
+  fi
+  return 1
+}
+
+# Kill the child's whole process GROUP so a wedged parent leaves NO orphaned subagent.
+# SIGTERM the group, escalate to SIGKILL after a short grace. Falls back to a plain PID
+# kill when job control / negative-pgid signaling is unavailable.
+kill_tree() {  # $1 = child pid
+  pid="$1"
+  [ -n "$pid" ] || return 0
+  if command -v taskkill.exe >/dev/null 2>&1; then
+    win_pid=$(ps -W -p "$pid" -l 2>/dev/null | awk 'NR==2{print $4; exit}')
+    case "$win_pid" in (*[!0-9]*|"") win_pid="" ;; esac
+    if [ -n "$win_pid" ] && taskkill.exe /T /F /PID "$win_pid" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+  descendants=""
+  pending="$pid"
+  while [ -n "$pending" ]; do
+    parent=${pending%% *}
+    case "$pending" in (*" "*) pending=${pending#* } ;; (*) pending="" ;; esac
+    children=$(ps -ef 2>/dev/null | awk -v parent="$parent" 'NR>1 && $3 == parent { print $2 }')
+    for child in $children; do
+      case " $descendants " in (*" $child "*) ;; (*) descendants="$child $descendants"; pending="$pending $child" ;; esac
+    done
+    pending=$(printf '%s' "$pending" | sed 's/^ *//')
+  done
+  for victim in $descendants "$pid"; do kill -TERM "$victim" 2>/dev/null || true; done
+  i=0
+  while [ "$i" -lt 4 ] && kill -0 "$pid" 2>/dev/null; do sleep 0.5 2>/dev/null || sleep 1; i=$((i + 1)); done
+  for victim in $descendants "$pid"; do
+    kill -0 "$victim" 2>/dev/null && kill -KILL "$victim" 2>/dev/null || true
+  done
+}
+
+# Run the real or fake launcher once; return its exit code.
+#
+# HEARTBEAT (PLAN-idle-watchdog V3): the child is launched in the BACKGROUND on
+# BOTH the real exec AND the dry-run fake path, so a SINGLE poll loop watches
+# liveness + frontier-COUNT staleness regardless of path (blocker 2: the poll loop
+# is genuinely exercised under --dry-run). While the child is alive, if
+# frontier_count has NOT grown beyond last_seen within IDLE_TIMEOUT and no sentinel
+# exists, the run is ALIVE-BUT-IDLE -> kill the child so the outer relaunch loop
+# RESUMEs it (the automatic CONTINUE for an idle agent). This is DISTINCT from the
+# EXIT-keyed poison guard and FEEDS it: a heartbeat kill that produced no count
+# growth is recorded by the outer loop as a no-progress restart, so a wedged child
+# still trips POISON after MAX_RESTARTS (anti-thrash, §4.5 - no second uncapped
+# relaunch path). LAUNCH_INDEX is incremented in the PARENT scope here, before the
+# fork, so only the exec / fake-work is backgrounded.
+LAUNCH_INDEX=0
+run_launcher() {
+  LAUNCH_INDEX=$((LAUNCH_INDEX + 1))
+  child_launch_epoch=$(date +%s 2>/dev/null || echo 0)
+  if [ "$DRY_RUN" -eq 0 ]; then
+    stored_binding=""
+    [ -r "$SCOPE_PHASE_START_FILE" ] && stored_binding=$(awk 'NR==1{print $2; exit}' "$SCOPE_PHASE_START_FILE" 2>/dev/null || echo)
+    if [ "$stored_binding" != "$SCOPE_MISSION_BINDING" ]; then
+      rm -f "$LEDGER_DIR/SCOPE-CONVERGE-REQUEST" \
+        "$LEDGER_DIR/SCOPE-BUDGET-BREACH" "$SCOPE_RESETS_FILE" 2>/dev/null
+      printf '%s %s\n' "$child_launch_epoch" "$SCOPE_MISSION_BINDING" \
+        > "$SCOPE_PHASE_START_FILE.tmp" 2>/dev/null \
+        && mv "$SCOPE_PHASE_START_FILE.tmp" "$SCOPE_PHASE_START_FILE" 2>/dev/null
+    fi
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    # Pop the next exit code from FAKE_EXITS in the PARENT (LAUNCH_INDEX-indexed);
+    # default 0 once the list is spent. The fork below exits with this code so the
+    # parent's `wait` retrieves it.
+    set -- ${FAKE_EXITS:-0}
+    idx="$LAUNCH_INDEX"
+    code=0; n=0
+    for c in "$@"; do n=$((n + 1)); if [ "$n" -eq "$idx" ]; then code="$c"; fi; done
+    (
+      # The backgrounded fake child. Optionally write the sentinel BEFORE exit
+      # (models the JANITOR having written it), advance the frontier unless poisoned,
+      # then optionally STAY ALIVE (FAKE_CHILD_ALIVE seconds) so the poll loop has a
+      # real PID to kill -0 / kill and a real .fake-frontier to read as stale. Exit
+      # with the popped code so `wait` recovers it.
+      if [ -n "${FAKE_SENTINEL_AFTER:-}" ] && [ "$idx" -ge "$FAKE_SENTINEL_AFTER" ]; then
+        printf '{"done": true, "nonce": "FAKE", "verdict": "fake done", "ts": "now"}' \
+          > "$LEDGER_DIR/DONE-FAKE.tmp" && mv "$LEDGER_DIR/DONE-FAKE.tmp" "$LEDGER_DIR/DONE-FAKE"
+      fi
+      if [ "${FAKE_POISON:-0}" != "1" ]; then
+        cur=0; [ -f "$LEDGER_DIR/.fake-frontier" ] && cur=$(cat "$LEDGER_DIR/.fake-frontier")
+        echo $((cur + 1)) > "$LEDGER_DIR/.fake-frontier"
+      fi
+      sleep "${FAKE_CHILD_ALIVE:-0}" 2>/dev/null || true
+      exit "$code"
+    ) &
+  else
+    # Launch one is fresh unless the operator explicitly invoked this supervisor as a
+    # resume. Relaunches always export AUTOPROMPT_RESUME=1.
+    # When LAUNCH_CMD is set it is used VERBATIM (word-split into command + args,
+    # mission appended) so a fresh user can pass their real CLI; otherwise the
+    # bare LAUNCHER label is exec'd as before.
+    # Neutralize nothing: omp has no subagent model pin environment variable.
+    # The resolved casting (selectors + effort) travels to the child session as
+    # AUTOPROMPT_AGENT_CASTING; agents=off exports nothing and every worker
+    # inherits the child session's active model.
+    (
+      export AUTOPROMPT_UNATTENDED=1
+      if [ "$LAUNCH_INDEX" -gt 1 ] || [ "$INITIAL_RESUME" -eq 1 ]; then
+        export AUTOPROMPT_RESUME=1
+      else
+        unset AUTOPROMPT_RESUME
+      fi
+      export AUTOPROMPT_MODE
+      if [ "$LEGACY_SENTINEL" != "1" ]; then export AUTOPROMPT_RUN_NONCE="$RUN_NONCE"; fi
+      export AUTOPROMPT_LEDGER_CHECK="$LEDGER_CHECK_PATH"
+      if [ -n "$AUTOPROMPT_SESSION_TOKEN" ]; then
+        export AUTOPROMPT_SESSION_TOKEN
+      else
+        unset AUTOPROMPT_SESSION_TOKEN
+      fi
+      export AUTOPROMPT_AGENTS="$AGENTS_SELECTOR"
+      export AUTOPROMPT_PROVIDER="$CAPABILITY_PROVIDER"
+      export AUTOPROMPT_CLI_VERSION="$CAPABILITY_CLI_VERSION"
+      export AUTOPROMPT_PERMISSION_PROFILE="$CAPABILITY_PERMISSION_PROFILE"
+      export AUTOPROMPT_AGENT_DEFINITIONS_HASH="$CAPABILITY_AGENT_DEFINITIONS_HASH"
+      export AUTOPROMPT_CASTING_HASH="$CAPABILITY_CASTING_HASH"
+      if [ -n "$AUTOPROMPT_CAPABILITY_ATTESTATION" ]; then
+        export AUTOPROMPT_CAPABILITY_ATTESTATION
+      else
+        unset AUTOPROMPT_CAPABILITY_ATTESTATION
+      fi
+      if [ "$CASTING_ENABLED" = "true" ]; then
+        export AUTOPROMPT_AGENT_CASTING="$CASTING_JSON"
+      fi
+      if [ -n "$LAUNCH_CMD" ]; then
+        # shellcheck disable=SC2086 # operator command is intentionally split into argv.
+        set -- $LAUNCH_CMD
+      else
+        set -- "$LAUNCHER"
+      fi
+      [ "$#" -gt 0 ] || exit 127
+      "$@" --agents "$AGENT_DEFINITIONS_JSON" "$MISSION"
+    ) &
+  fi
+  child_pid=$!
+  # NOTE on `date +%s`: used ONLY for the elapsed-wall-clock comparison
+  # (now - last_progress), exactly as the existing relaunch loop already does - it is
+  # NOT a file probe, and its `|| echo 0` fallback only pins now/last_progress to the
+  # same baseline, which can at worst DELAY the timeout, never falsely fire it. The
+  # progress decision is purely the integer frontier-count delta (blocker 3: no mtime
+  # probe, so a healthy progressing run is NEVER mischaracterized as stale).
+  last_progress=$(date +%s 2>/dev/null || echo 0)
+  last_seen_count=$(frontier_count)
+  # The poll loop wakes on a RESPONSIVE slice (min of HEARTBEAT_INTERVAL and 1s) so a
+  # child that EXITS is detected promptly instead of after a full HEARTBEAT_INTERVAL
+  # block - the staleness evaluation still only runs once per HEARTBEAT_INTERVAL of
+  # elapsed wall-clock. This keeps a fast-exiting (real or dry-run) child from pinning
+  # the loop for the whole interval while preserving the exact heartbeat cadence.
+  poll_slice="$HEARTBEAT_INTERVAL"; [ "$poll_slice" -gt 1 ] 2>/dev/null && poll_slice=1
+  last_eval="$last_progress"
+  while kill -0 "$child_pid" 2>/dev/null; do
+    sleep "$poll_slice" 2>/dev/null || true
+    sentinel_present && break        # the run finished while we slept; let the outer loop halt cleanly
+    now=$(date +%s 2>/dev/null || echo 0)
+    [ $((now - last_eval)) -ge "$HEARTBEAT_INTERVAL" ] || continue   # not yet a heartbeat tick
+    last_eval="$now"
+    cur_count=$(frontier_count)
+    if [ "$cur_count" -gt "$last_seen_count" ]; then
+      last_seen_count="$cur_count"; last_progress="$now"          # frontier advanced -> healthy, reset
+    elif [ $((now - last_progress)) -ge "$IDLE_TIMEOUT" ]; then
+      log "HEARTBEAT: no frontier progress for >=${IDLE_TIMEOUT}s while alive and no sentinel - killing to relaunch with RESUME (auto-continue an idle agent)."
+      kill "$child_pid" 2>/dev/null || true; break
+    fi
+    # PLAN-auto-compact-threshold: proactive supervisor-fired compaction check. Writes
+    # COMPACT-REQUEST when the externally-observed context size crosses COMPACT_AT; on a
+    # request unhonored past COMPACT_GRACE (parent wedged) forces the reset.
+    if maybe_request_compaction "$child_launch_epoch" "$now"; then
+      if [ "$COMPACT_FORCE" -eq 1 ]; then
+        log "COMPACT FALLBACK: request unhonored for >=${COMPACT_GRACE}s (parent likely wedged) - recording a .forced-reset marker, then killing the WHOLE child process group so no subagent is orphaned; the outer loop RESUMEs from the SCRIBE-refreshed ANCHOR.md."
+        printf '%s forced est_unhonored grace=%s\n' "$now" "$COMPACT_GRACE" > "$COMPACT_STATE_FILE.forced.tmp" 2>/dev/null \
+          && mv "$COMPACT_STATE_FILE.forced.tmp" "$LEDGER_DIR/.forced-reset" 2>/dev/null
+        printf '%s forced\n' "$now" > "$COMPACT_STATE_FILE.tmp" 2>/dev/null \
+          && mv "$COMPACT_STATE_FILE.tmp" "$COMPACT_STATE_FILE" 2>/dev/null
+        rm -f "$COMPACT_REQUEST_FILE" 2>/dev/null || true
+        kill_tree "$child_pid"
+        break
+      fi
+    fi
+    # F-SPEED steer-2 B3: PHASE WALL-CLOCK BUDGET check. Once per tick, when the SCOPE
+    # phase is active (ROADMAP/scout evidence present, no build artifact yet), consult phase-budget.js.
+    # It is anchored to scope ENTRY and NOT reset by frontier growth, so it fires on the
+    # progressing-but-slow 30-min scope IDLE_TIMEOUT can never bound. Fail-open: an absent
+    # node/module skips the block (guarded by [ -r ]) and the run proceeds on IDLE_TIMEOUT.
+    scope_el=$(scope_phase_elapsed)
+    if [ -n "$scope_el" ] && [ -r "$PHASE_BUDGET_PATH" ]; then
+      req_age=$(scope_converge_request_age)
+      prior=$(awk 'NR==1{print $1+0; exit}' "$SCOPE_RESETS_FILE" 2>/dev/null || echo 0)
+      case "$prior" in (*[!0-9]*|"") prior=0 ;; esac
+      landed=$(scope_landed_angles)
+      node "$PHASE_BUDGET_PATH" --verdict --phase scope --elapsed "$scope_el" \
+           --soft "$SCOPE_SOFT_SEC" --hard "$SCOPE_HARD_SEC" --request-age "$req_age" \
+           --grace "$SCOPE_GRACE_SEC" --prior-resets "$prior" --max-resets "$MAX_SCOPE_RESETS" \
+           --landed "$landed" >/dev/null 2>&1
+      case $? in
+        10)  # SOFT breach: write the converge heads-up ONCE (idempotent), keep running.
+            if [ ! -f "$LEDGER_DIR/SCOPE-CONVERGE-REQUEST" ]; then
+              printf '%s soft scope budget: mission=%s elapsed=%ss soft=%ss landed=%s - converge on the landed angles; do NOT fabricate unscoped ones.\n' \
+                "$now" "$SCOPE_MISSION_BINDING" "$scope_el" "$SCOPE_SOFT_SEC" "$landed" \
+                > "$LEDGER_DIR/SCOPE-CONVERGE-REQUEST.tmp" 2>/dev/null \
+                && mv "$LEDGER_DIR/SCOPE-CONVERGE-REQUEST.tmp" "$LEDGER_DIR/SCOPE-CONVERGE-REQUEST" 2>/dev/null
+              log "SCOPE BUDGET soft breach at ${scope_el}s (>= ${SCOPE_SOFT_SEC}s, frontier advancing) - wrote SCOPE-CONVERGE-REQUEST (converge on landed=${landed}); child NOT killed."
+            fi ;;
+        20)  # HARD/grace breach: durable breach marker (honest landed residual), bump the
+             # forced-reset counter, then REAL kill->RESUME via the existing idle-kill path.
+            printf '%s hard scope budget breach: mission=%s elapsed=%ss hard=%ss landed=%s residual=%s - converge on landed, surface any unscoped angle; DO NOT fabricate.\n' \
+              "$now" "$SCOPE_MISSION_BINDING" "$scope_el" "$SCOPE_HARD_SEC" "$landed" "$landed" \
+              > "$LEDGER_DIR/SCOPE-BUDGET-BREACH.tmp" 2>/dev/null \
+              && mv "$LEDGER_DIR/SCOPE-BUDGET-BREACH.tmp" "$LEDGER_DIR/SCOPE-BUDGET-BREACH" 2>/dev/null
+            echo $((prior + 1)) > "$SCOPE_RESETS_FILE.tmp" 2>/dev/null \
+              && mv "$SCOPE_RESETS_FILE.tmp" "$SCOPE_RESETS_FILE" 2>/dev/null
+            log "SCOPE BUDGET hard breach at ${scope_el}s (frontier was advancing) - wrote SCOPE-BUDGET-BREACH (residual=${landed}); killing the process tree and terminating this supervisor run."
+            SCOPE_BUDGET_TERMINAL=1
+            kill_tree "$child_pid"; break ;;
+        30)  # RE-BREACH past the reset cap: escalate honestly, never fake a roadmap.
+            {
+              echo "supervisor escalation: scope budget breached past MAX_SCOPE_RESETS=$MAX_SCOPE_RESETS"
+              echo "scope_elapsed=$scope_el hard=$SCOPE_HARD_SEC prior_resets=$prior landed=$landed"
+              echo "converge unreachable - landed angles surfaced as the honest residual; NO fabricated roadmap"
+              echo "ts=$(date 2>/dev/null)"
+            } > "$ESCALATE_FILE" 2>/dev/null || true
+            log "SCOPE BUDGET escalation at ${scope_el}s - breached past MAX_SCOPE_RESETS=${MAX_SCOPE_RESETS}; landed=${landed} surfaced as residual; killing and exiting 1."
+            kill_tree "$child_pid"
+            wait "$child_pid" 2>/dev/null
+            exit 1 ;;
+      esac
+    fi
+  done
+  wait "$child_pid" 2>/dev/null
+  exit_code=$?
+  [ "$SCOPE_BUDGET_TERMINAL" -eq 1 ] && return 124
+  return "$exit_code"
+}
+
+# EDIT 23: seed the per-conversation session token BEFORE the relaunch loop. The
+# supervisor is the durable producer across relaunches of one conversation; this
+# establishes the token precedence ONCE: an env-supplied token (operator or a prior
+# same-conversation export) wins and is persisted to the durable file; else a
+# previously-harvested token is read back from the file; else the token stays empty
+# and the first SCRIBE-run resolver MINTS one (which we then harvest, below).
+# Fail-soft: an unwritable/unreadable token file never aborts the run - the token
+# just stays empty and the next launch re-mints (worst case a fresh session).
+seed_session_token() {
+  if [ -n "$AUTOPROMPT_SESSION_TOKEN" ]; then
+    printf '%s\n' "$AUTOPROMPT_SESSION_TOKEN" > "$SESSION_TOKEN_FILE" 2>/dev/null || true
+  elif [ -r "$SESSION_TOKEN_FILE" ]; then
+    AUTOPROMPT_SESSION_TOKEN=$(head -n1 "$SESSION_TOKEN_FILE" 2>/dev/null || echo)
+  fi
+}
+
+# EDIT 23: HARVEST the resolver-minted token after a launch when the supervisor holds
+# none yet. The SCRIBE-run `--resolve-prompt-dir` CLI writes the marker
+# "$LEDGER_DIR/.session-current" as "session_NN  <token>" (two whitespace-separated
+# fields - the EDIT 7 contract). We read the 2nd field and persist it so the NEXT
+# launch re-exports the SAME token and a 2nd prompt rejoins the same session_NN.
+# Fail-soft: an absent/corrupt marker (no 2nd field) leaves the token empty and the
+# next launch mints again - a fresh session, never a crash.
+harvest_session_token() {
+  [ -n "$AUTOPROMPT_SESSION_TOKEN" ] && return 0
+  marker="$LEDGER_DIR/.session-current"
+  [ -r "$marker" ] || return 0
+  harvested=$(awk 'NR==1{print $2; exit}' "$marker" 2>/dev/null || echo)
+  if [ -n "$harvested" ]; then
+    AUTOPROMPT_SESSION_TOKEN="$harvested"
+    printf '%s\n' "$AUTOPROMPT_SESSION_TOKEN" > "$SESSION_TOKEN_FILE" 2>/dev/null || true
+  fi
+}
+
+# PLAN-auto-compact-threshold: a discovery-level test sources this script to call
+# canon_path / find_parent_transcript directly. AUTOPROMPT_SOURCE_ONLY=1 stops here,
+# AFTER every function + path var is defined but BEFORE the launch loop runs.
+[ "${AUTOPROMPT_SOURCE_ONLY:-0}" = "1" ] && return 0 2>/dev/null
+
+# Legacy broad DONE-* matching is a DOWNGRADE honored only for a verified legacy
+# resume: the operator opted in explicitly AND the ledger directory carries
+# physical evidence of a pre-nonce run (legacy governance files a three-file
+# new-format run never creates). A fresh or new-format directory fails closed so
+# the downgrade can never weaken a current-format run. Checked on the launch
+# path only (after the source-only return) so sourced function evaluation is
+# not subjected to launch-time validation.
+if [ "$LEGACY_SENTINEL" = "1" ]; then
+  LEGACY_EVIDENCE=0
+  for marker in BRIEF.md AGENTS.md bucketlist.md ANCHOR.md; do
+    if [ -f "$LEDGER_DIR/$marker" ]; then LEGACY_EVIDENCE=1; break; fi
+  done
+  if [ "$LEGACY_EVIDENCE" -ne 1 ]; then
+    echo "supervisor: AUTOPROMPT_LEGACY_SENTINEL=1 requires a verified legacy resume (legacy governance files under $LEDGER_DIR); unset it for new runs" >&2
+    exit 2
+  fi
+fi
+
+if [ -z "$LAUNCHER" ] && [ -z "$LAUNCH_CMD" ] && [ "$DRY_RUN" -eq 0 ]; then
+  echo "supervisor: no launch command (use --cmd \"<your CLI>\" / AUTOPROMPT_LAUNCH_CMD, or --launcher apidemo|codexdemo / AUTOPROMPT_LAUNCHER)" >&2
+  exit 2
+fi
+
+resolve_model_casting || exit $?
+resolve_capability_binding || exit $?
+if [ "$DRY_RUN" -eq 0 ]; then
+  AGENT_DEFINITIONS_JSON=""
+  resolve_agent_definitions_json || exit $?
+fi
+
+LAUNCH_LABEL="${LAUNCH_CMD:-${LAUNCHER:-<dry-run>}}"
+log "starting: launcher=$LAUNCH_LABEL ledger=$LEDGER_DIR mission=\"$MISSION\""
+log "topology: 5-level L0->L4; mode=$AUTOPROMPT_MODE; per-L3 fan-out=$FANOUT; L3 tracks=$L3_TRACKS; L1 never executes (rule 68); single-block spawns (rule 67) - enforced in the harness."
+# THE stale-sentinel guarantee: snapshot every pre-existing DONE-* PATH BEFORE the
+# first launch and BEFORE quarantine. sentinel_present refuses any path still in
+# this snapshot, so a prior-run sentinel can never halt this mission -- even if the
+# quarantine rename below fails (read-only dir / permissions). ORDER IS LOAD-BEARING:
+# snapshot first (records the dir as it was), THEN quarantine -- which prunes each
+# SUCCESSFULLY-renamed path from the live snapshot so the same-activation
+# DONE-<nonce> can be reclaimed by a genuine fresh sentinel. A path whose rename
+# FAILS stays snapshotted and vetoed. Both run before the first sentinel_present.
+snapshot_pre_existing_sentinels
+# Quarantine renames each stale sentinel aside, emits a loud log line, and prunes
+# every successfully-cleared path from the snapshot so a fresh same-path sentinel is
+# honored; a failed rename leaves the path vetoed and degrades to RELAUNCH.
+quarantine_stale_sentinels
+# EDIT 23: seed the session token once, after the ledger dir exists and before the
+# first launch, so run_launcher can re-export it and harvest_session_token can fill it.
+seed_session_token
+
+restart_times=""    # space-separated epoch seconds of recent restarts (no progress)
+last_frontier=$(frontier_count)
+backoff="$RETRY_BASE"
+
+while :; do
+  if sentinel_present; then
+    log "DONE-sentinel present - run complete, halting cleanly."
+    exit 0
+  fi
+
+  run_launcher
+  exit_code=$?
+  if [ "$SCOPE_BUDGET_TERMINAL" -eq 1 ]; then
+    log "SCOPE BUDGET terminal stop - no same-mission relaunch will consume another worker."
+    exit 124
+  fi
+
+  if sentinel_present; then
+    log "DONE-sentinel present after launch (exit $exit_code) - run complete, halting cleanly."
+    exit 0
+  fi
+
+  # V5 (MANDATORY terminal caller): the child EXITED with no DONE-sentinel - a
+  # TERMINAL boundary for that child. Mark it so a ledger audit treats this as
+  # run-ended, then run the terminal IDLE-FINISH audit. RUN-ENDED is the marker
+  # autoprompt-ledger-check.js reads to set runEnded=true (§2.3 Edit L1). Written
+  # every exit-without-sentinel; idempotent (overwritten each exit). The clean-DONE
+  # path short-circuits at the sentinel checks above, so RUN-ENDED is only ever
+  # written when the run is genuinely not done.
+  printf 'run-ended exit=%s ts=%s\n' "$exit_code" "$(date 2>/dev/null)" > "$LEDGER_DIR/RUN-ENDED" 2>/dev/null || true
+  if [ "$DRY_RUN" -eq 0 ] && [ -n "$LEDGER_CHECK_PATH" ] && [ -r "$LEDGER_CHECK_PATH" ]; then
+    # Best-effort loud-log: the marker alone is sufficient for the rule to fire on the
+    # NEXT audit, so this node call's exit 1 is informational; the relaunch happens regardless.
+    if node "$LEDGER_CHECK_PATH" --ledger-dir "$LEDGER_DIR" --transcript-dir "$LEDGER_DIR" --terminal >/dev/null 2>&1; then :; else
+      log "IDLE-FINISH terminal audit flagged a P0 (run ended with open work, no live agent) - relaunching with RESUME to re-drive."
+    fi
+  fi
+
+  now=$(date +%s 2>/dev/null || echo 0)
+  cur_frontier=$(frontier_count)
+  # EDIT 23: harvest the resolver-minted session token (no-op once we hold one) so
+  # the next relaunch re-exports the SAME token and a 2nd prompt rejoins the session.
+  harvest_session_token
+  log "launcher exited ($exit_code); frontier $last_frontier -> $cur_frontier; no sentinel - relaunching with RESUME."
+
+  if [ "$cur_frontier" -gt "$last_frontier" ]; then
+    # Healthy-long: progress was made. Reset the poison window and backoff.
+    restart_times=""
+    backoff="$RETRY_BASE"
+    last_frontier="$cur_frontier"
+  else
+    # No progress since the last launch. Record this restart in the rolling
+    # window and check the poison guard.
+    new_times=""
+    rapid=1
+    for t in $restart_times; do
+      if [ $((now - t)) -lt "$WINDOW" ]; then
+        new_times="$new_times $t"
+        rapid=$((rapid + 1))
+      fi
+    done
+    restart_times="$new_times $now"
+    if [ "$rapid" -ge "$MAX_RESTARTS" ]; then
+      log "POISON: $rapid restarts within ${WINDOW}s with NO frontier progress - escalating, not relaunching."
+      {
+        echo "supervisor escalation: crash-loop with no frontier progress"
+        echo "restarts_in_window=$rapid window_s=$WINDOW last_exit=$exit_code frontier=$cur_frontier"
+        echo "ts=$(date 2>/dev/null)"
+      } > "$ESCALATE_FILE"
+      exit 1
+    fi
+    # Exponential backoff, capped, between unproductive relaunches.
+    if [ "$backoff" -gt 0 ] 2>/dev/null; then sleep "$backoff" 2>/dev/null || true; fi
+    next=$((backoff * 2)); [ "$next" -gt "$RETRY_CAP" ] && next="$RETRY_CAP"
+    backoff="$next"
+  fi
+done

--- a/scripts/runtime-payload.cjs
+++ b/scripts/runtime-payload.cjs
@@ -61,9 +61,17 @@ const PROVIDERS = {
     workflow: [],
   },
   omp: {
-    topLevel: ['GATES.md', 'MODES.md', 'PLAYBOOKS.md', 'README.md', 'VERSION'],
+    topLevel: ['GATES.md', 'MODES.md', 'PLAYBOOKS.md', 'README.md', 'SKILL.md', 'VERSION', 'autoprompt-models.schema.md'],
     agents: 'personas',
-    workflow: [],
+    workflow: [
+      'agent-definitions-cli.js',
+      'autoprompt-gate.js',
+      'autoprompt-ledger-check.js',
+      'model-casting.js',
+      'phase-budget.js',
+      'supervisor.ps1',
+      'supervisor.sh',
+    ],
   },
   deepseek: {
     topLevel: [

--- a/tests/helpers/resolve-bash.cjs
+++ b/tests/helpers/resolve-bash.cjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict'
+
+// Shared Bash discovery for tests that shell out to Git for Windows.
+//
+// The default install location is `C:\Program Files\Git\bin\bash.exe`, but
+// contributors may install Git to another drive (e.g. `D:\Program Files\Git`).
+// Hardcoding the C:\ path fails the entire test suite on those machines.
+// This helper probes the standard Program Files locations plus D: so the
+// test suite passes regardless of where Git was installed.
+
+const childProcess = require('node:child_process')
+
+const BASH_CANDIDATES = [
+  () => process.env.ProgramFiles && `${process.env.ProgramFiles}\\Git\\bin\\bash.exe`,
+  () => process.env.ProgramFiles && `${process.env.ProgramFiles}\\Git\\usr\\bin\\bash.exe`,
+  () => process.env['ProgramFiles(x86)'] && `${process.env['ProgramFiles(x86)']}\\Git\\bin\\bash.exe`,
+  () => process.env['ProgramFiles(x86)'] && `${process.env['ProgramFiles(x86)']}\\Git\\usr\\bin\\bash.exe`,
+  () => process.env.ProgramW6432 && `${process.env.ProgramW6432}\\Git\\bin\\bash.exe`,
+  () => process.env.ProgramW6432 && `${process.env.ProgramW6432}\\Git\\usr\\bin\\bash.exe`,
+  () => 'C:\\Program Files\\Git\\bin\\bash.exe',
+  () => 'C:\\Program Files\\Git\\usr\\bin\\bash.exe',
+  () => 'D:\\Program Files\\Git\\bin\\bash.exe',
+  () => 'D:\\Program Files\\Git\\usr\\bin\\bash.exe',
+]
+
+function resolveBash() {
+  if (process.platform !== 'win32') return 'bash'
+  for (const candidate of BASH_CANDIDATES) {
+    const path = candidate()
+    if (!path) continue
+    try {
+      if (childProcess.spawnSync(path, ['--version'], { timeout: 2000 }).status === 0) {
+        return path
+      }
+    } catch {
+      // Candidate not present or not executable - try next
+    }
+  }
+  return 'bash'
+}
+
+module.exports = { resolveBash }

--- a/tests/source/custom-claude-formatter.test.cjs
+++ b/tests/source/custom-claude-formatter.test.cjs
@@ -7,9 +7,8 @@ const path = require('node:path')
 const test = require('node:test')
 
 const ROOT = path.resolve(__dirname, '..', '..')
-const BASH = process.platform === 'win32'
-  ? 'C:\\Program Files\\Git\\bin\\bash.exe'
-  : 'bash'
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
+const BASH = resolveBash()
 const POWERSHELL = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
 const BASH_LIBRARY = path.join(ROOT, 'scripts', 'install', 'lib', 'install-lib.sh')
 const POWERSHELL_LIBRARY = path.join(ROOT, 'scripts', 'install', 'lib', 'install-lib.ps1')

--- a/tests/source/harness-provider-config.test.cjs
+++ b/tests/source/harness-provider-config.test.cjs
@@ -10,9 +10,8 @@ const test = require('node:test')
 
 const ROOT = path.resolve(__dirname, '..', '..')
 const HELPER = path.join(ROOT, 'scripts', 'harness-provider-config.cjs')
-const BASH = process.platform === 'win32'
-  ? 'C:\\Program Files\\Git\\bin\\bash.exe'
-  : 'bash'
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
+const BASH = resolveBash()
 const POWERSHELL = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
 
 function runHelper (args) {

--- a/tests/source/install-custom-root.test.cjs
+++ b/tests/source/install-custom-root.test.cjs
@@ -12,9 +12,8 @@ const test = require('node:test')
 const ROOT = path.resolve(__dirname, '..', '..')
 const PACKAGE_VERSION = require('../../package.json').version
 const POWERSHELL = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
-const GIT_BASH = process.platform === 'win32'
-  ? 'C:\\Program Files\\Git\\bin\\bash.exe'
-  : 'bash'
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
+const GIT_BASH = resolveBash()
 const PUBLIC_CLIENTS = [
   'claude', 'codex', 'opencode', 'kilo', 'vscode', 'prime',
   'omp', 'deepseek', 'reasonix',

--- a/tests/source/kilo-provider.test.cjs
+++ b/tests/source/kilo-provider.test.cjs
@@ -11,7 +11,8 @@ const test = require('node:test')
 const ROOT = path.resolve(__dirname, '..', '..')
 const CONTRACT = path.join(ROOT, 'agents', 'contracts', 'autoprompt.contract.json')
 const POWERSHELL = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
-const GIT_BASH = 'C:\\Program Files\\Git\\bin\\bash.exe'
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
+const GIT_BASH = resolveBash()
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8').replace(/\r\n/g, '\n')

--- a/tests/source/new-harness-lifecycle.test.cjs
+++ b/tests/source/new-harness-lifecycle.test.cjs
@@ -9,9 +9,8 @@ const path = require('node:path')
 const test = require('node:test')
 
 const ROOT = path.resolve(__dirname, '..', '..')
-const BASH = process.platform === 'win32'
-  ? 'C:\\Program Files\\Git\\bin\\bash.exe'
-  : 'bash'
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
+const BASH = resolveBash()
 const POWERSHELL = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
 const NODE_DIRECTORY = path.dirname(process.execPath)
 const PYTHON_DIRECTORY = path.dirname(childProcess.spawnSync(

--- a/tests/source/posix-shell-performance.test.cjs
+++ b/tests/source/posix-shell-performance.test.cjs
@@ -9,7 +9,8 @@ const path = require('node:path')
 const test = require('node:test')
 
 const ROOT = path.resolve(__dirname, '..', '..')
-const GIT_BASH = 'C:\\Program Files\\Git\\bin\\bash.exe'
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
+const GIT_BASH = resolveBash()
 
 function bashPath(value) {
   return value.replaceAll('\\', '/').replace(

--- a/tests/source/provider-compatibility-registry.test.cjs
+++ b/tests/source/provider-compatibility-registry.test.cjs
@@ -35,18 +35,14 @@ function run(command, args, options = {}) {
   })
 }
 
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
 function findBash() {
-  const candidates = process.platform === 'win32'
-    ? [
-        path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Git', 'bin', 'bash.exe'),
-        path.join(process.env.LOCALAPPDATA || '', 'Programs', 'Git', 'bin', 'bash.exe'),
-        'bash',
-      ]
-    : ['bash']
-  for (const candidate of candidates) {
-    if (run(candidate, ['--version']).status === 0) return candidate
-  }
-  return null
+  // resolveBash probes Program Files (including D:) and returns a real Git Bash
+  // path on Windows; it never returns the WSL stub 'C:\Windows\system32\bash.exe'.
+  const resolved = resolveBash()
+  return resolved === 'bash' && process.platform === 'win32'
+    ? null
+    : resolved
 }
 
 function powershellLiteral(value) {

--- a/tests/source/supervisor-mode-contract.test.cjs
+++ b/tests/source/supervisor-mode-contract.test.cjs
@@ -9,7 +9,8 @@ const path = require('node:path')
 const test = require('node:test')
 
 const ROOT = path.resolve(__dirname, '..', '..')
-const GIT_BASH = 'C:\\Program Files\\Git\\bin\\bash.exe'
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
+const GIT_BASH = resolveBash()
 const POWERSHELL = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
 const SUPERVISORS = [
   ['claude Bash', path.join(ROOT, 'agents', 'claude', 'workflow', 'supervisor.sh'), 'bash'],

--- a/tests/source/vscode-lifecycle.test.cjs
+++ b/tests/source/vscode-lifecycle.test.cjs
@@ -10,7 +10,8 @@ const test = require('node:test')
 
 const ROOT = path.resolve(__dirname, '..', '..')
 const POWERSHELL = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
-const GIT_BASH = 'C:\\Program Files\\Git\\bin\\bash.exe'
+const { resolveBash } = require('../helpers/resolve-bash.cjs')
+const GIT_BASH = resolveBash()
 const ACTIVATION_KEY = 'chat.subagents.allowInvocationsFromSubagents'
 const manifest = JSON.parse(fs.readFileSync(
   path.join(ROOT, 'agents', 'manifests', 'vscode-runtime.json'),


### PR DESCRIPTION
## Summary

Building on the OMP support merged in #9, this adds the optional operational extras needed for unattended OMP runs and fixes a pre-existing test failure that hits contributors with non-default Git install locations on Windows.

### Added

- **Supervisor** (`agents/omp/workflow/supervisor.sh`, `supervisor.ps1`): external auto-relaunch wrapper that drives `omp -p --auto-approve`, watches the DONE sentinel, distinguishes a FINISHED run from a HEALTHY-LONG run, and escalates on poison restarts
- **Orchestration helpers** (`autoprompt-gate.js`, `autoprompt-ledger-check.js`, `model-casting.js`, `phase-budget.js`, `agent-definitions-cli.js`): the gate orchestrator, ledger validator, model caster, budget tracker, and CLI introspection the supervisor uses
- **Schema documentation** (`agents/omp/autoprompt-models.schema.md`): contract for the `~/.omp/agent/autoprompt-models.json` registry consumed by `model-casting.js` when `agents=auto`
- **Payload registration** (`scripts/runtime-payload.cjs`): new omp top-level and workflow files so the installer ships them

### Fixed

- **Test environment portability** (resolves #14):
  - Introduces `tests/helpers/resolve-bash.cjs` which probes `Program Files`, `Program Files (x86)`, `ProgramW6432`, and both `C:\` and `D:\` drives for Git Bash, so the test suite passes when Git is not at the default location
  - Replaces hardcoded `C:\Program Files\Git\bin\bash.exe` in 8 test files
  - Replaces the permissive `findBash()` in `provider-compatibility-registry.test.cjs` that fell back to the WSL stub on PATH; subprocesses now reliably run the real Git Bash

## Validation

| Check | Command / Steps | Result |
| ----- | --------------- | ------ |
| Full unit suite | `npm test` | 82 pass / 0 fail / 4 skipped |
| Provider suite | `npm run test:providers` | 66 pass / 0 fail / 4 skipped (was: 59 pass / 7 fail) |
| Runtime payload check | `node scripts/runtime-payload.cjs --check` | `runtime manifests are current` |
| OMP payload size | 57 files in manifest (was 48) | includes supervisor, model-casting, schema |

## Checklist

- [x] The change is focused and has no unrelated edits
- [x] Tests cover changed behavior (helper used across all shell-driver tests)
- [x] Documentation matches changed behavior (schema + READMEs)
- [x] Generated provider files are current (payload manifest regenerated via `runtime-payload.cjs --generate`)
- [x] Logs, fixtures, and screenshots contain no secrets or personal data
- [x] I followed the [contribution guide](docs/CONTRIBUTING.md) and [Code of Conduct](docs/CODE_OF_CONDUCT.md)

## Linked Issues

- Resolves #14

## Notes for Reviewers

- The supervisor is **opt-in**; interactive `/skill:autoprompt` runs are unchanged
- Model casting defaults to `agents=off` (workers inherit the session model); `agents=auto` requires an explicit registry matching the schema
- Pre-existing `test:lifecycle` failures are unrelated to this change and reproduce on pristine `main`

---

_Automatically created by an autonomous agent (Oh My Pi harness)._
