### PR TITLE
Fix grammar: correct subject-verb agreement 'fails' to 'fail' in MODES.md

### DIFF
--- a/agents/claude/MODES.md
+++ b/agents/claude/MODES.md
@@ -167,7 +167,7 @@ personas, hierarchy, concurrency, roadmap, or gates.
 For Claude Code, enabled casting is a pre-launch supervisor responsibility.
 Claude exposes only `opus`, `sonnet`, and `haiku` aliases: one selected model
 fills all three; two map the stronger model to `opus`/`sonnet` and the weaker to
-`haiku`; three map strongest/middle/weakest; more than three fails explicitly.
+`haiku`; three map strongest/middle/weakest; more than three fail explicitly.
 An already-running process may use casting only when trusted metadata and live
 alias bindings match. Codex uses its actual per-agent model and reasoning-effort
 configuration; do not copy Claude alias claims into Codex routing.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `agents/claude/MODES.md` (line 170).

## Problem

"more than three fails explicitly." has a subject-verb agreement error. The subject "more than three" (referring to models) is plural, so the verb should be "fail" not "fails".

The problematic text:

```markdown
more than three fails explicitly.
```

## Fix

Replaced with:

```markdown
more than three fail explicitly.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text