### PR TITLE
Fix grammar: replace non-standard 'differ heavily' with 'differ significantly' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ DeepSeek's 82.7% used its own test setup, so it is a reference point, not a comp
 <details>
 <summary><strong>Expected trade-off:</strong> about 3x the time and 2x the tokens.</summary>
 
-Timing and token logs were not retained, so these are planning estimates based on user experience reports, not measured benchmark results. The measured result was 29 to 16 failures (45% fewer) in this run, which translates to about 2x fewer mistakes. Note: for very small tasks, this may differ heavily.
+Timing and token logs were not retained, so these are planning estimates based on user experience reports, not measured benchmark results. The measured result was 29 to 16 failures (45% fewer) in this run, which translates to about 2x fewer mistakes. Note: for very small tasks, this may differ significantly.
 
 </details>
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 120).

## Problem

"this may differ heavily" uses a non-standard collocation. "Heavily" does not typically modify "differ" in English. The standard adverb is "significantly" or "greatly".

The problematic text:

```markdown
Note: for very small tasks, this may differ heavily.
```

## Fix

Replaced with:

```markdown
Note: for very small tasks, this may differ significantly.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text