### PR TITLE
Fix grammar: correct subject-verb agreement 'fails' to 'fail' in SKILL.md

### DIFF
--- a/agents/claude/SKILL.md
+++ b/agents/claude/SKILL.md
@@ -134,7 +134,7 @@ Agent selection changes only model/effort routing, not gates or concurrency.
 
 ### Claude Code
 
-Claude Code routing uses `opus`, `sonnet`, and `haiku`. One selected model fills all three aliases. Therefore `agents=claude-fable-5` routes every role to canonical `claude-fable-5`. Two models map stronger to `opus`/`sonnet` and weaker to `haiku`; three map strongest/middle/weakest. More than three fails explicitly.
+Claude Code routing uses `opus`, `sonnet`, and `haiku`. One selected model fills all three aliases. Therefore `agents=claude-fable-5` routes every role to canonical `claude-fable-5`. Two models map stronger to `opus`/`sonnet` and weaker to `haiku`; three map strongest/middle/weakest. More than three fail explicitly.
 
 ### Codex
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `agents/claude/SKILL.md` (line 137).

## Problem

"More than three fails explicitly." has a subject-verb agreement error. The subject "More than three" (referring to models) is plural, so the verb should be "fail" not "fails".

The problematic text:

```markdown
More than three fails explicitly.
```

## Fix

Replaced with:

```markdown
More than three fail explicitly.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text