### PR TITLE
Fix grammar: hyphen used as dash separator in agents/claude/SKILL.md

### DIFF
--- a/agents/claude/SKILL.md
+++ b/agents/claude/SKILL.md
@@ -65,7 +65,7 @@ Multi-surface scope uses **exactly 5 agents, 3 rounds**:
 
 Unusually-large scope may exceed the 6-agent ordinary budget only when `ROADMAP.md` records a concrete escalation reason. Additional scouts own disjoint themes. External research runs only when current external facts are required; repository-only work does not pay a research round trip.
 
-On assurance failure, retain accepted evidence and repair only named roadmap items. Never rerun the whole scope wave by default. Structural failures-empty roadmap, invalid dependency DAG, overlapping ownership, missing frameworks/tests, or failed capability-remain fail-closed.
+On assurance failure, retain accepted evidence and repair only named roadmap items. Never rerun the whole scope wave by default. Structural failures - empty roadmap, invalid dependency DAG, overlapping ownership, missing frameworks/tests, or failed capability - remain fail-closed.
 
 ## 4. Executable roadmap contract
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `agents/claude/SKILL.md` (line 68).

## Problem

Hyphens are used where dashes should be used to separate sentence clauses, making the text ambiguous.

The problematic text:

```markdown
Structural failures-empty roadmap, invalid dependency DAG, overlapping ownership, missing frameworks/tests, or failed capability-remain fail-closed.
```

## Fix

Replaced with:

```markdown
Structural failures - empty roadmap, invalid dependency DAG, overlapping ownership, missing frameworks/tests, or failed capability - remain fail-closed.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text