### PR TITLE
Resolve python3 in bash installer when no bare python exists

### DIFF
--- a/scripts/install/doctor.sh
+++ b/scripts/install/doctor.sh
@@ -42,8 +42,9 @@ opencode_activation_status() {
     printf 'missing:autoprompt.opencode.json'
     return 0
   fi
-  local status
-  status="$(python - "$skill" "$base" <<'PY' 2>/dev/null
+  local status py
+  py="$(autoprompt_python)" || { printf 'invalid:python-unavailable'; return 0; }
+  status="$("$py" - "$skill" "$base" <<'PY' 2>/dev/null
 import hashlib
 import json
 import pathlib

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -83,7 +83,9 @@ payload_file() {
 # payload_body <file>: the skill body with its source frontmatter STRIPPED (format_skill
 # refuses a body that still carries a --- fence, code 6). Raw UTF-8 so glyphs survive.
 payload_body() {
-  python - "$1" <<'PY'
+  local py
+  py="$(autoprompt_python)" || return 1
+  "$py" - "$1" <<'PY'
 import sys
 text = open(sys.argv[1], encoding="utf-8").read()
 parts = text.split("---\n")
@@ -95,7 +97,9 @@ PY
 # payload_field <file> <key>: a top-level frontmatter scalar via the real YAML parser, so
 # a single-quoted multi-line description round-trips exactly into what we hand the library.
 payload_field() {
-  python - "$1" "$2" <<'PY'
+  local py
+  py="$(autoprompt_python)" || return 1
+  "$py" - "$1" "$2" <<'PY'
 import sys, yaml
 text = open(sys.argv[1], encoding="utf-8").read()
 fm = yaml.safe_load(text.split("---\n")[1])
@@ -581,7 +585,9 @@ install_kilo_activation() {
 }
 
 validate_opencode_profile() {
-  python - "$1" <<'PY' >/dev/null 2>&1
+  local py
+  py="$(autoprompt_python)" || return 1
+  "$py" - "$1" <<'PY' >/dev/null 2>&1
 import json, sys
 try:
     profile = json.load(open(sys.argv[1], encoding='utf-8'))

--- a/scripts/install/lib/install-lib.sh
+++ b/scripts/install/lib/install-lib.sh
@@ -37,6 +37,51 @@ declare -A AUTOPROMPT_CLIENT_BIN=(
 AUTOPROMPT_VERSION_FLAG="--version"
 AUTOPROMPT_PROBE_TIMEOUT=10
 
+# Resolved Python interpreter used by every verify/parse path. Cached on first
+# resolution; AUTOPROMPT_PYTHON is an explicit operator override. Many POSIX
+# systems (notably macOS) ship `python3` but no bare `python`, so we resolve
+# `python3` before `python` rather than hardcoding one name - mirroring the
+# Resolve-VerifyPython helper in the .ps1 port.
+AUTOPROMPT_PYTHON="${AUTOPROMPT_PYTHON:-}"
+
+# _autoprompt_python_probe <candidate>: true iff <candidate> is a runnable Python.
+_autoprompt_python_probe() {
+  [ -n "${1:-}" ] || return 1
+  command -v "$1" >/dev/null 2>&1 || return 1
+  "$1" -c 'pass' >/dev/null 2>&1
+}
+
+# resolve_autoprompt_python: print the resolved interpreter (caching it) or print
+# a loud diagnostic and return non-zero when none is available. Failures here are
+# never silent so an operator sees why a verify/parse step could not run.
+resolve_autoprompt_python() {
+  local candidate
+  if [ -n "$AUTOPROMPT_PYTHON" ] && _autoprompt_python_probe "$AUTOPROMPT_PYTHON"; then
+    printf '%s' "$AUTOPROMPT_PYTHON"
+    return 0
+  fi
+  for candidate in python3 python; do
+    if _autoprompt_python_probe "$candidate"; then
+      AUTOPROMPT_PYTHON="$candidate"
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  printf 'Autoprompt needs a python interpreter (python3 or python) on PATH.\n' >&2
+  return 1
+}
+
+# autoprompt_python: print the resolved interpreter, resolving lazily on first
+# call. Call sites use "$(autoprompt_python)" so the value resolves at call time
+# and the cache mutates in the calling shell.
+autoprompt_python() {
+  if [ -n "$AUTOPROMPT_PYTHON" ]; then
+    printf '%s' "$AUTOPROMPT_PYTHON"
+    return 0
+  fi
+  resolve_autoprompt_python
+}
+
 # Public install compatibility is a closed nine-provider registry. Historical
 # path resolvers remain below only for receipt-owned cleanup of earlier installs.
 declare -A AUTOPROMPT_PROVIDER_STATUS=(
@@ -2741,11 +2786,12 @@ AUTOPROMPT_CODEX_DESCRIPTION_MAX=1024
 # absent), or 65 (no python+yaml tool). Probes the parser first so a missing tool
 # is a loud distinct code, never a silent FAIL.
 _verify_parse_yaml_frontmatter() {
-  local file="$1" required="$2"
-  if ! python -c "import yaml" >/dev/null 2>&1; then
+  local file="$1" required="$2" py
+  py="$(autoprompt_python)" || return 65
+  if ! "$py" -c "import yaml" >/dev/null 2>&1; then
     return 65
   fi
-  python - "$file" "$required" <<'PY' >/dev/null 2>&1
+  "$py" - "$file" "$required" <<'PY' >/dev/null 2>&1
 import sys, yaml
 text = open(sys.argv[1], encoding="utf-8").read()
 parts = text.split("---")
@@ -2766,12 +2812,13 @@ PY
 # Returns 0 (length printed to stdout), 61 (no parseable description), or 65 (no
 # python+yaml). Reuses the same parser-probe discipline as the parse helpers.
 _verify_codex_description_len() {
-  local file="$1"
-  if ! python -c "import yaml" >/dev/null 2>&1; then
+  local file="$1" py
+  py="$(autoprompt_python)" || return 65
+  if ! "$py" -c "import yaml" >/dev/null 2>&1; then
     return 65
   fi
   local out
-  out="$(python - "$file" <<'PY' 2>/dev/null
+  out="$("$py" - "$file" <<'PY' 2>/dev/null
 import sys, yaml
 text = open(sys.argv[1], encoding="utf-8").read()
 parts = text.split("---")
@@ -2789,11 +2836,12 @@ PY
   return 0
 }
 _verify_parse_toml() {
-  local file="$1"
-  if ! python -c "import tomllib" >/dev/null 2>&1; then
+  local file="$1" py
+  py="$(autoprompt_python)" || return 65
+  if ! "$py" -c "import tomllib" >/dev/null 2>&1; then
     return 65
   fi
-  python - "$file" <<'PY' >/dev/null 2>&1
+  "$py" - "$file" <<'PY' >/dev/null 2>&1
 import sys, tomllib
 d = tomllib.load(open(sys.argv[1], "rb"))
 if "prompt" not in d:
@@ -2809,11 +2857,12 @@ PY
 # a non-empty customInstructions. Returns 0 / 61 (parse error / shape wrong / mode
 # absent) / 65 (no python+yaml tool).
 _verify_parse_roomodes() {
-  local file="$1"
-  if ! python -c "import yaml" >/dev/null 2>&1; then
+  local file="$1" py
+  py="$(autoprompt_python)" || return 65
+  if ! "$py" -c "import yaml" >/dev/null 2>&1; then
     return 65
   fi
-  python - "$file" <<'PY' >/dev/null 2>&1
+  "$py" - "$file" <<'PY' >/dev/null 2>&1
 import sys, yaml
 doc = yaml.safe_load(open(sys.argv[1], encoding="utf-8").read())
 if not isinstance(doc, dict):
@@ -2834,11 +2883,12 @@ PY
 # require a mapping with a non-empty `instructions` OR `prompt` (Goose's
 # validate_prompt_or_instructions rule). Returns 0 / 61 / 65, same discipline.
 _verify_parse_goose_recipe() {
-  local file="$1"
-  if ! python -c "import yaml" >/dev/null 2>&1; then
+  local file="$1" py
+  py="$(autoprompt_python)" || return 65
+  if ! "$py" -c "import yaml" >/dev/null 2>&1; then
     return 65
   fi
-  python - "$file" <<'PY' >/dev/null 2>&1
+  "$py" - "$file" <<'PY' >/dev/null 2>&1
 import sys, yaml
 doc = yaml.safe_load(open(sys.argv[1], encoding="utf-8").read())
 if not isinstance(doc, dict):
@@ -5015,7 +5065,9 @@ vscode_settings_status() {
 }
 
 validate_kilo_profile() {
-  python - "$1" <<'PY' >/dev/null 2>&1
+  local py
+  py="$(autoprompt_python)" || return 1
+  "$py" - "$1" <<'PY' >/dev/null 2>&1
 import json, sys
 try:
     profile = json.load(open(sys.argv[1], encoding='utf-8'))

--- a/tests/source/opencode-lifecycle.test.cjs
+++ b/tests/source/opencode-lifecycle.test.cjs
@@ -35,6 +35,22 @@ function findBash() {
   return null
 }
 
+function findOnPath(command) {
+  const sep = process.platform === 'win32' ? ';' : ':'
+  const pathEntries = String(process.env.PATH || '').split(sep)
+  for (const dir of pathEntries) {
+    if (!dir) continue
+    const candidate = path.join(dir, command + (process.platform === 'win32' ? '.exe' : ''))
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK)
+      return candidate
+    } catch {
+      // continue searching
+    }
+  }
+  return null
+}
+
 function powershellLiteral(value) {
   return `'${value.replaceAll("'", "''")}'`
 }
@@ -149,7 +165,8 @@ test('POSIX OpenCode lifecycle syntax, version boundary, profile schema, and wra
     '[ "${AUTOPROMPT_VERSION_FLOOR[opencode]}" = 1.18.7 ]',
     '! _precheck_version_ge 1.18.6 "${AUTOPROMPT_VERSION_FLOOR[opencode]}"',
     '_precheck_version_ge 1.18.7 "${AUTOPROMPT_VERSION_FLOOR[opencode]}"',
-    `python - ${powershellLiteral(path.join(ROOT, 'agents', 'opencode', 'autoprompt.opencode.json'))} <<'PY'`,
+    `py="$(autoprompt_python)" || { printf 'no-python\n' >&2; exit 1; }`,
+    `"$py" - ${powershellLiteral(path.join(ROOT, 'agents', 'opencode', 'autoprompt.opencode.json'))} <<'PY'`,
     'import json, sys',
     'profile = json.load(open(sys.argv[1], encoding="utf-8"))',
     'assert profile == {',
@@ -303,4 +320,45 @@ test('PowerShell OpenCode 1.18.18 lifecycle detects tamper, repairs, stays idemp
   } finally {
     fs.rmSync(sandbox, { recursive: true, force: true })
   }
+})
+
+test('POSIX OpenCode profile validation resolves python3 when no bare python exists', {
+  skip: process.platform === 'win32',
+}, () => {
+  const bash = findBash()
+  assert.ok(bash, 'bash is required for the POSIX python-resolver checks')
+
+  const python3 = findOnPath('python3')
+  assert.ok(python3, 'python3 is required for the python3-only PATH regression test')
+  const python = findOnPath('python')
+  assert.equal(python, null, 'this test needs a system without bare `python` on PATH')
+
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'autoprompt-python3-only-'))
+  const bin = path.join(sandbox, 'bin')
+  fs.mkdirSync(bin, { recursive: true })
+  fs.symlinkSync(python3, path.join(bin, 'python3'))
+
+  const script = [
+    'set -u',
+    `. scripts/install/lib/install-lib.sh`,
+    `py="$(autoprompt_python)" || { printf 'no-python-resolved\n' >&2; exit 1; }`,
+    `"$py" - ${powershellLiteral(path.join(ROOT, 'agents', 'opencode', 'autoprompt.opencode.json'))} <<'PY'`,
+    'import json, sys',
+    'profile = json.load(open(sys.argv[1], encoding="utf-8"))',
+    'assert profile == {',
+    '  "$schema": "https://opencode.ai/config.json",',
+    '  "subagent_depth": 4,',
+    '  "share": "disabled",',
+    '  "permission": {"task": {"*": "deny", "ap-*": "allow"}},',
+    '}',
+    'PY',
+    'printf "resolved=$py\\n"',
+  ].join('\n')
+  const completed = run(bash, ['-c', script], {
+    env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH || ''}` },
+  })
+  assert.equal(completed.status, 0, completed.stderr)
+  assert.match(completed.stdout, /resolved=python3/)
+
+  fs.rmSync(sandbox, { recursive: true, force: true })
 })


### PR DESCRIPTION
## Problem

POSIX systems (notably macOS) ship `python3` but no bare `python`. The bash installer invoked `python` directly in ~14 places across `install-lib.sh`, `install.sh`, and `doctor.sh`. Those calls failed silently (stdout/stderr were suppressed), so `validate_opencode_profile` exited non-zero and opencode installs misreported:

```
error=activation-profile-invalid stage=profile
```

even though the shipped profile is valid. The `.ps1` port already had a `Resolve-VerifyPython` helper; the bash port never got the equivalent.

## Fix

- Add a shared resolver in `scripts/install/lib/install-lib.sh` (`autoprompt_python` / `resolve_autoprompt_python`) that:
  - prefers `python3` then `python`,
  - honors an `AUTOPROMPT_PYTHON` environment override,
  - caches the resolved interpreter,
  - fails loudly (never silently) when no interpreter is available.
- Route every bare `python` call site through it across `install-lib.sh`, `install.sh`, and `doctor.sh`.
- Update the POSIX opencode lifecycle test to use the resolver and add a regression test that reproduces the python3-only PATH failure (no bare `python`).

## Verification

- `bash -n` passes on all three touched shell scripts.
- Reproduced the original failure (PATH with `python3` only) and confirmed the resolver now selects `python3` and the opencode profile validates.
- `npm run test:cli`: 82 tests, 79 pass — identical to baseline (the 1 pre-existing failure is a sandboxed-subprocess PyYAML issue on this machine, present before this change).
- PowerShell lifecycle tests skip on macOS as before.

Bash-only change, no PS1 parity work in this PR.