### PR TITLE
fix: retry non-blocking stdin reads instead of failing with EAGAIN

### DIFF
--- a/bin/autoprompt.cjs
+++ b/bin/autoprompt.cjs
@@ -300,6 +300,13 @@ function providerInstallLocations(client, locationOptions = {}) {
 class InputClosedError extends Error {}
 class BackNavigationError extends Error {}
 
+const SLEEP_SAB = new SharedArrayBuffer(4)
+const SLEEP_SLOT = new Int32Array(SLEEP_SAB)
+
+function sleepSync(milliseconds) {
+  Atomics.wait(SLEEP_SLOT, 0, 0, milliseconds)
+}
+
 function readLineSync(stdin, stdout) {
   const descriptor = Number.isInteger(stdin.fd) ? stdin.fd : 0
   const byte = Buffer.allocUnsafe(1)
@@ -313,7 +320,10 @@ function readLineSync(stdin, stdout) {
       try {
         count = fs.readSync(descriptor, byte, 0, 1, null)
       } catch (error) {
-        if (error && error.code === 'EINTR') continue
+        if (error && (error.code === 'EINTR' || error.code === 'EAGAIN' || error.code === 'EWOULDBLOCK')) {
+          sleepSync(10)
+          continue
+        }
         throw error
       }
       if (count === 0) return bytes.length === 0 ? null : Buffer.from(bytes).toString('utf8')
@@ -1314,6 +1324,7 @@ module.exports = {
   providerInstallState,
   queryLatestVersion,
   queryLatestGitHubRevision,
+  readLineSync,
   resolveInteractiveUpdateStatus,
   run,
 }

--- a/tests/source/autoprompt-cli.test.cjs
+++ b/tests/source/autoprompt-cli.test.cjs
@@ -23,6 +23,7 @@ const {
   providerInstallState,
   queryLatestGitHubRevision,
   queryLatestVersion,
+  readLineSync,
   resolveInteractiveUpdateStatus,
   run,
 } = require('../../bin/autoprompt.cjs')
@@ -1975,4 +1976,48 @@ test('Escape returns to provider selection, then exits the interactive uninstall
   assert.match(result.stdout, /Back to provider selection\./)
   assert.match(result.stdout, /Autoprompt uninstaller closed\./)
   assert.deepEqual(result.calls, [])
+})
+
+test('readLineSync retries a non-blocking stdin instead of failing with EAGAIN', () => {
+  const child = childProcess.spawn(
+    process.execPath,
+    ['-e', "setTimeout(() => process.stdout.write('x\\n'), 150); setInterval(() => {}, 1000)"],
+    { stdio: ['ignore', 'pipe', 'ignore'] },
+  )
+  child.on('error', (error) => {
+    throw error
+  })
+  const descriptor = child.stdout._handle.fd
+  const stdout = capture()
+  const stderr = capture()
+  const rawModes = []
+  const stdin = {
+    fd: descriptor,
+    isRaw: false,
+    isTTY: true,
+    setRawMode(value) {
+      rawModes.push(value)
+      this.isRaw = value
+    },
+  }
+  stdout.stream.isTTY = true
+
+  try {
+    const fcntl = childProcess.spawnSync(
+      'python3',
+      ['-c', 'import fcntl,sys; fcntl.fcntl(3, fcntl.F_SETFL, fcntl.fcntl(3, fcntl.F_GETFL) | __import__("os").O_NONBLOCK)'],
+      { stdio: ['ignore', 'pipe', 'pipe', descriptor] },
+    )
+    assert.equal(fcntl.status, 0, fcntl.stderr.toString())
+
+    const started = Date.now()
+    const value = readLineSync(stdin, stdout.stream)
+    const elapsed = Date.now() - started
+
+    assert.equal(value, 'x')
+    assert.ok(elapsed >= 100, `expected to block for the delayed byte, took ${elapsed}ms`)
+    assert.deepEqual(rawModes, [true, false])
+  } finally {
+    child.kill()
+  }
 })


### PR DESCRIPTION
## Summary

Fixes the interactive installer crashing with `Autoprompt interactive install failed: EAGAIN: resource temporarily unavailable, read` when stdin is a non-blocking file descriptor.

## The bug

`readLineSync` in `bin/autoprompt.cjs` reads stdin one byte at a time with `fs.readSync`:

```js
count = fs.readSync(descriptor, byte, 0, 1, null)
} catch (error) {
  if (error && error.code === 'EINTR') continue
  throw error
}
```

When stdin is a **non-blocking fd** with no data ready, the kernel returns `EAGAIN` (or `EWOULDBLOCK`) instead of blocking. The catch only retries on `EINTR`, so `EAGAIN` propagates up through `answer()` → `runInteractive()` and aborts the whole installer.

### Why it happens in practice

The self-update path restarts the installer via `runUpdatedInstaller`, which spawns the child with `stdio: 'inherit'`:

```js
const result = options.spawnSync(process.execPath, [cli], {
  ...spawnOptions(options), // stdio: 'inherit'
  env: { ...options.env, [UPDATE_HANDOFF_ENV]: '1' },
})
```

The child inherits the parent's stdin fd. When the CLI is launched from a wrapper, IDE terminal, or script that sets `O_NONBLOCK` on stdin, the restarted installer hits `EAGAIN` on the very first prompt and dies.

### Reproduction

A non-blocking pipe with no data ready reproduces the exact error:

```
ERROR code= EAGAIN msg= EAGAIN: resource temporarily unavailable, read
```

## The fix

Treat `EAGAIN`/`EWOULDBLOCK` the same as `EINTR`: sleep briefly and retry the read. This restores the blocking-read behavior the code already intends, without any OS-specific syscalls, so it works identically on macOS, Linux, and Windows.

```js
const SLEEP_SAB = new SharedArrayBuffer(4)
const SLEEP_SLOT = new Int32Array(SLEEP_SAB)

function sleepSync(milliseconds) {
  Atomics.wait(SLEEP_SLOT, 0, 0, milliseconds)
}
```

```js
} catch (error) {
  if (error && (error.code === 'EINTR' || error.code === 'EAGAIN' || error.code === 'EWOULDBLOCK')) {
    sleepSync(10)
    continue
  }
  throw error
}
```

The short `sleepSync` (via `Atomics.wait` on a `SharedArrayBuffer`) avoids a busy-spin while waiting for data. `readLineSync` is also exported so it can be unit-tested directly.

## Testing evidence

Added a regression test in `tests/source/autoprompt-cli.test.cjs` that:
- spawns a child that writes a byte after a 150ms delay,
- sets `O_NONBLOCK` on the pipe's read end via `fcntl`,
- calls `readLineSync` and asserts it blocks and reads the delayed byte without throwing.

```
✔ readLineSync retries a non-blocking stdin instead of failing with EAGAIN (189.396541ms)
```

Full `autoprompt-cli` suite: **53 pass, 0 fail**.

Manual verification against a real non-blocking pipe confirmed the fix: before the change `readLineSync` threw `EAGAIN`; after, it returned the byte after ~211ms.

> Note: `npm test` also runs `codex-configure.test.cjs`, which fails on this machine because `python`/PyYAML is not installed. That failure is pre-existing and unrelated to this change (it fails identically on the clean baseline).
