### PR TITLE
fix(eagain): retry EAGAIN in readLineSync so interactive installer works on non-blocking PTY stdin

### DIFF
--- a/bin/autoprompt.cjs
+++ b/bin/autoprompt.cjs
@@ -313,7 +313,11 @@ function readLineSync(stdin, stdout) {
       try {
         count = fs.readSync(descriptor, byte, 0, 1, null)
       } catch (error) {
-        if (error && error.code === 'EINTR') continue
+        // EINTR: interrupted by a signal, retry.
+        // EAGAIN: stdin is non-blocking (set by many terminal emulators and
+        // multiplexers like tmux/screen; O_NONBLOCK on fd 0). No key has been
+        // pressed yet — wait for the next one instead of failing the install.
+        if (error && (error.code === 'EINTR' || error.code === 'EAGAIN')) continue
         throw error
       }
       if (count === 0) return bytes.length === 0 ? null : Buffer.from(bytes).toString('utf8')


### PR DESCRIPTION
## Problem

The interactive installer dies instantly with:

```
Autoprompt interactive install failed: EAGAIN: resource temporarily unavailable, read
```

before the user can pick an agent. This happens in every real terminal
emulator / multiplexer (tmux, screen, integrated terminals).

## Root cause

`readLineSync` in `bin/autoprompt.cjs` retries only `EINTR`. Terminal
emulators spawn child processes with `O_NONBLOCK` set on fd 0. The first
`fs.readSync(0)` therefore returns `EAGAIN` immediately (no key pressed yet)
instead of blocking for input, and the read loop throws — killing the
installer before any prompt is shown.

## Fix

Retry `EAGAIN` exactly like `EINTR`: wait for the next keystroke instead of
failing. One-line change in the shared reader; all interactive prompts route
through it.

## Verification

- Reproduced the crash on a PTY (tmux-style non-blocking stdin) before the fix.
- Confirmed the installer now blocks at "Provider [1-10, Esc]:" instead of dying.
- Installed successfully to both VS Code (`/home/banitams/.copilot/skills/autoprompt/SKILL.md`) and Oh My Pi (`/home/banitams/.dsh/skills/autoprompt/SKILL.md`).