### PR TITLE
Fix grammar: hyphen used as dash separator in agents/claude/GATES.md

### DIFF
--- a/agents/claude/GATES.md
+++ b/agents/claude/GATES.md
@@ -14,7 +14,7 @@ Scope produces one canonical `ROADMAP.md`:
 - **Multi-surface:** **exactly 5 agents, 3 rounds**; retain the first author's complete roadmap, add exactly two complementary scouts concurrently, then run reviewer and fresh verifier concurrently. No redundant ordinary synthesis dispatch.
 - **Unusually large:** may exceed the 6-agent ordinary budget only when the roadmap records a concrete escalation reason. Extra scouts own disjoint themes.
 
-Assurance failures repair only named roadmap items while preserving accepted evidence. Structural failures-empty roadmap, invalid dependencies, overlapping ownership, missing frameworks/tests, or failed capability-fail closed.
+Assurance failures repair only named roadmap items while preserving accepted evidence. Structural failures - empty roadmap, invalid dependencies, overlapping ownership, missing frameworks/tests, or failed capability - fail closed.
 
 ## Executable roadmap
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `agents/claude/GATES.md` (line 17).

## Problem

Hyphens are used where dashes should be used to separate sentence clauses, making the text ambiguous.

The problematic text:

```markdown
Structural failures-empty roadmap, invalid dependencies, overlapping ownership, missing frameworks/tests, or failed capability-fail closed.
```

## Fix

Replaced with:

```markdown
Structural failures - empty roadmap, invalid dependencies, overlapping ownership, missing frameworks/tests, or failed capability - fail closed.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text